### PR TITLE
Makefile for openwrt/lede builds for 3700, 3800, and 3800ch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
+# Ignore openwrt build dir
+openwrt/build
 *.swp
 *.DS_Store

--- a/openwrt/Makefile
+++ b/openwrt/Makefile
@@ -1,0 +1,39 @@
+#
+# Builds Lede (Openwrt) images for Netgear 3700v2, 3800, & 3800ch used at Scale
+# Assumes all dependency tools are already installed
+#
+
+BUILD_DIR = build
+DEFAULT_PACKAGES = -dnsmasq -firewall -ip6tables -iptables -odhcp6c -odhcpd-ipv6only -odhcpd -ppp -ppp-mod-pppoe kmod-usb-serial kmod-usb-serial-ftdi kmod-usb-serial-pl2303
+BUILD_3700_FLAGS = PROFILE=wndr3700v2 PACKAGES="$(DEFAULT_PACKAGES)"
+BUILD_3800_FLAGS = PROFILE=wndr3800 PACKAGES="$(DEFAULT_PACKAGES)"
+BUILD_3800CH_FLAGS = PROFILE=wndr3800ch PACKAGES="$(DEFAULT_PACKAGES)"
+
+LEDE_VER = 17.01.4
+IMAGEBUILDER = lede-imagebuilder-$(LEDE_VER)-ar71xx-generic.Linux-x86_64
+TAR_EXT = .tar.xz
+
+download-image: $(BUILD_DIR)/$(IMAGEBUILDER)$(TAR_EXT)
+
+extract: $(BUILD_DIR)/$(IMAGEBUILDER)
+
+$(BUILD_DIR)/$(IMAGEBUILDER)$(TAR_EXT): | $(BUILD_DIR)
+	curl -o $(BUILD_DIR)/$(IMAGEBUILDER)$(TAR_EXT) https://downloads.lede-project.org/releases/$(LEDE_VER)/targets/ar71xx/generic/$(IMAGEBUILDER)$(TAR_EXT)
+
+$(BUILD_DIR)/$(IMAGEBUILDER): $(BUILD_DIR)/$(IMAGEBUILDER)$(TAR_EXT)
+	@cd $(BUILD_DIR) && tar -xJmf  $(IMAGEBUILDER)$(TAR_EXT)
+
+build-3700: extract
+	@cd $(BUILD_DIR)/$(IMAGEBUILDER) && $(MAKE) image $(BUILD_3700_FLAGS)
+
+build-3800: extract
+	@cd $(BUILD_DIR)/$(IMAGEBUILDER) && $(MAKE) image  $(BUILD_3800_FLAGS)
+
+build-3800ch: extract
+	@cd $(BUILD_DIR)/$(IMAGEBUILDER) && $(MAKE) image $(BUILD_3800CH_FLAGS)
+
+$(BUILD_DIR):
+	mkdir -p $(BUILD_DIR)
+
+clean:
+	rm -rf $(BUILD_DIR)

--- a/openwrt/README.md
+++ b/openwrt/README.md
@@ -1,0 +1,41 @@
+# Prereqs
+
+Make sure you have the prereqs for the [LEDE Image Builder](https://lede-project.org/docs/user-guide/imagebuilder#prerequisites)
+
+# Build image
+
+To build an image just specify the model to build for. Currently we support
+Netgear `3700v2`, `3800`, & `3800ch` images. To build for `3800ch`:
+
+```sh
+make build-3800ch
+```
+> This requires an internet connection since it downloads the LEDE builds
+> from their mirrors.
+
+You will find the images in `./build/lede-imagebuilder-<version>-ar71xx-generic.Linux-x86_64/bin/targets/ar71xx/generic/`
+The `*sysupgrade.bin` file that matches the AP model should have been generated
+.
+Assuming openwrt or LEDE is already installed:
+
+```sh
+scp <sysupgrade.bin> root@<AP IP>:/tmp/
+ssh root@<AP IP>
+cd /tmp
+sysupgrade -v <sysupgrade.bin> # Wait for the AP to load and reboot
+```
+
+Once it comes back online `ssh` back in an confirm the version
+
+```sh
+ssh root@<AP IP>
+cat /etc/os-release
+```
+# Notes
+
+## Make
+
+* http://makefiletutorial.com/
+* https://bost.ocks.org/mike/make/
+* http://mrbook.org/blog/tutorials/make/
+* ftp://ftp.gnu.org/old-gnu/Manuals/make-3.79.1/html_chapter/make_2.html


### PR DESCRIPTION
Heres some initial work for standardizing the builds for openwrt/lede so more of the team can build the images themselves for improving and testing. I'm not the best with `make` but these have been very helpful for me with my testing currently. There using the latest stable branch of `lede`.

~~I am still testing each build of the APs but I wanted to get everyones thoughts on what I have so far. I'll probably have some fixups before this is ready to be merged.~~ All three models took the builds correctly for the most recent version of LEDE: `17.01.4`

@owendelong @irabinovitch @hriday @jaymzh @kylerisse 
  