### PR TITLE
Fixed #58, syntax vlans.d/Briged (spaces->tabs)

### DIFF
--- a/switch-configuration/config/scripts/build_switch_configs.pl
+++ b/switch-configuration/config/scripts/build_switch_configs.pl
@@ -15,6 +15,7 @@ if(scalar(@ARGV)) # One or more switch names specified
 else
 {
     # Rebuild entire config set, so start with empty output directory
+    ##FIXME## Should probably only delete configurations we are about to build
     my $file;
     foreach $file (glob("output/*"))
     {
@@ -27,6 +28,14 @@ foreach $switch (@{$switchlist})
     debug(2, "Building $switch\n");
     my $cf = build_config_from_template($switch,
             '$5$c1mAcDv3$zQkDfQL9dswXflyqd6stNT3A3aPLhZoXLtuIgWjG073');
+    if ( ! -d "output")
+    {
+	mkdir "output";
+    }
+    if ( ! -d "output" || ! -w "output" || ! -x "output" )
+    {
+        die("Directory \"output\" does not exist!\n");
+    }
     open OUTPUT, ">output/$switch.conf" ||
              die("Couldn't write configuration for ".$switch." $!\n");
     print OUTPUT $cf;

--- a/switch-configuration/config/vlans.d/Bridged
+++ b/switch-configuration/config/vlans.d/Bridged
@@ -1,4 +1,4 @@
 // Bridged -- 900-999
 VLAN	MDF_LINK	900	2001:470:f325:8000::/64	172.20.0.0/24	Link between IDF in Conference and Expo Centers
 VLAN	HAM_BRIDGE	950	::/0			0.0.0.0/0	Link between N6S station and Ham Booth in Expo
-VLAN  COGENT  999 ::/0  38.98.46.128/25 COGENT IPv4 Transit Link (PSAV / PCC)
+VLAN	COGENT	999 ::/0	38.98.46.128/25	COGENT IPv4 Transit Link (PSAV / PCC)


### PR DESCRIPTION
## Description of PR
Create output directory automatically


## Previous Behavior
Did not create output directory

## New Behavior
Creates output directory if needed, properly errors if not possible

## Tests
Run script Run. -- Forest Gump
