### PR TITLE
[READY] Simple zabbix & rsyslog configs

### DIFF
--- a/facts/secrets/openwrt.yaml.example
+++ b/facts/secrets/openwrt.yaml.example
@@ -1,4 +1,13 @@
 root_hash: "$dfjakls$1md5crypthashofpassword"
+
+rsyslog:
+  server: 'server2.scale.lan'
+  port: '514'
+  protocol: 'udp'
+
+zabbix:
+  server: 'server3.scale.lan'
+
 wired:
   switches:
     - 'switch0'
@@ -34,7 +43,6 @@ wired:
       proto: 'none'
       device: 'switch0'
       ports: '0t 5t'
-
 
 wireless:
   radios:

--- a/openwrt/diffconfig
+++ b/openwrt/diffconfig
@@ -39,6 +39,7 @@ CONFIG_PACKAGE_libuuid=y
 CONFIG_PACKAGE_lldpd=y
 # CONFIG_PACKAGE_logd is not set
 CONFIG_PACKAGE_lua=y
+# CONFIG_PACKAGE_odhcpd-ipv6only is not set
 CONFIG_PACKAGE_openssh-client=y
 CONFIG_PACKAGE_openssh-client-utils=y
 CONFIG_PACKAGE_openssh-keygen=y

--- a/openwrt/diffconfig
+++ b/openwrt/diffconfig
@@ -22,6 +22,7 @@ CONFIG_OPENSSL_WITH_SRP=y
 # CONFIG_PACKAGE_dropbear is not set
 # CONFIG_PACKAGE_firewall is not set
 CONFIG_PACKAGE_iperf3=y
+CONFIG_PACKAGE_jq=y
 CONFIG_PACKAGE_kmod-usb-serial=y
 CONFIG_PACKAGE_kmod-usb-serial-ftdi=y
 CONFIG_PACKAGE_kmod-usb-serial-pl2303=y

--- a/openwrt/files/etc/rsyslog.conf
+++ b/openwrt/files/etc/rsyslog.conf
@@ -16,3 +16,5 @@ mail.*                                    /var/log/maillog
 cron.*                                    /var/log/cron
 
 local7.*                                  /var/log/boot.log
+
+*.* action(type="omfwd" target="{{ (datasource "openwrt").rsyslog.server }}" port="{{ (datasource "openwrt").rsyslog.port }}" protocol="{{ (datasource "openwrt").rsyslog.protocol }}")

--- a/openwrt/files/etc/zabbix_agentd.conf
+++ b/openwrt/files/etc/zabbix_agentd.conf
@@ -1,0 +1,12 @@
+# use syslog
+LogType=system
+
+# List of comma delmited IP addressses of Zabbix servers
+Server={{ (datasource "openwrt").zabbix.server }}
+
+# Number of pre-forked instances of zabbix_agentd that
+# process passive checks
+StartAgents=1
+
+# Include additional config
+Include=/etc/zabbix_agentd.config.d/


### PR DESCRIPTION
## Description of PR
Simple `zabbix`  and `rsyslog` remote config. Fulfills #34

Adding and removing a few packages
```diff
- odhcpd
+ jq
```


## Previous Behavior
Zabbix was installed but not configured. Rsyslog was only logging locally

## New Behavior
* Zabbix now can be templated out and included in the image
* Rsyslog now sends logs to a remote host

## Tests
Yes zabbix did log to my test rsyslog server
None for zabbix, I dont have the server to test with yet. Based this config off 2016 and 2017 configs
