### PR TITLE
Issue #216 plus some cleanup

### DIFF
--- a/switch-configuration/config/switchtypes
+++ b/switch-configuration/config/switchtypes
@@ -23,7 +23,7 @@ AVSwitch	14	503	2001:470:f325:503::200:14	cfAV			//	F.9		Normal
 Party		15	103	2001:470:f325:103::200:15	Party			//	X.9		Loud
 Expo-Catwalk	16	103	2001:470:f325:103::200:16	Catwalk			//	W.1		Loud
 Rm209-210	17	503	2001:470:f325:503::200:17	cfRoom			//	I.9		Normal
-ExpoA1		18	103	2001:470:f325:103::200:38	Booth			//	W.9		Loud
+ExpoA1		18	103	2001:470:f325:103::200:18	Booth			//	W.9		Loud
 Rm211		19	503	2001:470:f325:503::200:19	cfRoom			//	I.9		Normal
 Rm104		20	503	2001:470:f325:503::200:20	cfRoom			//	I.9		Quiet
 NOC		21	503	2001:470:f325:503::200:21	cfIDF			//	I.2		Normal


### PR DESCRIPTION

## Description of PR
Added v6 router-advertisements for vendor prefixes
Improved internal documentation
Fixed IPv4 Default gateway variable name typos (defagw->defgw)
Cleaned up some erroneous indentation

## Previous Behavior
IPV4 default gateway didn't make it into configuration (not fatal due to OSPF)
No IPv6 RAs for vendor VLANs

## New Behavior
Default gateway is configured (static)
IPv6 RAs are configured for vendor VLANs

## Tests
Testing -- Novel concept.
