### PR TITLE
[READY] Fix DHCP issue caused by Expo file changes

### DIFF
--- a/ansible/inventory.py
+++ b/ansible/inventory.py
@@ -36,9 +36,12 @@ def populatevlans():
                 ipv4bitmask = ipv4[1]
                 ipv4dhcp = dhcp4ranges(ipv4prefix, int(ipv4bitmask))
                 ipv4netmask = bitmasktonetmask(int(ipv4bitmask))
+                vlanid = elems[2]
+                if not vlanid.isdigit():
+                    continue
                 vlans.append({
                     "name": elems[1],
-                    "id": elems[2],
+                    "id": vlanid,
                     "ipv6prefix": ipv6prefix,
                     "ipv6bitmask": ipv6bitmask,
                     "ipv4prefix": ipv4prefix,
@@ -71,7 +74,8 @@ def ip4toptr(ip_address):
 
 def ip6toptr(ip_address):
     '''generates a split PTR for IPv6 an returns it'''
-    return re.split(r'\.ip6', ipaddress.ip_address(ip_address).reverse_pointer)[0]
+    return re.split(r'\.ip6',
+                    ipaddress.ip_address(ip_address).reverse_pointer)[0]
 
 
 def dhcp6ranges(prefix, bitmask):


### PR DESCRIPTION
## Description of PR
During further investigation for #144 found an error with DHCP services due to changes in the Expo vlans.d file. This fix eliminates the cause by testing if the vlan ID is a digit. Another solution would be to comment out the offending line in that file but this PR can proceed regardless of that choice.

## Previous Behavior
isc-dhcp-server would fail on start due to an invald entry in `/etc/dhcp/dhcpd.conf.subnets` related to the ex_v_ line in `vlans.d/Expo`

## New Behavior

- Inserted a quick check when parsing the vlans.d files to test whether the vlan ID is a digit. There isn't a valid case where a real VLAN would be a non digit (in the case ofo ex_v_ containing a "-") so there's no harm in adding it.
- Reduced the number of characters in line 77 to pass pylint, unrelated to bug fix.

## Tests
1. Ran `inventory.py` and verified the culprit VLAN was no longer present in the output.
2. After a `vagrant provision` verified `/var/log/dhcp.log` did not show exiting for v4 anymore.
3. Verified service health with `systemctl status isc-dhcp-server`. Service no longer in `failed` state.
