### PR TITLE
Showtime DNS, server names

### DIFF
--- a/ansible/Vagrantfile
+++ b/ansible/Vagrantfile
@@ -72,3 +72,4 @@ Vagrant.configure(2) do |configure|
     end
   end
 end
+

--- a/ansible/etc/ansible/roles/dnsserver/templates/db.scale.lan.records.servers.j2
+++ b/ansible/etc/ansible/roles/dnsserver/templates/db.scale.lan.records.servers.j2
@@ -11,7 +11,6 @@ ns      IN  A    {{ hostvars[item].ipv4 }}
 
 {% for item in groups["monitoring"] %}
 zabbix  IN  CNAME   {{ hostvars[item].fqdn }}.
-monitor  IN  CNAME   {{ hostvars[item].fqdn }}.
 bigbrother  IN  CNAME   {{ hostvars[item].fqdn }}.
 loghost     IN  CNAME   {{ hostvars[item].fqdn }}.
 {% endfor -%}

--- a/facts/servers/serverlist.tsv
+++ b/facts/servers/serverlist.tsv
@@ -6,13 +6,15 @@
 // automation - ansible, signs
 //
 //name	mac-address	ipv6	ipv4	ansible-role
-server1	4c:72:b9:7c:41:17
-server2	4c:72:b9:7c:40:ec	2001:470:f325:103::5	10.0.3.5	core
-server3	4c:72:b9:7c:44:88	2001:470:f325:503::6	10.128.3.6	monitoring
+server1	4c:72:b9:7c:41:17	2001:470:f325:503::5	10.128.3.5	core
+server2	4c:72:b9:7c:40:ec
+server3	4c:72:b9:7c:44:88
 server4	4c:72:b9:7c:43:27
-server5	4c:72:b9:7c:41:d6	2001:470:f325:503::5	10.128.3.5	core
+server5	4c:72:b9:7c:41:d6
 server6	4c:72:b9:7c:42:12
-server7	4c:72:b9:7c:3a:f9
+server7	4c:72:b9:7c:3a:f9	2001:470:f325:103::5	10.0.3.5	core
 server8	4c:72:b9:7c:42:21	2001:470:f325:503::7	10.128.3.7	automation
 server9	4c:72:b9:7c:3e:1d
 server10	4c:72:b9:7c:3f:bc
+monitor	00:25:90:34:d2:14	2001:470:f325:503::6	10.128.3.6	monitoring
+// 00:25:90:34:d2:15

--- a/openwrt/flash
+++ b/openwrt/flash
@@ -13,7 +13,7 @@ spawn /usr/sbin/arp -n 192.168.1.1
 expect -re "192.168.1.1 *ether *(\[^ \]*) "
 set mac $expect_out(1,string)
 set file [open aplist a]
-puts $file "$ap,$mac"
+puts $file "$ap,$mac,"
 close $file
 spawn tftp 192.168.1.1
 expect tftp


### PR DESCRIPTION
## Description of PR
Quick PR to cover the server names for this year, slightly update openwrt script for DL, and resolve DNS issue when a box is named monitor

## Previous Behavior
Last year's server names, openwrt script didn't pause after $ap,$mac, monitor was an alias to a box name.

## New Behavior
This year's server names, openwrt script now pauses per DL request, monitor is now a server name and not a CNAME

## Tests
Doin it live!
