### PR TITLE
script to flash netgear APs

### DIFF
--- a/openwrt/flash
+++ b/openwrt/flash
@@ -1,0 +1,27 @@
+#!/usr/bin/expect
+spawn /usr/sbin/arp -d 192.168.1.1
+spawn ping -n 192.168.1.1
+expect {
+  Unreachable exp_continue
+  "taking countermeasures"
+}
+close
+send_user "enter the name of this AP: "
+expect_user -re "(.*)\n"
+set ap $expect_out(1,string)
+spawn /usr/sbin/arp -n 192.168.1.1
+expect -re "192.168.1.1 *ether *(\[^ \]*) "
+set mac $expect_out(1,string)
+set file [open aplist a]
+puts $file "$ap,$mac"
+close $file
+spawn tftp 192.168.1.1
+expect tftp
+send "bin\n"
+expect tftp
+send "put factory.img\n"
+expect tftp
+send "quit\n"
+close
+spawn /usr/sbin/arp -d 192.168.1.1
+send_user "\n\nfinished, do the next AP\n\n"


### PR DESCRIPTION
set the machine to an address that can talk to 192.168.1.1
hook up a powered off netgear wndr3800, run the script

hold down the reset button and power on the AP, when it prompts for a name, enter the name and the script will flash the AP and save the name and mac address to a csv file, and then loop back for the next device

## Description of PR
Brief description of the PR

## Previous Behavior
Remove this section if not relevant

## New Behavior
Remove this section if not relevant

## Tests
How was this PR tested?
