### PR TITLE
Od.17.04

### DIFF
--- a/switch-configuration/config/scripts/switch_template.pl
+++ b/switch-configuration/config/scripts/switch_template.pl
@@ -918,12 +918,7 @@ EOF
 #	"firewall"    -> $VV_firewall,
 
 #	"dhcp"        -> $VV_dhcp,
-##FIXME## Put forwarding options here to facilitate DHCP (v4,v6)
-##FIXME## This is more complext than one would hope because it needs
-##FIXME## to produce a list of interfaces for IPv4 and IPv6 along
-##FIXME## with some other parameters. The best we can do at this
-##FIXME## stage is store the list of l3 interfaces for later use
-##FIXME## in the "Finish up strings" area below
+#       Build list of Vendor VLAN Interfaces for later use to build DHCP forwarders
         push @VV_intlist, "vlan.$VLID";
 
 

--- a/switch-configuration/config/scripts/switch_template.pl
+++ b/switch-configuration/config/scripts/switch_template.pl
@@ -372,16 +372,14 @@ sub build_l3_from_config
 {
   my $hostname = shift @_;
   my ($Number, $MgtVL, $IPv6addr, $Type) = get_switchtype($hostname);
-  my $OUTPUT = "    # Automatically Generated Layer 3 Configuration ".
+  my $OUTPUT = "        # Automatically Generated Layer 3 Configuration ".
                 "for $hostname (MGT: $MgtVL Addr: $IPv6addr Type: $Type\n";
   $OUTPUT .= <<EOF;
-    vlan {
         unit $MgtVL {
             family inet6 {
                 address $IPv6addr/64;
             }
         }
-    }
 EOF
   my $gw = get_default_gw($IPv6addr);
   return($OUTPUT, $gw);
@@ -433,15 +431,15 @@ sub build_vlans_from_config
       $desc = $TOKENS[5];
       $IPv6 = $TOKENS[3];
       $IPv4 = $TOKENS[4];
+      $VLANS_byname{$name} = $vlid;
+      $VLANS{$vlid} = [ $type, $name, $IPv6, $IPv4, $desc, 
+                        ($prim ? $prim : undef) ];
+      debug(1, "VLAN $vlid => $name ($type) $IPv6 $IPv4 $prim $desc\n");
     }
     elsif ($TOKENS[0] eq "VVRNG") # Vendor VLAN Range Specification
     {
       # Skip this line here... Process elsewhere
     }
-    debug(1, "VLAN $vlid => $name ($type) $IPv6 $IPv4 $prim $desc\n");
-    $VLANS_byname{$name} = $vlid;
-    $VLANS{$vlid} = [ $type, $name, $IPv6, $IPv4, $desc, 
-                      ($prim ? $prim : undef) ];
   }
 
   # Now that we have a hash containing all of the VLAN configurations, iterate
@@ -824,15 +822,14 @@ sub build_vendor_from_config
       debug(5, "Vendor v4_nexthop set to $v4_nexthop\n");
       ##FIXME## Vendor VLAN Backbone should come from a configuration file. This is a terrible hack for expedience
       $VV_vlans = <<EOF;
-vendor_backbone {
-    description "Vendor Backbone";
-    vlan-id 499;
-    l3-interface vlan.499;
-}
+    vendor_backbone {
+        description "Vendor Backbone";
+        vlan-id 499;
+        l3-interface vlan.499;
+    }
 EOF
       my $ipv4_suffix = $VV_COUNT + 10;
       $VV_vlans_l3 = <<EOF;
-    vlan {
         unit 499 {
             family inet {
                 address 10.2.0.$ipv4_suffix/24;
@@ -938,9 +935,6 @@ EOF
     }
   }
   # Finish up strings that need to be terminated (currently just $VV_vlans_l3)
-  $VV_vlans_l3 .= <<EOF;
-    }
-EOF
   # Finalize DHCP Forwarder configuration
   my $active_srv_grp = ($MgtVL < 500) ? "Expo" : "Conference";
   $VV_dhcp = <<EOF;
@@ -999,11 +993,10 @@ EOF
 
   $VV_dhcp .= <<EOF;
         }
-
     }
 }
 EOF
-##FIXME## Put DHCP finalization steps here
+
   if ($VV_portcount == 0) # No VVLAN statement encountered.
   {
     return(0);
@@ -1101,14 +1094,12 @@ snmp {
     }
 }
 interfaces {
-    $INTERFACES_PHYSICAL
-    $INTERFACES_LAYER3
-}
-forwarding-options {
-    dhcp-relay {
-        $DHCP_CONFIG;
+$INTERFACES_PHYSICAL
+    vlan {
+$INTERFACES_LAYER3
     }
 }
+$DHCP_CONFIG
 routing-options {
     $IPV4_DEFGW
     rib inet6.0 {
@@ -1130,7 +1121,7 @@ protocols {
     }
 }
 firewall {
-    $FIREWALL_CONFIG
+$FIREWALL_CONFIG
 }
 ethernet-switching-options {
     storm-control {

--- a/switch-configuration/config/switchtypes
+++ b/switch-configuration/config/switchtypes
@@ -1,4 +1,5 @@
-//	Switch	Type	Definitions
+//Switch Definitions
+//
 //Name		Num	MgtVL	IPv6				Type			// Switch Noiselevel
 Rm101-102	1	503	2001:470:f325:503::200:1	cfRoom			// Quiet
 NW-IDF		2	103	2001:470:f325:103::200:2	exIDF			// Loud
@@ -45,3 +46,5 @@ ExpoA5		42	103	2001:470:f325:103::200:42	Booth			// Normal
 ExpoB5		43	103	2001:470:f325:103::200:43	Booth			// Normal
 ExpoC5		44	103	2001:470:f325:103::200:44	Booth			// Loud
 ExpoAW		45	103	2001:470:f325:103::200:45	Booth			// Normal
+CTF5		46	103	2001:470:f325:103::200:46	cfCTF			// Loud
+CTF6		47	103	2001:470:f325:103::200:47	cfCTF			// Normal

--- a/switch-configuration/config/types/Booth
+++ b/switch-configuration/config/types/Booth
@@ -1,18 +1,18 @@
 // Expo Booth Area switch Template
 TRUNK	ge-0/0/0	exSCALE-SLOW,exSCALE-FAST,exSpeaker,exInfra,exAVLAN, \
-					exSigns,exStaff,exDWCC,exVendor
+				exSigns,exStaff,exDWCC,vendor_backbone
 TRUNK	ge-0/0/1	exSCALE-SLOW,exSCALE-FAST,exSpeaker,exInfra,exAVLAN, \
-					exSigns,exStaff,exDWCC,exVendor
-TRUNK	ge-0/0/8	exInfra,exSCALE-SLOW,exSCALE-FAST,exStaff				// AP
-TRUNK	ge-0/0/9	exInfra,exSCALE-SLOW,exSCALE-FAST,exStaff				// AP
-TRUNK	ge-0/0/10	exInfra,exSCALE-SLOW,exSCALE-FAST,exStaff				// AP
-TRUNK	ge-0/0/11	exInfra,exSCALE-SLOW,exSCALE-FAST,exStaff				// AP
-TRUNK	ge-0/0/12	exInfra,exSCALE-SLOW,exSCALE-FAST,exStaff				// AP
-TRUNK	ge-0/0/13	exInfra,exSCALE-SLOW,exSCALE-FAST,exStaff				// AP
-TRUNK	ge-0/0/14	exInfra,exSCALE-SLOW,exSCALE-FAST,exStaff				// AP
-TRUNK	ge-0/0/15	exInfra,exSCALE-SLOW,exSCALE-FAST,exStaff				// AP
-TRUNK	ge-0/0/16	exInfra,exSCALE-SLOW,exSCALE-FAST,exStaff				// AP
-TRUNK	ge-0/0/17	exInfra,exSCALE-SLOW,exSCALE-FAST,exStaff				// AP
+				exSigns,exStaff,exDWCC,vendor_backbone
+TRUNK	ge-0/0/8	exInfra,exSCALE-SLOW,exSCALE-FAST,exStaff	// AP
+TRUNK	ge-0/0/9	exInfra,exSCALE-SLOW,exSCALE-FAST,exStaff	// AP
+TRUNK	ge-0/0/10	exInfra,exSCALE-SLOW,exSCALE-FAST,exStaff	// AP
+TRUNK	ge-0/0/11	exInfra,exSCALE-SLOW,exSCALE-FAST,exStaff	// AP
+TRUNK	ge-0/0/12	exInfra,exSCALE-SLOW,exSCALE-FAST,exStaff	// AP
+TRUNK	ge-0/0/13	exInfra,exSCALE-SLOW,exSCALE-FAST,exStaff	// AP
+TRUNK	ge-0/0/14	exInfra,exSCALE-SLOW,exSCALE-FAST,exStaff	// AP
+TRUNK	ge-0/0/15	exInfra,exSCALE-SLOW,exSCALE-FAST,exStaff	// AP
+TRUNK	ge-0/0/16	exInfra,exSCALE-SLOW,exSCALE-FAST,exStaff	// AP
+TRUNK	ge-0/0/17	exInfra,exSCALE-SLOW,exSCALE-FAST,exStaff	// AP
 RSRVD	6
 VVLAN	16			// Dynamically assigned Vendor VLAN ports
 

--- a/switch-configuration/config/types/Catwalk
+++ b/switch-configuration/config/types/Catwalk
@@ -1,91 +1,91 @@
 // Expo Center Catwalk Switch Configuration
 TRUNK	ge-0/0/0	exSCALE-SLOW,exSCALE-FAST,exSpeaker,exInfra, \
-    		exAVLAN,exStaff, \
+			exAVLAN,exStaff, vendor_backbone \
 			exSigns,exDWCC,HAM_BRIDGE // Link to EX Router
 TRUNK	ge-0/0/1	exSCALE-SLOW,exSCALE-FAST,exSpeaker,exInfra, \
-    		exAVLAN,exStaff, \
+			exAVLAN,exStaff, \
 			exSigns,exDWCC,HAM_BRIDGE // Downlink to BallroomF
 TRUNK	ge-0/0/2	exSCALE-SLOW,exSCALE-FAST,exSpeaker,exInfra, \
-    		exAVLAN,exStaff, \
+			exAVLAN,exStaff, \
 			exSigns,exDWCC,HAM_BRIDGE // Downlink to BallroomG
 TRUNK	ge-0/0/3	exSCALE-SLOW,exSCALE-FAST,exSpeaker,exInfra, \
-    		exAVLAN,exStaff, \
+			exAVLAN,exStaff, \
 			exSigns,exDWCC,HAM_BRIDGE // Downlink to BallroomH
 TRUNK	ge-0/0/4	exSCALE-SLOW,exSCALE-FAST,exSpeaker,exInfra, \
-    		exAVLAN,exStaff, \
+			exAVLAN,exStaff, vendor_backbone \
 			exSigns,exDWCC,HAM_BRIDGE // 
 TRUNK	ge-0/0/5	exSCALE-SLOW,exSCALE-FAST,exSpeaker,exInfra, \
-    		exAVLAN,exStaff, \
+			exAVLAN,exStaff, vendor_backbone \
 			exSigns,exDWCC,HAM_BRIDGE // 
 TRUNK	ge-0/0/6	exSCALE-SLOW,exSCALE-FAST,exSpeaker,exInfra, \
-    		exAVLAN,exStaff, \
+			exAVLAN,exStaff, vendor_backbone \
 			exSigns,exDWCC,HAM_BRIDGE // 
 TRUNK	ge-0/0/7	exSCALE-SLOW,exSCALE-FAST,exSpeaker,exInfra, \
-    		exAVLAN,exStaff, \
+			exAVLAN,exStaff, vendor_backbone \
 			exSigns,exDWCC,HAM_BRIDGE // 
 TRUNK	ge-0/0/8	exSCALE-SLOW,exSCALE-FAST,exSpeaker,exInfra, \
-    		exAVLAN,exStaff, \
+			exAVLAN,exStaff, vendor_backbone \
 			exSigns,exDWCC,HAM_BRIDGE // 
 TRUNK	ge-0/0/9	exSCALE-SLOW,exSCALE-FAST,exSpeaker,exInfra, \
-    		exAVLAN,exStaff, \
+			exAVLAN,exStaff, vendor_backbone \
 			exSigns,exDWCC,HAM_BRIDGE // 
 TRUNK	ge-0/0/10	exSCALE-SLOW,exSCALE-FAST,exSpeaker,exInfra, \
-    		exAVLAN,exStaff, \
+			exAVLAN,exStaff, vendor_backbone \
 			exSigns,exDWCC,HAM_BRIDGE // 
 TRUNK	ge-0/0/11	exSCALE-SLOW,exSCALE-FAST,exSpeaker,exInfra, \
-    		exAVLAN,exStaff, \
+			exAVLAN,exStaff, vendor_backbone \
 			exSigns,exDWCC,HAM_BRIDGE // 
 TRUNK	ge-0/0/12	exSCALE-SLOW,exSCALE-FAST,exSpeaker,exInfra, \
-    		exAVLAN,exStaff, \
+			exAVLAN,exStaff, vendor_backbone \
 			exSigns,exDWCC,HAM_BRIDGE // 
 TRUNK	ge-0/0/13	exSCALE-SLOW,exSCALE-FAST,exSpeaker,exInfra, \
-    		exAVLAN,exStaff, \
+			exAVLAN,exStaff, vendor_backbone \
 			exSigns,exDWCC,HAM_BRIDGE // 
 TRUNK	ge-0/0/14	exSCALE-SLOW,exSCALE-FAST,exSpeaker,exInfra, \
-    		exAVLAN,exStaff, \
+			exAVLAN,exStaff, vendor_backbone \
 			exSigns,exDWCC,HAM_BRIDGE // 
 TRUNK	ge-0/0/15	exSCALE-SLOW,exSCALE-FAST,exSpeaker,exInfra, \
-    		exAVLAN,exStaff, \
+			exAVLAN,exStaff, vendor_backbone \
 			exSigns,exDWCC,HAM_BRIDGE // 
 TRUNK	ge-0/0/16	exSCALE-SLOW,exSCALE-FAST,exSpeaker,exInfra, \
-    		exAVLAN,exStaff, \
+			exAVLAN,exStaff, vendor_backbone \
 			exSigns,exDWCC,HAM_BRIDGE // 
 TRUNK	ge-0/0/17	exSCALE-SLOW,exSCALE-FAST,exSpeaker,exInfra, \
-    		exAVLAN,exStaff, \
+			exAVLAN,exStaff, vendor_backbone \
 			exSigns,exDWCC,HAM_BRIDGE // 
 TRUNK	ge-0/0/18	exSCALE-SLOW,exSCALE-FAST,exSpeaker,exInfra, \
-    		exAVLAN,exStaff, \
+			exAVLAN,exStaff, vendor_backbone \
 			exSigns,exDWCC,HAM_BRIDGE // 
 TRUNK	ge-0/0/19	exSCALE-SLOW,exSCALE-FAST,exSpeaker,exInfra, \
-    		exAVLAN,exStaff, \
+			exAVLAN,exStaff, vendor_backbone \
 			exSigns,exDWCC,HAM_BRIDGE // 
 TRUNK	ge-0/0/20	exSCALE-SLOW,exSCALE-FAST,exSpeaker,exInfra, \
-    		exAVLAN,exStaff, \
+			exAVLAN,exStaff, vendor_backbone \
 			exSigns,exDWCC,HAM_BRIDGE // 
 TRUNK	ge-0/0/21	exSCALE-SLOW,exSCALE-FAST,exSpeaker,exInfra, \
-    		exAVLAN,exStaff, \
+			exAVLAN,exStaff, vendor_backbone \
 			exSigns,exDWCC,HAM_BRIDGE // 
 TRUNK	ge-0/0/22	exSCALE-SLOW,exSCALE-FAST,exSpeaker,exInfra, \
-    		exAVLAN,exStaff, \
+			exAVLAN,exStaff, vendor_backbone \
 			exSigns,exDWCC,HAM_BRIDGE // 
 TRUNK	ge-0/0/23	exSCALE-SLOW,exSCALE-FAST,exSpeaker,exInfra, \
-    		exAVLAN,exStaff, \
+			exAVLAN,exStaff, vendor_backbone \
 			exSigns,exDWCC,HAM_BRIDGE // 
 TRUNK	ge-0/0/24	exSCALE-SLOW,exSCALE-FAST,exSpeaker,exInfra, \
-    		exAVLAN,exStaff, \
+			exAVLAN,exStaff, vendor_backbone \
 			exSigns,exDWCC,HAM_BRIDGE // 
 TRUNK	ge-0/0/25	exSCALE-SLOW,exSCALE-FAST,exSpeaker,exInfra, \
-    		exAVLAN,exStaff, \
+			exAVLAN,exStaff, vendor_backbone \
 			exSigns,exDWCC,HAM_BRIDGE // 
 TRUNK	ge-0/0/26	exSCALE-SLOW,exSCALE-FAST,exSpeaker,exInfra, \
-    		exAVLAN,exStaff, \
+			exAVLAN,exStaff, vendor_backbone \
 			exSigns,exDWCC,HAM_BRIDGE // 
 TRUNK	ge-0/0/27	exSCALE-SLOW,exSCALE-FAST,exSpeaker,exInfra, \
-    		exAVLAN,exStaff, \
+			exAVLAN,exStaff, vendor_backbone \
 			exSigns,exDWCC,HAM_BRIDGE // 
 TRUNK	ge-0/0/28	exSCALE-SLOW,exSCALE-FAST,exSpeaker,exInfra, \
-    		exAVLAN,exStaff, \
+			exAVLAN,exStaff, vendor_backbone \
 			exSigns,exDWCC,HAM_BRIDGE // 
 TRUNK	ge-0/0/29	exSCALE-SLOW,exSCALE-FAST,exSpeaker,exInfra, \
-    		exAVLAN,exStaff, \
+			exAVLAN,exStaff, vendor_backbone \
 			exSigns,exDWCC,HAM_BRIDGE // 

--- a/switch-configuration/config/vlans.d/Expo
+++ b/switch-configuration/config/vlans.d/Expo
@@ -16,5 +16,5 @@ VLAN	exAkamai		111	2001:470:f325:111::/64	0.0.0.0/0	Special public Akamai Cache 
 //200-498 are dynamically generated from Booth information file as Vendor VLANs.
 //The difference is that these VLAN interfaces will also be built with firewall filters to prevent access to other
 //VLANs (vendor_vlan <-> internet only)
-VVRNG	ex_v_			200-498	2001:470:f325:200::/55	10.1.0.0/16	Dynamically allocated and named booth VLANs
+VVRNG	ex_v_			200-498	2001:470:f325:200::/54	10.2.0.0/15	Dynamically allocated and named booth VLANs
 //499 is reserved for the Vendor backbone VLAN between the Expo switches and the routers.


### PR DESCRIPTION
## Description of PR
Resolves issue #153 

## Previous Behavior
vv_get_prefix4 and vv_get_prefix6 had flawed bounds checking
Changed prefixes in VVRNG to support required number of VLANs and pass working bounds check

## New Behavior
Bounds checking works.

## Tests
Test runs fo script with different VVRNG parameters to force failures and success behaved appropriately.
