### PR TITLE
[READY]: Initial openwrt build docker container and weekly builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,35 +26,53 @@ jobs:
         name: openwrt ipq806x golden file test
         command: sh -x test.sh -t ipq806x
 
-  # TODO: Figure out when to do end-to-end build test
-  # builds take a long time and should be done
-  # outside of initial ci testing
-  #openwrt_test_build:
-  #  docker:
-  #  - image: debian:jessie-20190204
-  #  resource_class: medium
-  #  working_directory: ~/scale-network/openwrt
-  #  steps:
-  #  - checkout:
-  #      path: ~/scale-network
-  #
-  #  - run:
-  #      name: install Image Builder Deps
-  #      command: apt-get update && apt-get install -y curl file build-essential libncurses5-dev
-  #        zlib1g-dev gawk git gettext libssl-dev xsltproc wget unzip python
-  #
-  #  - run:
-  #      name: download gomplate
-  #      command: wget -o /usr/local/bin/gomplate https://github.com/hairyhenderson/gomplate/releases/download/v3.2.0/gomplate_linux-amd64
-  #        && chmod +x /usr/local/bin/gomplate
-  #
-  #  - run:
-  #      name: rename default facts
-  #      command: cp ../facts/secrets/openwrt-example.yaml ../facts/secrets/openwrt.yaml
-  #
-  #  - run:
-  #      name: build openwrt image
-  #      command: make build-img
+  # This build takes a long time and should be done
+  # outside of initial PR CI testing
+  openwrt_build_ar71xx:
+    docker:
+      - image: sarcasticadmin/openwrt-build@sha256:e744706323d34bd51f8abc0a9d0413c4a53817c09b6ab50666acafe66eaefb38
+    resource_class: medium
+    working_directory: ~/scale-network/openwrt
+    steps:
+      - checkout:
+          path: ~/scale-network
+
+      - run:
+          name: build openwrt image
+          command: TARGET=ar71xx make templates build-img
+
+      - run:
+          name: copy ar71xx artifacts
+          command: |
+              mkdir -p /tmp/ar71xx
+              cp /home/openwrt/scale-network/openwrt/build/source-ar71xx-*/bin/targets/ar71xx/generic/*factory.img /tmp/ar71xx
+              cp /home/openwrt/scale-network/openwrt/build/source-ar71xx-*/bin/targets/ar71xx/generic/sha256sums /tmp/ar71xx
+
+      - store_artifacts:
+          path: /tmp/ar71xx
+
+  openwrt_build_ipq806x:
+    docker:
+      - image: sarcasticadmin/openwrt-build@sha256:e744706323d34bd51f8abc0a9d0413c4a53817c09b6ab50666acafe66eaefb38
+    resource_class: medium
+    working_directory: ~/scale-network/openwrt
+    steps:
+      - checkout:
+          path: ~/scale-network
+
+      - run:
+          name: build openwrt image
+          command: TARGET=ipq806x make templates build-img
+
+      - run:
+          name: copy ipq806x artifacts
+          command: |
+              mkdir -p /tmp/ipq806x
+              cp /home/openwrt/scale-network/openwrt/build/source-ipq806x-*/bin/targets/ipq806x/generic/*factory.bin /tmp/ipq806x
+              cp /home/openwrt/scale-network/openwrt/build/source-ipq806x-*/bin/targets/ipq806x/generic/sha256sums /tmp/ipq806x
+
+      - store_artifacts:
+          path: /tmp/ipq806x
 
   ansible_lint:
     docker:
@@ -112,8 +130,19 @@ jobs:
 
 workflows:
   version: 2
-  build_all:
+  test_all:
     jobs:
-    - gomplate_tests
-    - ansible_lint
-    - perl_lint
+      - gomplate_tests
+      - ansible_lint
+      - perl_lint
+  weekly:
+    triggers:
+      - schedule:
+          cron: "15 3 * * 0"
+          filters:
+            branches:
+              only:
+                - master
+    jobs:
+      - openwrt_build_ar71xx
+      - openwrt_build_ipq806x

--- a/openwrt/Dockerfile
+++ b/openwrt/Dockerfile
@@ -1,0 +1,16 @@
+FROM hairyhenderson/gomplate:v3.2.0-slim AS gomplate
+FROM ubuntu:16.04 as build
+
+RUN apt-get update &&\
+    apt-get install -y sudo time git-core subversion build-essential gcc-multilib \
+                       libncurses5-dev zlib1g-dev gawk flex gettext wget unzip \
+                       curl python &&\
+    apt-get clean
+
+COPY --from=gomplate /gomplate /bin/gomplate
+
+RUN useradd -m openwrt &&\
+    echo 'openwrt ALL=NOPASSWD: ALL' > /etc/sudoers.d/openwrt
+
+USER openwrt
+WORKDIR /home/openwrt

--- a/openwrt/Makefile
+++ b/openwrt/Makefile
@@ -3,6 +3,8 @@
 # Assumes all dependency tools are already installed
 #
 
+include include/*.mk
+
 # Export all variables by default
 .EXPORT_ALL_VARIABLES:
 

--- a/openwrt/README.md
+++ b/openwrt/README.md
@@ -12,6 +12,25 @@ If you are building images with templates you'll also need:
 * [gomplate](../README.md#requirements)
 
 ## Build
+
+### Docker
+
+You can build these images inside a docker container. This makes it easy to has a consistent build environment
+for all members of the tech team.
+
+To start building:
+
+```
+docker pull sarcasticadmin/openwrt-build:528bc79
+# Make sure to mount the git root inside this container
+docker run -v $(git rev-parse --show-toplevel):/home/openwrt/scale-network --rm -it sarcasticadmin/openwrt-build:528bc79 /bin/bash
+cd /home/openwrt/scale-network
+```
+> There is no latest tag so make sure to specify the version (short commit hash)
+> The docker mount only works in linux, on OSX you'll get: "Build dependency: OpenWrt can only be built on a case-sensitive filesystem"
+
+Then continue onto whichever image you'd like to build.
+
 ### Stock Image
 
 Currently we support Netgear `3700v2`, `3800`, & `3800ch` images.

--- a/openwrt/include/docker.mk
+++ b/openwrt/include/docker.mk
@@ -1,0 +1,14 @@
+# Docker parameters
+DOCKERCMD = docker
+# TODO: dockerhub for scale eventually
+DOCKERREPO = sarcasticadmin
+IMAGENAME ?= openwrt-build
+DOCKERBUILD = $(DOCKERCMD) build
+
+DOCKERVERSION ?= $(shell git rev-parse --short HEAD)
+
+docker-build:
+	$(DOCKERBUILD) -t "$(DOCKERREPO)/$(IMAGENAME):$(DOCKERVERSION)" .
+
+docker-push: build
+	$(DOCKERCMD) push "$(DOCKERREPO)/$(IMAGENAME):$(DOCKERVERSION)"


### PR DESCRIPTION
## Description of PR
Fixes: #253 

Adding a openwrt build environment via docker container and circleci weekly build process

## Previous Behavior
* No consistent build environment

## New Behavior
* openwrt build container
* circle ci weekly image build process

## Tests
Example of `make docker-build`:
```
$ make docker-build
docker build -t "sarcasticadmin/openwrt-build:fe4f471" .
Sending build context to Docker daemon  144.9MB
Step 1/7 : FROM hairyhenderson/gomplate:v3.2.0-slim AS gomplate
 ---> 16ac0ad06c9a
Step 2/7 : FROM ubuntu:16.04 as build
 ---> 7e87e2b3bf7a
Step 3/7 : RUN apt-get update &&    apt-get install -y sudo time git-core subversion build-essential gcc-multilib                        libncurses5-dev zlib1g-dev gawk flex gettext wget unzip                        curl python &&    apt-get clean
 ---> Using cache
 ---> f47b7beb930a
Step 4/7 : COPY --from=gomplate /gomplate /bin/gomplate
 ---> Using cache
 ---> 28328913107e
Step 5/7 : RUN useradd -m openwrt &&    echo 'openwrt ALL=NOPASSWD: ALL' > /etc/sudoers.d/openwrt
 ---> Using cache
 ---> 736b136bc81f
Step 6/7 : USER openwrt
 ---> Using cache
 ---> 9c45f9998815
Step 7/7 : WORKDIR /home/openwrt
 ---> Using cache
 ---> 4b37fa2fbc65
Successfully built 4b37fa2fbc65
Successfully tagged sarcasticadmin/openwrt-build:fe4f471
```

Initially tested the artifact builds on this PR, see the successful builds here:
* ar71xx: https://circleci.com/gh/socallinuxexpo/scale-network/546
* ipq806x: https://circleci.com/gh/socallinuxexpo/scale-network/542