### PR TITLE
[WAIT] perl lint per issue 143

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,6 +3,19 @@
 version: 2
 jobs:
 
+  switch-configuration_lint:
+    docker:
+    - image: perl:5
+    resource_class: medium
+    working_directory: ~/scale-network
+    steps:
+    - checkout:
+        path: ~/scale-network
+
+    - run:
+        name: lint switch-configuration
+        command: find ./switch-configuration/ -iname "*.pl" -exec perl -Mstrict -Mdiagnostics -cw {} \;
+
   gomplate_tests:
     docker:
     - image: hairyhenderson/gomplate:v3.2.0-alpine
@@ -89,5 +102,6 @@ workflows:
   version: 2
   build_all:
     jobs:
+    - switch-configuration_lint
     - gomplate_tests
     - ansible_lint


### PR DESCRIPTION
## Description of PR
Adds perl lint to switch configuration scripts per #143  

## Previous Behavior
No perl based lint

## New Behavior
Basic lint check of perl scripts per original scope of #143 . This does not run the scripts per my suggestion in that issue due to a bit of complication it brings up when script names aren't known ahead of time. Can discuss and make that a future issue if needed. This fulfills the original scope.

## Tests
Verifying function via the Circle CI web interface
