### PR TITLE
[READY]: Adding build identifiers to openwrt

### DIFF
--- a/openwrt/Makefile
+++ b/openwrt/Makefile
@@ -70,7 +70,11 @@ targetconfig: diffconfig
 config: $(BUILD_DIR)/$(IMAGEBUILDER)/.config
 
 build-img: $(BUILD_DIR)/$(IMAGEBUILDER)/.config
-	@cd $(BUILD_DIR)/$(IMAGEBUILDER) && $(MAKE) download && $(MAKE) V=s -j 4
+	@cd $(BUILD_DIR)/$(IMAGEBUILDER) \
+	  && echo SCALE_VER=$(shell git rev-parse HEAD) > $(TMPL_SRC_DIR)/etc/scale-release \
+	  && echo OPENWRT_VER=$(OPENWRT_VER) >> $(TMPL_SRC_DIR)/etc/scale-release \
+	  && $(MAKE) download \
+	  && $(MAKE) V=s -j 4
 
 $(BUILD_DIR):
 	mkdir -p $(BUILD_DIR)

--- a/tests/serverspec/spec/shared/openwrt/init.rb
+++ b/tests/serverspec/spec/shared/openwrt/init.rb
@@ -51,8 +51,26 @@ RSpec.shared_examples "openwrt" do
     its(:exit_status) { should eq 0 }
   end
 
-  # Look for config that doesnt exist 
+  # Look for config that doesnt exist
   describe command('/root/bin/config-version.sh -c 9999') do
+    its(:exit_status) { should eq 1 }
+  end
+
+  describe file('/etc/scale-release') do
+      it { should exist }
+      it { should be_mode 644 }
+      it { should be_owned_by 'root' }
+      it { should be_grouped_into 'root' }
+  end
+
+  # Make sure vars is not unset or empty
+  # :pre_command doesnt work here since mutliple shell instances cant be used
+  describe command("source /etc/scale-release && test -z $SCALE_VER") do
+    its(:exit_status) { should eq 1 }
+  end
+
+  # Make sure var is not unset or empty
+  describe command("source /etc/scale-release && test -z $OPENWRT_VER") do
     its(:exit_status) { should eq 1 }
   end
 


### PR DESCRIPTION
## Description of PR
Fixes #251 

~~Adding build identifiers for both template generation and the actual build generation since they could vary if template info isnt necessarily updated but the openwrt build is.~~

~~@kylerisse would you mind checking this out? What are your thoughts on the naming for the `*.info` files? Do you think we should make it more obvious that this is a `SCaLE` file? I know you had some suggestions when we last talked about it but I couldnt remember the details, open to any suggestions here.~~

FYI, Im including the following in the `/etc/scale-release`:

```
- git SHA from this repo
- git SHA of openwrt
```
## Update

I opted to contain the build info into a single file: `/etc/scale-release` to align with the existing `/etc/openwrt-release` file which is included with the openwrt project. The templates typically arent something I think we need to worry about and the current condition that you could build the templates out of band of the rest of the build needs to be fixed in the `Makefile` but for now its a know limitation.

## Previous Behavior
* No build IDs existed, causing confusion on version of build

## New Behavior
* `/etc/scale-release`
* Added necessary serverspec to ensure files always get laid down

## Tests
* CI passes
* [TBD] Serverspec checks out on actual hardware (Netgear 3800CH)