### PR TITLE
[READY] Adding links to maps pdfs

### DIFF
--- a/MAPS.md
+++ b/MAPS.md
@@ -1,0 +1,15 @@
+# Maps
+
+Maps of the layout for SCaLE 16x at Pasadena Convention Center maps can be found:
+
+* [cbll-diagram-1](http://sarcasticadmin.com/scale/maps/16x/cbll-diagram-1-scale.pdf)
+* [cbul-diagram-2](http://sarcasticadmin.com/scale/maps/16x/cbul-diagram-2-scale.pdf)
+* [cbul-diagram-3](http://sarcasticadmin.com/scale/maps/16x/cbul-diagram-3-scale.pdf)
+* [ballroom-diagram-4](http://sarcasticadmin.com/scale/maps/16x/ballroom-diagram-4-scale.pdf)
+* [ballroom-diagram-5](http://sarcasticadmin.com/scale/maps/16x/ballroom-diagram-5-scale.pdf)
+* [ballroom-diagram-6](http://sarcasticadmin.com/scale/maps/16x/ballroom-diagram-6-scale.pdf)
+
+## Updates
+
+For now we are hosting these out of s3 to keep the repo size small. Please contact Rob on the SCaLE mailing list if you'd
+like to update this info.

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@ configurations, tooling and scripts for [SCALE's](https://www.socallinuxexpo.org
 
 ## Table of Contents
 * [CONTRIBUTING](./CONTRIBUTING.md)
+* [MAPS](./MAPS.md)
 * [SWITCH CONFIG](./switch-configuration/README.md)
 * [ANSIBLE](./ansible/README.md)
 * [OPENWRT](./openwrt/README.md)


### PR DESCRIPTION
## Description of PR
@sbibayoff I added these to `s3` instead of directly in git. That way theres no having to mess with `git-lfs`. This was my alternative to #124. Let me know what you think.

Sorry for the delay.

## Previous Behavior
We didnt have maps

## New Behavior
Now we have maps for the Pasadena Convention Center from 16x 

## Tests
Links work
