### PR TITLE
[READY] wifi gateway monitor and then some

### DIFF
--- a/facts/secrets/openwrt.yaml.example
+++ b/facts/secrets/openwrt.yaml.example
@@ -8,6 +8,11 @@ rsyslog:
 zabbix:
   server: 'server3.scale.lan'
 
+nameserver: '8.8.8.8'
+
+apinger:
+  endpoint: '8.8.8.8'
+
 wired:
   switches:
     - 'switch0'
@@ -57,9 +62,11 @@ wireless:
         - ssid: 'scale-public-slow'
           password: 'tuxlinux'
           interface: 'scaleslow'
+          disabled: 0
         - ssid: 'scale-staff-24'
           password: 'testpassword'
           interface: 'staffwifi'
+          disabled: 0
     - name: 'radio1'
       type: 'mac80211'
       hwmode: '11a'
@@ -71,6 +78,8 @@ wireless:
         - ssid: 'scale-public-fast'
           password: 'tuxlinux'
           interface: 'scalefast'
+          disabled: 0
         - ssid: 'scale-staff-5'
           password: 'testpassword'
           interface: 'staffwifi'
+          disabled: 0

--- a/openwrt/Makefile
+++ b/openwrt/Makefile
@@ -41,7 +41,7 @@ $(BUILD_DIR)/$(IMAGEBUILDER)/.config: extract
 	  && make defconfig
 
 build-img: $(BUILD_DIR)/$(IMAGEBUILDER)/.config
-	@cd $(BUILD_DIR)/$(IMAGEBUILDER) && $(MAKE) download && $(MAKE) V=s j=4
+	@cd $(BUILD_DIR)/$(IMAGEBUILDER) && $(MAKE) download && $(MAKE) V=s -j 4
 
 $(BUILD_DIR):
 	mkdir -p $(BUILD_DIR)
@@ -59,4 +59,6 @@ ifndef GOMPLATE
   $(error "gomplate is not available please install it")
 endif
 	$(GOMPLATE) -d openwrt=$(BUILD_SECRETS) --input-dir=$(TMPL_SRC_DIR) --output-dir=$(TMPL_OUT_DIR)
+	# TODO: should do this automatically for .sh file types
+	chmod 750 $(TMPL_OUT_DIR)/root/bin/wifi-details.sh
 	touch $(TMPL_OUT_DIR)

--- a/openwrt/diffconfig
+++ b/openwrt/diffconfig
@@ -18,6 +18,7 @@ CONFIG_OPENSSL_WITH_EC=y
 CONFIG_OPENSSL_WITH_NPN=y
 CONFIG_OPENSSL_WITH_PSK=y
 CONFIG_OPENSSL_WITH_SRP=y
+CONFIG_PACKAGE_apinger=y
 # CONFIG_PACKAGE_dnsmasq is not set
 # CONFIG_PACKAGE_dropbear is not set
 # CONFIG_PACKAGE_firewall is not set
@@ -33,17 +34,21 @@ CONFIG_PACKAGE_libiwinfo-lua=y
 CONFIG_PACKAGE_liblua=y
 CONFIG_PACKAGE_libnetsnmp=y
 CONFIG_PACKAGE_libopenssl=y
+CONFIG_PACKAGE_libpopt=y
+CONFIG_PACKAGE_librrd1=y
 CONFIG_PACKAGE_librt=y
 CONFIG_PACKAGE_libuci-lua=y
 CONFIG_PACKAGE_libuuid=y
 CONFIG_PACKAGE_lldpd=y
 # CONFIG_PACKAGE_logd is not set
+CONFIG_PACKAGE_logrotate=y
 CONFIG_PACKAGE_lua=y
 # CONFIG_PACKAGE_odhcpd-ipv6only is not set
 CONFIG_PACKAGE_openssh-client=y
 CONFIG_PACKAGE_openssh-client-utils=y
 CONFIG_PACKAGE_openssh-keygen=y
 CONFIG_PACKAGE_openssh-server=y
+CONFIG_PACKAGE_rrdtool1=y
 CONFIG_PACKAGE_rsyslog=y
 CONFIG_PACKAGE_snmp-utils=y
 CONFIG_PACKAGE_snmpd=y

--- a/openwrt/files/etc/apinger.conf
+++ b/openwrt/files/etc/apinger.conf
@@ -1,0 +1,57 @@
+## Following "macros" may be used in options below:
+##      %t - target name (address)
+##      %T - target description
+##      %a - alarm name
+##      %A - alarm type ("down"/"loss"/"delay")
+##      %r - reason of message ("ALARM"/"alarm canceled"/"alarm canceled (config reload)")
+##      %p - probes send
+##      %P - probes received
+##      %l - recent average packet loss
+##      %d - recent average delay
+##      %s - current timestamp
+##      %% - '%' character
+
+## User and group the pinger should run as
+user "nobody"
+group "nogroup"
+
+## Location of the pid-file (default: "/var/run/apinger.pid")
+#pid_file "/var/run/apinger.pid"
+
+status {
+	## File where the status information whould be written to
+	file "/tmp/apinger.status"
+	## Interval between file updates
+	## when 0 or not set, file is written only when SIGUSR1 is received
+	interval 1m
+}
+
+## Target defaults that are inheretted by each target
+## and can be overwritten
+target default {
+	## How often the probe should be sent
+	interval 2s
+
+	## How many replies should be used to compute average delay
+	## for controlling "delay" alarms
+	avg_delay_samples 10
+
+	## How many probes should be used to compute average loss
+	avg_loss_samples 50
+	## The delay (in samples) after which loss is computed
+	## without this delays larger than interval would be treated as loss
+	avg_loss_delay_samples 20
+}
+
+alarm down "wifi" {
+	time 10s
+        ## Turn off network
+	command on "/usr/bin/logger -t apinger %t %a: %r && wifi off"
+        ## Turn on network
+	command off "/usr/bin/logger -t apinger %t %a: %r && wifi on"
+	combine 10s
+}
+
+target "{{ (datasource "openwrt").apinger.endpoint }}" {
+        description "endpoint validation"
+        alarms override "wifi"

--- a/openwrt/files/etc/apinger.conf
+++ b/openwrt/files/etc/apinger.conf
@@ -12,7 +12,8 @@
 ##      %% - '%' character
 
 ## User and group the pinger should run as
-user "nobody"
+# Needs to be root for interacting with wifi
+user "root"
 group "nogroup"
 
 ## Location of the pid-file (default: "/var/run/apinger.pid")
@@ -23,7 +24,7 @@ status {
 	file "/tmp/apinger.status"
 	## Interval between file updates
 	## when 0 or not set, file is written only when SIGUSR1 is received
-	interval 1m
+	interval 10s
 }
 
 ## Target defaults that are inheretted by each target
@@ -46,12 +47,13 @@ target default {
 alarm down "wifi" {
 	time 10s
         ## Turn off network
-	command on "/usr/bin/logger -t apinger %t %a: %r && wifi off"
+	command on "/usr/bin/logger -t apinger %t %a: %r && wifi down"
         ## Turn on network
-	command off "/usr/bin/logger -t apinger %t %a: %r && wifi on"
+	command off "/usr/bin/logger -t apinger %t %a: %r && wifi up"
 	combine 10s
 }
 
 target "{{ (datasource "openwrt").apinger.endpoint }}" {
         description "endpoint validation"
         alarms override "wifi"
+}

--- a/openwrt/files/etc/config/wireless
+++ b/openwrt/files/etc/config/wireless
@@ -18,5 +18,6 @@ config wifi-iface '{{.interface}}_{{$element.name}}'
 	option network '{{.interface}}'
 	option encryption 'psk2'
 	option key '{{.password}}'
+	option disabled '{{.disabled}}'
 {{end}}
 {{- end}}

--- a/openwrt/files/etc/crontabs/root
+++ b/openwrt/files/etc/crontabs/root
@@ -1,0 +1,1 @@
+0 * * * * /usr/sbin/logrotate -f /etc/logrotate.conf -s /tmp/logrotate.status

--- a/openwrt/files/etc/logrotate.conf
+++ b/openwrt/files/etc/logrotate.conf
@@ -1,0 +1,18 @@
+# rotate log files daily
+daily
+
+# keep 2 days worth of backlogs
+rotate 2
+
+# create new (empty) log files after rotating old ones
+create
+
+notifempty
+nomail
+missingok
+
+# uncomment this if you want your log files compressed
+compress
+
+# packages can drop log rotation information into this directory
+include /etc/logrotate.d

--- a/openwrt/files/etc/logrotate.d/rsyslog
+++ b/openwrt/files/etc/logrotate.d/rsyslog
@@ -1,0 +1,7 @@
+/var/log/messages {
+    missingok
+    notifempty
+    compress
+    size 500k
+    copytruncate
+}

--- a/openwrt/files/etc/rc.local
+++ b/openwrt/files/etc/rc.local
@@ -1,0 +1,7 @@
+# Put your custom commands here that should be executed once
+# the system init finished. By default this file does nothing.
+
+# TODO make this a true service
+/root/bin/wifi-details.sh &
+
+exit 0

--- a/openwrt/files/etc/resolv.conf
+++ b/openwrt/files/etc/resolv.conf
@@ -1,0 +1,1 @@
+nameserver {{ (datasource "openwrt").nameserver }}

--- a/openwrt/files/root/bin/wifi-details.sh
+++ b/openwrt/files/root/bin/wifi-details.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+
+while true
+do
+  # Example of output
+  # /sys/kernel/debug/ieee80211/phy1/netdev:wlan1/stations/14:1a:a3:9a:47:35/rc_stats
+  CLIENTS=$(find /sys/kernel/debug/ieee80211/ -name rc_stats)
+  echo $CLIENTS |sed -e s#/sys/kernel/debug/ieee80211/## -e s#/netdev:#' '# -e s#/stations/#' '# -e s#/rc_stats## -e s/:/-/g |while rea
+  do
+    /usr/bin/logger -t "stats-$net-$mac" $(cat $CLIENTS |sed -e :0 -e '/,.*,.*,/b' -e N -e 's/\n/#014/' -e b0)
+  done
+
+  # Wait a little
+  sleep 1
+done


### PR DESCRIPTION
## Description of PR
This allows us to monitor gateway endpoints and turn off wifi networks when the gateways are not reachable. Fulfills #15 

## Previous Behavior
Wifi radios were always advertising the wireless networks even if the network was unhealthy

## New Behavior
* Wifi networks are taken down when the endpoint is not reachable
* Added @davidelang's wifi report script
* Added logrotate package and config
* Added rrdtool1 package
* Resolver is now configurable
* Fixed some `Makefile` issues

## Tests
Tested on `3700v2` and this will be the image used for testing on sunday