### PR TITLE
[READY] Updating build to latest openwrt master

### DIFF
--- a/facts/secrets/openwrt.yaml.example
+++ b/facts/secrets/openwrt.yaml.example
@@ -21,33 +21,25 @@ wired:
   networks:
     # interface names cant have special characters
     - name: 'mgmt'
-      parent_if: 'eth0'
-      vlans: ['103', '503']
+      ifname: 'eth1.103 eth1.503'
       type: 'bridge'
       proto: 'dhcp'
-      device: 'switch0'
-      ports: '0t 5t'
+    - name: 'mgmt6'
+      ifname: '@mgmt'
+      proto: 'dhcpv6'
+      reqprefix: 'no'
     - name: 'staffwifi'
-      parent_if: 'eth0'
-      vlans: ['108', '508']
+      ifname: 'eth1.108 eth1.508'
       type: 'bridge'
       proto: 'none'
-      device: 'switch0'
-      ports: '0t 5t'
     - name: 'scaleslow'
-      parent_if: 'eth0'
-      vlans: ['100', '500']
+      ifname: 'eth1.100 eth1.500'
       type: 'bridge'
       proto: 'none'
-      device: 'switch0'
-      ports: '0t 5t'
     - name: 'scalefast'
-      parent_if: 'eth0'
-      vlans: ['101', '501']
+      ifname: 'eth1.101 eth1.501'
       type: 'bridge'
       proto: 'none'
-      device: 'switch0'
-      ports: '0t 5t'
 
 wireless:
   radios:

--- a/openwrt/Makefile
+++ b/openwrt/Makefile
@@ -10,7 +10,8 @@ BUILD_SECRETS = ../facts/secrets/openwrt.yaml
 GOMPLATE := $(shell command -v gomplate 2> /dev/null)
 CURL := $(shell command -v curl 2> /dev/null)
 
-LEDE_VER = 7da64807002cbe665176b125d8b2ee1a46d4e785
+#LEDE_VER = 7da64807002cbe665176b125d8b2ee1a46d4e785
+LEDE_VER = 4056be58f323ee813bccf500aa30ebac3bbb263d
 IMAGEBUILDER = source-$(LEDE_VER)
 TAR_EXT = .tar.gz
 

--- a/openwrt/README.md
+++ b/openwrt/README.md
@@ -1,6 +1,6 @@
 # Prereqs
 
-Make sure you have the prereqs for the [LEDE Image Builder](https://lede-project.org/docs/user-guide/imagebuilder#prerequisites)
+Make sure you have the prereq pkgs for the [LEDE Image Builder](https://openwrt.org/docs/guide-user/additional-software/imagebuilder)
 
 If you are building images with templates you'll also need:
 * gomplate 2.2.0: https://github.com/hairyhenderson/gomplate/releases/tag/v2.2.0
@@ -9,6 +9,7 @@ If you are building images with templates you'll also need:
 ## Stock Image
 
 Currently we support Netgear `3700v2`, `3800`, & `3800ch` images.
+
 We build all 3 modules at once:
 
 ```sh
@@ -54,20 +55,35 @@ This will populate the templates with the necessary values and include them
 into the lede build
 
 # Upgrading
-## Auto TFTP
-Set a static ip in `192.168.1.1/24` then use the `flash` script:
+
+1. Connect an ethernet cable from your workstation's ethernet port to one
+   of the LAN (not WAN) ports on the router.
+2. Set  static ip in `192.168.1.1/24` on your workstations ethernet port.
+3. Create symlink to `.img` due to tftp being picky about long filenames:
 
 ```sh
 cd openwrt
-ln -s locationof.img factory.img
+ln -s <locationof>.img factory.img
+```
+
+4. Start the AP up while holding down the reset button. Once the power lede is
+   flashing green you can let go of the reset button.
+
+The AP is now ready to accept a new `.img`, continue with either method below:
+
+## Auto TFTP
+
+Use the `flash` script:
+
+```sh
+cd openwrt
 ./flash
 ```
 > This will also update the .csv with the mac address
 
 ## Manual TFTP
-Start the AP up while holding down the reset button. Once the power lede is
-flashing green you can let go of the reset button. Set a static ip in
-`192.168.1.1/24` then `tftp`:
+
+Manual interaction with `tftp` client:
 
 ```sh
 ln -s locationof.img factory.img

--- a/openwrt/files/etc/config/network
+++ b/openwrt/files/etc/config/network
@@ -16,16 +16,6 @@ config switch
         option blinkrate '2'
 {{ end }}
 
-config interface 'mgmt'
-        option ifname 'eth1.103 eth1.503 '
-        option type 'bridge'
-        option proto 'dhcp'
-
-config interface 'mgmt6'
-        option proto 'dhcpv6'
-        option ifname '@mgmt'
-        option reqprefix no
-
 {{ range $index, $element := (datasource "openwrt").wired.networks }}
 config interface '{{.name}}'
         {{ range $key, $value := . -}}

--- a/openwrt/files/etc/config/network
+++ b/openwrt/files/etc/config/network
@@ -28,9 +28,11 @@ config interface 'mgmt6'
 
 {{ range $index, $element := (datasource "openwrt").wired.networks }}
 config interface '{{.name}}'
-        option ifname '{{range .vlans}}{{$element.parent_if}}.{{.}} {{ end -}}'
-        option type '{{.type}}'
-        option proto '{{.proto}}'
+        {{ range $key, $value := . -}}
+        {{ if (ne $key "name") -}}
+        option {{ $key }} '{{ $value }}'
+        {{ end -}}
+        {{ end -}}
 {{ end }}
 
 


### PR DESCRIPTION
## Description of PR
Fulfills #117 

Its time to get rolling on the `openwrt` front for Scale 17x!

Existing `openwrt` build was referencing old SHA from Scale 16x. I needed to investigate to make sure that the build process still works on our existing hardware against latest `master`. I know that the goal is to get the process working with the newer model but this is an initial step in that direction.

Ideally I'm hoping this build process supports both models of APs (well see how feasible that is).

@owendelong @davidelang @kylerisse

## Previous Behavior
* Building against old SHA from scale16x
* Old link in README.md
* Hardcoded mgmt interface during crunchtime: #78 

## New Behavior
* Latest images were build and successfully running our code as intended!
* Updated documentation
* Refactored `go templating` to remove hardcode mgmt interface and example

## Tests
`flash` and ran against Netgear `3800CH`. Successful `ssh` session and radios are up:
```
BusyBox v1.29.3 () built-in shell (ash)

  _______                     ________        __
 |       |.-----.-----.-----.|  |  |  |.----.|  |_
 |   -   ||  _  |  -__|     ||  |  |  ||   _||   _|
 |_______||   __|_____|__|__||________||__|  |____|
          |__| W I R E L E S S   F R E E D O M
 -----------------------------------------------------
 OpenWrt SNAPSHOT, r0-6a15bdc
 -----------------------------------------------------
root@OpenWrt:~# uname -a
Linux OpenWrt 4.14.78 #0 Tue Oct 30 21:07:38 2018 mips GNU/Linux
root@OpenWrt:~#
```

