### PR TITLE
[READY] issue-182 - Adding WPS LED build identifier

### DIFF
--- a/facts/secrets/ar71xx-openwrt-example.yaml
+++ b/facts/secrets/ar71xx-openwrt-example.yaml
@@ -14,6 +14,9 @@ zabbix:
 
 nameserver: '8.8.8.8'
 
+ntp:
+  server: '0.openwrt.pool.ntp.org'
+
 apinger:
   endpoint: '8.8.8.8'
 

--- a/facts/secrets/ar71xx-openwrt-example.yaml
+++ b/facts/secrets/ar71xx-openwrt-example.yaml
@@ -1,6 +1,9 @@
 # scale
 root_hash: "$1$zh0PjBbB$f9aFGDX9vNYNdSRexhib8/"
 
+# Bump for each year for scale
+scale: 18
+
 rsyslog:
   server: 'server2.scale.lan'
   port: '514'

--- a/facts/secrets/ipq806x-openwrt-example.yaml
+++ b/facts/secrets/ipq806x-openwrt-example.yaml
@@ -14,6 +14,9 @@ zabbix:
 
 nameserver: '8.8.8.8'
 
+ntp:
+  server: '0.openwrt.pool.ntp.org'
+
 apinger:
   endpoint: '8.8.8.8'
 

--- a/facts/secrets/ipq806x-openwrt-example.yaml
+++ b/facts/secrets/ipq806x-openwrt-example.yaml
@@ -1,6 +1,9 @@
 # scale
 root_hash: "$1$zh0PjBbB$f9aFGDX9vNYNdSRexhib8/"
 
+# Bump for each year for scale
+scale: 18
+
 rsyslog:
   server: 'server2.scale.lan'
   port: '514'

--- a/facts/secrets/openwrt-example.yaml
+++ b/facts/secrets/openwrt-example.yaml
@@ -1,6 +1,9 @@
 # scale
 root_hash: "$1$zh0PjBbB$f9aFGDX9vNYNdSRexhib8/"
 
+# Bump for each year for scale
+scale: 18
+
 rsyslog:
   server: 'server2.scale.lan'
   port: '514'

--- a/openwrt/README.md
+++ b/openwrt/README.md
@@ -170,6 +170,12 @@ ssh root@<AP IP>
 cat /etc/os-release
 ```
 # Notes
+## Identity
+
+Depending on the SCaLE conference number, the WPS LED will be green for even years and off
+for odd years.
+> NOTE: This depends on the SCaLE conference number not the year since the build
+> would drift based on when it was built.
 
 ## Files
 ### SSH

--- a/openwrt/files/etc/config/system
+++ b/openwrt/files/etc/config/system
@@ -8,10 +8,7 @@ config system
 config timeserver 'ntp'
         option enabled '1'
         option enable_server '0'
-        list server '0.openwrt.pool.ntp.org'
-        list server '1.openwrt.pool.ntp.org'
-        list server '2.openwrt.pool.ntp.org'
-        list server '3.openwrt.pool.ntp.org'
+        list server '{{ (datasource "openwrt").ntp.server }}'
 
 {{ if (eq (env.Getenv "TARGET") "ar71xx") }}
 config led 'led_wan'

--- a/openwrt/files/etc/config/system
+++ b/openwrt/files/etc/config/system
@@ -1,0 +1,64 @@
+config system
+        option hostname 'OpenWrt'
+        option timezone 'UTC'
+        option ttylogin '0'
+        option log_size '64'
+        option urandom_seed '0'
+
+config timeserver 'ntp'
+        option enabled '1'
+        option enable_server '0'
+        list server '0.openwrt.pool.ntp.org'
+        list server '1.openwrt.pool.ntp.org'
+        list server '2.openwrt.pool.ntp.org'
+        list server '3.openwrt.pool.ntp.org'
+
+{{ if (eq (env.Getenv "TARGET") "ar71xx") }}
+config led 'led_wan'
+        option name 'WAN LED (green)'
+        option sysfs 'netgear:green:wan'
+        option default '0'
+
+config led 'led_usb'
+        option name 'USB'
+        option sysfs 'netgear:green:usb'
+        option trigger 'usbdev'
+        option interval '50'
+        option dev '1-1'
+
+config led 'led_wps'
+        option name 'WPS for build ID'
+	option 'sysfs' 'netgear:green:wps'
+        option default '{{if math.Rem ((datasource "openwrt").scale) 2 }}0{{else}}1{{end}}'
+{{ else if (eq (env.Getenv "TARGET") "ipq806x") }}
+config led 'led_usb1'
+        option name 'USB 1'
+        option sysfs 'c2600:white:usb_2'
+        option trigger 'usbport'
+        list port 'usb1-port1'
+        list port 'usb2-port1'
+
+config led 'led_usb2'
+        option name 'USB 2'
+        option sysfs 'c2600:white:usb_4'
+        option trigger 'usbport'
+        list port 'usb3-port1'
+        list port 'usb4-port1'
+
+config led 'led_wan'
+        option name 'wan'
+        option sysfs 'c2600:white:wan'
+        option trigger 'switch0'
+        option port_mask '0x20'
+
+config led 'led_lan'
+        option name 'lan'
+        option sysfs 'c2600:white:lan'
+        option trigger 'switch0'
+        option port_mask '0x1e'
+
+config led 'led_wps'
+        option name 'WPS for build ID'
+        option sysfs 'c2600:white:wps'
+        option default '{{if math.Rem ((datasource "openwrt").scale) 2 }}0{{else}}1{{end}}'
+{{ end }}

--- a/openwrt/include/tests.mk
+++ b/openwrt/include/tests.mk
@@ -1,0 +1,12 @@
+REPO_ROOT := $(shell git rev-parse --show-toplevel)
+
+golden-test:
+	@cd $(REPO_ROOT)/tests/unit/openwrt && \
+	    sh test.sh -t ar71xx && \
+	    sh test.sh -t ipq806x
+
+
+golden-update:
+	@cd $(REPO_ROOT)/tests/unit/openwrt && \
+	    sh test.sh -u -t ar71xx && \
+	    sh test.sh -u -t ipq806x

--- a/tests/serverspec/spec/openwrt_show/init_spec.rb
+++ b/tests/serverspec/spec/openwrt_show/init_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 #require_relative '../shared/openwrt/init.rb'
 require_relative '../shared/openwrt/init.rb'
 
-RESOLVABLE=["loghost.scale.lan", "zabbix.scale.lan", "google.com"]
+RESOLVABLE=["ntp.scale.lan", "loghost.scale.lan", "zabbix.scale.lan", "google.com"]
 
 describe "shared" do
   include_examples "openwrt"

--- a/tests/unit/openwrt/golden/ar71xx/etc/config/system
+++ b/tests/unit/openwrt/golden/ar71xx/etc/config/system
@@ -1,0 +1,30 @@
+config system
+        option hostname 'OpenWrt'
+        option timezone 'UTC'
+        option ttylogin '0'
+        option log_size '64'
+        option urandom_seed '0'
+
+config timeserver 'ntp'
+        option enabled '1'
+        option enable_server '0'
+        list server '0.openwrt.pool.ntp.org'
+
+
+config led 'led_wan'
+        option name 'WAN LED (green)'
+        option sysfs 'netgear:green:wan'
+        option default '0'
+
+config led 'led_usb'
+        option name 'USB'
+        option sysfs 'netgear:green:usb'
+        option trigger 'usbdev'
+        option interval '50'
+        option dev '1-1'
+
+config led 'led_wps'
+        option name 'WPS for build ID'
+	option 'sysfs' 'netgear:green:wps'
+        option default '1'
+

--- a/tests/unit/openwrt/golden/ipq806x/etc/config/system
+++ b/tests/unit/openwrt/golden/ipq806x/etc/config/system
@@ -1,0 +1,44 @@
+config system
+        option hostname 'OpenWrt'
+        option timezone 'UTC'
+        option ttylogin '0'
+        option log_size '64'
+        option urandom_seed '0'
+
+config timeserver 'ntp'
+        option enabled '1'
+        option enable_server '0'
+        list server '0.openwrt.pool.ntp.org'
+
+
+config led 'led_usb1'
+        option name 'USB 1'
+        option sysfs 'c2600:white:usb_2'
+        option trigger 'usbport'
+        list port 'usb1-port1'
+        list port 'usb2-port1'
+
+config led 'led_usb2'
+        option name 'USB 2'
+        option sysfs 'c2600:white:usb_4'
+        option trigger 'usbport'
+        list port 'usb3-port1'
+        list port 'usb4-port1'
+
+config led 'led_wan'
+        option name 'wan'
+        option sysfs 'c2600:white:wan'
+        option trigger 'switch0'
+        option port_mask '0x20'
+
+config led 'led_lan'
+        option name 'lan'
+        option sysfs 'c2600:white:lan'
+        option trigger 'switch0'
+        option port_mask '0x1e'
+
+config led 'led_wps'
+        option name 'WPS for build ID'
+        option sysfs 'c2600:white:wps'
+        option default '1'
+


### PR DESCRIPTION
## Description of PR
Fixes: #182 

This allows us to be able to have a visual cue about whether or not the image was flashed correctly. 
 
## Previous Behavior
* WPS LED was always off

## New Behavior
* For even scale conferences the WPS led will be `on` and for odd scale conferences it'll be `off`
* Moved ntp config to `facts`
* Added tests for ntp config serverspec

## Tests
* Flashed and validated that WPS LEDs are ON as expected on both ipq806x and ar71xx builds
* Also tested the inverse for odd scale numbers where WPS LED is OFF
