### PR TITLE
[READY] Ansible signs role

### DIFF
--- a/ansible/README.md
+++ b/ansible/README.md
@@ -25,6 +25,10 @@ This playbook is used for deploying and maintaining the SCaLE Server Infrastruct
   * Tech Team
     * Auto create team user accounts and home dirs
     * Effortless passwordless sudo
+  * SCaLE Signs
+    * Automatically pulls down scale signs repo, builds as docker image, and wraps it up as a systemd service
+    * Subsequent runs after an update to the repo will rebuild the container and restart service
+    * Secrets management is still manual for twitter creds and requires rebuilding the container and restarting manually
   * Automatically updates via apt
 
 ## Requirements:

--- a/ansible/etc/ansible/roles/signs/defaults/main.yml
+++ b/ansible/etc/ansible/roles/signs/defaults/main.yml
@@ -1,0 +1,5 @@
+---
+
+scale_signs_root: /usr/local/scale-signs
+scale_signs_repo_url: https://github.com/socallinuxexpo/scale-signs.git
+scale_signs_repo_branch: master

--- a/ansible/etc/ansible/roles/signs/handlers/main.yml
+++ b/ansible/etc/ansible/roles/signs/handlers/main.yml
@@ -1,0 +1,15 @@
+---
+
+- name: rebuild scale-signs docker image
+  command: docker-compose build
+  args:
+    chdir: "{{ scale_signs_root }}"
+  listen: scale-signs repo updated
+
+- name: restart scale-signs
+  systemd:
+    name: scale-signs
+    state: restarted
+  listen:
+    - scale-signs repo updated
+    - restart scale-signs

--- a/ansible/etc/ansible/roles/signs/tasks/main.yml
+++ b/ansible/etc/ansible/roles/signs/tasks/main.yml
@@ -31,13 +31,13 @@
             1. secrets are populated \
             2. contianer is rebuilt \
             3. service is restarted "
-  when: signs_secrets.stat.exists == False
+  when: not signs_secrets.stat.exists
 
 - name: create temporary blank secrets file
   file:
     path: "{{ scale_signs_root }}/secrets.env"
     state: touch
-  when: signs_secrets.stat.exists == False
+  when: not signs_secrets.stat.exists
 
 - name: copy scale-signs systemd unit file
   template:

--- a/ansible/etc/ansible/roles/signs/tasks/main.yml
+++ b/ansible/etc/ansible/roles/signs/tasks/main.yml
@@ -1,0 +1,54 @@
+---
+
+- name: install signs packages
+  apt:
+    name: ['docker.io', 'python3-pip', 'git']
+    state: present
+
+- name: install docker-compose
+  pip:
+    name: docker-compose
+    state: present
+
+- name: pull scale-signs repo
+  git:
+    repo: "{{ scale_signs_repo_url }}"
+    version: "{{ scale_signs_repo_branch }}"
+    dest: "{{ scale_signs_root }}"
+    update: yes
+  notify: scale-signs repo updated
+
+- name: check if secrets exist
+  stat:
+    path: "{{ scale_signs_root }}/secrets.env"
+  register: signs_secrets
+
+- name: warn of missing secrets file
+  debug:
+    msg: "\
+        Missing secrets file {{ scale_signs_root }}/secrets.env \
+        a blank one will be created but Twitter integration will not work until: \
+            1. secrets are populated \
+            2. contianer is rebuilt \
+            3. service is restarted "
+  when: signs_secrets.stat.exists == False
+
+- name: create temporary blank secrets file
+  file:
+    path: "{{ scale_signs_root }}/secrets.env"
+    state: touch
+  when: signs_secrets.stat.exists == False
+
+- name: copy scale-signs systemd unit file
+  template:
+    src: scale-signs.service.j2
+    dest: /etc/systemd/system/scale-signs.service
+    owner: root
+    group: root
+    mode: 0755
+
+- name: enable scale-signs service
+  systemd:
+    name: scale-signs
+    enabled: yes
+    daemon_reload: yes

--- a/ansible/etc/ansible/roles/signs/templates/scale-signs.service.j2
+++ b/ansible/etc/ansible/roles/signs/templates/scale-signs.service.j2
@@ -1,0 +1,16 @@
+[Unit]
+Description=SCaLE Signs Service
+Requires=docker.service
+After=docker.service
+
+[Service]
+WorkingDirectory={{ scale_signs_root }}
+ExecStart=/usr/local/bin/docker-compose up
+ExecStop=/usr/local/bin/docker-compose down
+TimeoutStartSec=0
+Restart=on-failure
+StartLimitIntervalSec=60
+StartLimitBurst=3
+
+[Install]
+WantedBy=multi-user.target

--- a/ansible/etc/ansible/scale.yml
+++ b/ansible/etc/ansible/scale.yml
@@ -27,3 +27,10 @@
     - dnsclient
     - noapparmor
     - chrony
+
+- hosts: automation
+  become: yes
+  vars:
+    ansible_python_interpreter: /usr/bin/python3
+  roles:
+    - signs


### PR DESCRIPTION
## Description of PR
Add an Ansible role for the signs server

## Previous Behavior
No role for signs server, deployment and updates were accomplished manually

## New Behavior
Ansible automatically deploys the signs server directly from github as a docker container wrapped in systemd. Will make on-site support a little easier despite a bit of manual effort to manage secrets initially. Changes to remote master for the scale-signs repo are easily deployed through this role.

## Tests
1. Provision vagrant environment with `vagrant up`
2. Verify signs page is available by browsing to `http://10.128.3.7`
3. Use `vagrant ssh server8` to log into signs server to complete following tests
4. Verify service starts and stops using systemd `sudo systemctl restart scale-signs`
5. Generate traffic in web browser and verify logging `cd /usr/local/scale-signs && sudo docker-compose logs`
6. Verify systemd status is showing logs and Active status `sudo systemctl status scale-signs`
7. Test twitter by replacing `/usr/local/scale-signs/secrets.env` with the real twitter oauth and consumer token info followed by `cd /usr/local/scale-signs/ && sudo docker-compose build && sudo systemctl restart scale-signs` then viewing the page in browser.
8. Simulate "update" by `sudo rm -rf /usr/local/scale-signs` then re-running the playbook with `vagrant provision` verifying container is rebuilt and services restarted.
