### PR TITLE
[READY] Adding expohall diagram link for 17x

### DIFF
--- a/MAPS.md
+++ b/MAPS.md
@@ -1,6 +1,6 @@
 # Maps
 
-Maps of the layout for SCaLE 16x at Pasadena Convention Center maps can be found:
+Maps of the layout for SCaLE 16x/17x at Pasadena Convention Center maps can be found:
 
 * [cbll-diagram-1](http://sarcasticadmin.com/scale/maps/16x/cbll-diagram-1-scale.pdf)
 * [cbul-diagram-2](http://sarcasticadmin.com/scale/maps/16x/cbul-diagram-2-scale.pdf)
@@ -8,6 +8,7 @@ Maps of the layout for SCaLE 16x at Pasadena Convention Center maps can be found
 * [ballroom-diagram-4](http://sarcasticadmin.com/scale/maps/16x/ballroom-diagram-4-scale.pdf)
 * [ballroom-diagram-5](http://sarcasticadmin.com/scale/maps/16x/ballroom-diagram-5-scale.pdf)
 * [ballroom-diagram-6](http://sarcasticadmin.com/scale/maps/16x/ballroom-diagram-6-scale.pdf)
+* [expohall-diagram-1](http://sarcasticadmin.com/scale/maps/17x/expohall-diagram-1-scale.pdf)
 
 ## Updates
 


### PR DESCRIPTION
## Description of PR
We were missing the diagram for 17x expohall, fulfills #179 

## Previous Behavior
No expohall diagram

## New Behavior
Now have the expohall diagram link added to `MAPS.md`

## Tests
How was this PR tested? NA
