### PR TITLE
Issues #150, #164, #165, #184, #186

### DIFF
--- a/switch-configuration/config/scripts/build_switch_configs.pl
+++ b/switch-configuration/config/scripts/build_switch_configs.pl
@@ -5,7 +5,7 @@
 #
 require "./scripts/switch_template.pl";   # Pull in configuration library
 set_debug_level(5);
-my $switchlist = get_switchlist();
+my $switchlist = "";
 my $switch;
 
 if(scalar(@ARGV)) # One or more switch names specified
@@ -16,6 +16,7 @@ else
 {
     ##FIXME## Probably should evaluate switch list and remove any entries
     ##FIXME## that no longer exist from output directory.
+    $switchlist = get_switchlist();
     my @outputs = ();
     my $file;
     if (scalar(@ARGV))
@@ -67,20 +68,21 @@ foreach(@{$VL_CONFIG})
 }
 
  
+# Pull in private configuration objects (not stored in repo)
+open(PASSWD, "< ../../facts/secrets/jroot_pw") ||
+    die "Couldnt find root PW: $!\n";
+my $rootpw = <PASSWD> || die "Couldn't read root PW: $!\n";
+chomp $rootpw;
+close PASSWD;
 
-
+# Iterate through list of switches and build each configuration file
 foreach $switch (@{$switchlist})
 {
     debug(2, "Building $switch\n");
-    open(PASSWD, "< ../../facts/secrets/jroot_pw") ||
-    	die "Couldnt find root PW: $!\n";
-    my $rootpw = <PASSWD> || die "Couldn't read root PW: $!\n";
-    chomp $rootpw;
-    close PASSWD;
     my $cf = build_config_from_template($switch,$rootpw);
     if ( ! -d "output")
     {
-	mkdir "output";
+        mkdir "output";
     }
     if ( ! -d "output" || ! -w "output" || ! -x "output" )
     {

--- a/switch-configuration/config/switchtypes
+++ b/switch-configuration/config/switchtypes
@@ -10,7 +10,7 @@ ExpoIDF		6	103	2001:470:f325:103::200:6	exIDF			// Loud
 BallroomF	7	103	2001:470:f325:103::200:7	exRoom			// Normal
 Rm103		8	503	2001:470:f325:503::200:8	cfRoom			// Quiet
 BallroomG	9	103	2001:470:f325:103::200:9	exRoom			// Normal
-ConfIDF		10	103	2001:470:f325:503::200:10	cfIDF			// Loud
+ConfIDF		10	503	2001:470:f325:503::200:10	cfIDF			// Loud
 BallroomH	11	103	2001:470:f325:103::200:11	exRoom			// Normal
 BallroomA	12	103	2001:470:f325:103::200:12	exRoom			// Normal
 BallroomB	13	103	2001:470:f325:103::200:13	exRoom			// Normal

--- a/switch-configuration/config/types/Catwalk
+++ b/switch-configuration/config/types/Catwalk
@@ -3,13 +3,13 @@ TRUNK	ge-0/0/0	exSCALE-SLOW,exSCALE-FAST,exSpeaker,exInfra, \
 			exAVLAN,exStaff, vendor_backbone \
 			exSigns,HAM_BRIDGE // Link to EX Router
 TRUNK	ge-0/0/1	exSCALE-SLOW,exSCALE-FAST,exSpeaker,exInfra, \
-			exAVLAN,exStaff, \
+			exAVLAN,exStaff, vendor_backbone\
 			exSigns,HAM_BRIDGE // Downlink to BallroomF
 TRUNK	ge-0/0/2	exSCALE-SLOW,exSCALE-FAST,exSpeaker,exInfra, \
-			exAVLAN,exStaff, \
+			exAVLAN,exStaff, vendor_backbone\
 			exSigns,HAM_BRIDGE // Downlink to BallroomG
 TRUNK	ge-0/0/3	exSCALE-SLOW,exSCALE-FAST,exSpeaker,exInfra, \
-			exAVLAN,exStaff, \
+			exAVLAN,exStaff, vendor_backbone\
 			exSigns,HAM_BRIDGE // Downlink to BallroomH
 TRUNK	ge-0/0/4	exSCALE-SLOW,exSCALE-FAST,exSpeaker,exInfra, \
 			exAVLAN,exStaff, vendor_backbone \

--- a/switch-configuration/config/vlans.d/Expo
+++ b/switch-configuration/config/vlans.d/Expo
@@ -1,20 +1,20 @@
 // Expo Center -- VLANS 100-499
 VLAN	exSCALE-SLOW		100	2001:470:f325:100::/64	10.0.128.0/21	2.4G Wireless Network in Expo Center
 VLAN	exSCALE-FAST		101	2001:470:f325:101::/64	10.0.136.0/21	5G Wireless Network in Expo Center
-VLAN	exSpeaker		102	2001:470:f325:102::/64	10.0.2.0/24	Speaker Network
-VLAN	exInfra			103	2001:470:f325:103::/64	10.0.3.0/24	SCALE Network Infrastructure and Servers (Expo Center)
-VLAN	exMDF			104	2001:470:f325:104::/64	10.0.4.0/24	Link to MDF Router
-VLAN	exAVLAN			105	2001:470:f325:105::/64	10.0.5.0/24	Audio Visual Network (DHCP Helper to AV server)
+VLAN	exSpeaker			102	2001:470:f325:102::/64	10.0.2.0/24	Speaker Network
+VLAN	exInfra				103	2001:470:f325:103::/64	10.0.3.0/24	SCALE Network Infrastructure and Servers (Expo Center)
+VLAN	exMDF				104	2001:470:f325:104::/64	10.0.4.0/24	Link to MDF Router
+VLAN	exAVLAN				105	2001:470:f325:105::/64	10.0.5.0/24	Audio Visual Network (DHCP Helper to AV server)
 //106 not used
-VLAN	exSigns			107	2001:470:f325:107::/64	0.0.0.0/0	Signs network (Expo Center) IPv6 Only
-VLAN	exStaff			108	2001:470:f325:108::/64	10.0.8.0/24	Staff Wireless Network
+VLAN	exSigns				107	2001:470:f325:107::/64	0.0.0.0/0	Signs network (Expo Center) IPv6 Only
+VLAN	exStaff				108	2001:470:f325:108::/64	10.0.8.0/24	Staff Wireless Network
 //109 not used
-VLAN	exRegistration	110	2001:470:f325:110::/64	10.0.10.0/24	Registration Network (Expo Center) IPv6 Only
-VLAN	exAkamai		111	2001:470:f325:111::/64	0.0.0.0/0	Special public Akamai Cache Cluster network (has IPv4 from convention center)
+VLAN	exRegistration  	110	2001:470:f325:110::/64	10.0.10.0/24	Registration Network (Expo Center) IPv6 Only
+VLAN	exAkamai			111	2001:470:f325:111::/64	0.0.0.0/0	Special public Akamai Cache Cluster network (has IPv4 from convention center)
 //112 through 199 not used
 //200 through 499 Vendors
 //200-498 are dynamically generated from Booth information file as Vendor VLANs.
 //The difference is that these VLAN interfaces will also be built with firewall filters to prevent access to other
 //VLANs (vendor_vlan <-> internet only)
-VVRNG	ex_v_			200-498	2001:470:f325:200::/54	10.2.0.0/15	Dynamically allocated and named booth VLANs
+VVRNG	vendor_vlan_		200-498	2001:470:f325:200::/54	10.2.0.0/15	Dynamically allocated and named booth VLANs
 //499 is reserved for the Vendor backbone VLAN between the Expo switches and the routers.


### PR DESCRIPTION
build_switch_configs.pl
    Improve list building logic     #186

switch_template.pl
    Add consistency check for MgtVL and IPv6Addr #184

    Add OSPF configuration for Expo Switches #165

    Extract Vendor VLAN name prefix from configuration file #150

    Improved logic for get_switchtypes #186

switchtypes
    Correct Management VLAN on ConfIDF switch #184

types/Catwalk
    Add vendor_backbone to ports ge-0/0/[1-3] #164

vlans.d/Expo
    Formatting improvements 
    Correct vendor_vlan name prefix (was ex_v_ now vendor_vlan_) #150
