### PR TITLE
[READY] auto-generate printed switch maps and router backups

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,9 @@ tests/unit/openwrt/tmp*
 # Ignore built configuration files directory
 switch-configuration/config/output
 
+# Ignore built switch map files
+switch-configuration/config/switch-maps
+
 # Created by https://www.gitignore.io/api/osx,vim,emacs,windows,libreoffice,sublimetext
 
 ### Emacs ###

--- a/router-configuration/backups/br-mdf-01
+++ b/router-configuration/backups/br-mdf-01
@@ -1,0 +1,383 @@
+## Last changed: 2019-10-27 02:59:16 UTC
+version 15.1X49-D70.3;
+system {
+    host-name br-mdf-01;
+    root-authentication {
+    }
+    name-server {
+        8.8.8.8;
+        8.8.4.4;
+    }
+    login {
+        user dlang {
+            uid 2002;
+            class super-user;
+            authentication {
+                ssh-rsa "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDFyz75cUD5pMz7bWdNVc9pLZ9QNS+scMMHHbVvZ060tYlbD2YS1FuIXcyisKYLr29/3O+/ciKOIcw/Q2pzsxgL8mO0ATJzwtvtyhWIcMhJBZNR2jbPwIeKp7Z5NBk8fMDRpWI6i9saLLMr9XtZ2B9RLewIqAAZs0vujJKauaLWVYVFQwkkqKL0WIGP/7fCf1BUHz3vrA1fQDwzhCMayNUBtYwzXtk1Cc0alSLvs1AiqEBWr/n+sduhyUERlFVgvATsH0j1AnLbESathqX4DIatVdHdkAkNaiOAWbguqLDtUiJqcU+eahPFJTeDpLqp6KNP5ZfOr2EQwXZt5mhACjHP davidlang@T470-op-07";
+            }
+        }
+        user kyle {
+            uid 2003;
+            class super-user;
+            authentication {
+                ssh-rsa "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDoQAOVBAEF/HANG4eWBZ6eSoL+7RLpVTMdYC4SZTX5cQqAuxhC3QUEW0ol64eka8/6MELe7Q0UlQ7gH1GpGlB01fGYAJyb0rjVauaS4UisRrZVrP/kLH1TcOJz/AZVQQiOp/XJUCM/KIaTvTUUaadgwPeTunsofzkXQm0WKI1Zqmzs2kj3Q2Tt6P253JvsjOxUV1s7S/oRLiBO9YGkdyCnxJwY7ulgsC9MyvopPsxSm8ta+OQfApQZOoo6T38vq2JrG41bzRlHzn5Bc1Elzkzj1bViX4gnbwooCuw60BjGkunv1bpQclM81jyWUNZ+0rUc/1Id3kFWMQhT5BBcaODoNh0JD62B01iFqovSseOCMDTHvDB497DPGQmQnyb+fMfPHYlx2T3zThMUz40je9h3IniOLnvBTfoAdqwqRsJD6JZ4G/CBcrY11kCzJg5W3I8jAhLs7o90lOGVaL23DvcRMAmIT33B2BHXcUyIF45CYcJYxDuTBn1TlkXoWRF4tWE9v9YPMqYDzLQAplgMK4GRUZA4nJ+JGzzvQz6AcgiTe1YRWO3TjVfqapLTTU6vlvsefI6swyjJW5U5VmqncNQqSiaI8YQIkTCkrTKPtKX4zfj0xa/KoSObnxigsgii11lK6YgS5WbZTnSUH8xJDLjifXKA1XIRbR6Q+YhTbvF1mw==";
+            }
+        }
+        user owen {
+            uid 2004;
+            class super-user;
+            authentication {
+                ssh-rsa "1024 35 114870125079119497064743730551404181721672323637756765961033342070324890531075442741038312582198068761882520928459647324479322148555144455780494777680624949377326717543633178036569565385043021169776538604325865960174754107961471683552906040905706631227199019520404589625948590225853880518583702852911526808117 owen@owen.delong.sj.ca.us";
+                ssh-ecdsa "ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBBjjcUJLTENGrV6K/nrPOswcBVMMuS4sLSs0UyTRw8wU87PDUzJz8Ht2SgHqeEQJdRm1+b6iLsx2uKOf+/pU8qE= root@kiev.delong.com";
+            }
+        }
+        user rob {
+            uid 2005;
+            class super-user;
+            authentication {
+                ssh-rsa "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDBP0XP83nOtxnsGJ7AG+FuT7dbAEO8BrIHlPbhCGhKjFKcq8g6LWa0htx3iwHJB2VfasIVSqWAC7SwX81XfSTwpvNSNVXvrIcMNdYOpEBHx5W94iVP2ooVVsGIeK/M+Eu9toiHebtVFT45hQ8VO5DwqbG6xPgEp1PmLsPhyBwP0LyC8Q4tA2ttftC6/fJa6fa1G54c7D/euIhZnyM/ovcpYfNYTlarX/yLJoYaOEk5ByYJPYnpQtm2GQX8CdT/U14nDtJ/VjzW8kP/R6+ZsmGpxBrWp2Mn03LjL4CzTSN3cbE2CAKKSjkIcaaoohRZS+JXnxm5+TXF/6QmN0MPU3SSThKWIzOhzfMrLqOu6hsw16x9lF1eJreUZr/WysWOswM4WNoffBv6mKvVsMR8Z8tgERR8+sIxUaoVOfChR9wRoD5lcNnVxrC6rcF+rBxeY4JiPS3zpyamwteyR0n2YspT9Dl0MlZb4cWml2aBnvYk0TmoCC3eGs+2/wssL4s+64TiFC8WkK7U7RW0eYODwPJQbzNGZBjcsVlKD4whs5cNGlgjkZJzTdFt49EwIKmFnSd9Ly/NY3zhByFS/MN3Mj9I2AqMRZ/i4iT72gATE9aLle1xViGxjK7bHmHT2H1yqQhJ5bMcorpDzSZyTkyBTDDnOgh8tM+tBG204kYywQW/RQ==";
+            }
+        }
+    }
+    services {
+        ssh {
+            protocol-version v2;
+        }
+        netconf {
+            ssh;
+        }
+    }
+    syslog {
+        archive size 100k files 3;
+        user * {
+            any emergency;
+        }
+        host loghost {
+            any any;
+        }
+        file messages {
+            any notice;
+            authorization info;
+        }
+        file interactive-commands {
+            interactive-commands any;
+        }
+    }
+    max-configurations-on-flash 5;
+    max-configuration-rollbacks 5;
+    license {
+        autoupdate {
+            url https://ae1.juniper.net/junos/key_retrieval;
+        }
+    }
+}
+security {
+    alg {
+        dns disable;
+        ftp disable;
+        h323 disable;
+        mgcp disable;
+        msrpc disable;
+        sunrpc disable;
+        rsh disable;
+        rtsp disable;
+        sccp disable;
+        sip disable;
+        sql disable;
+        talk disable;
+        tftp disable;
+        pptp disable;
+    }
+    forwarding-options {
+        family {
+            inet6 {
+                mode packet-based;
+            }
+        }
+    }
+    flow {
+        allow-dns-reply;
+        tcp-session {
+            no-syn-check;
+            no-syn-check-in-tunnel;
+            no-sequence-check;
+        }
+    }
+    nat {
+        source {
+            rule-set interface-nat {
+                from zone trust;
+                to zone untrust;
+                rule nat {
+                    match {
+                        source-address [ 10.0.0.0/8 172.16.0.0/12 192.168.0.0/16 ];
+                    }
+                    then {
+                        source-nat {
+                            interface;
+                        }
+                    }
+                }
+            }
+        }
+    }
+    policies {
+        from-zone trust to-zone trust {
+            policy allow-all {
+                match {
+                    source-address any;
+                    destination-address any;
+                    application any;
+                }
+                then {
+                    permit;
+                }
+            }
+        }
+        default-policy {
+            permit-all;
+        }
+    }
+    zones {
+        security-zone trust {
+            host-inbound-traffic {
+                system-services {
+                    any-service;
+                }
+                protocols {
+                    all;
+                }
+            }
+            interfaces {
+                irb.103;
+                irb.104;
+                irb.900;
+            }
+        }
+        security-zone untrust {
+            host-inbound-traffic {
+                system-services {
+                    ping;
+                    traceroute;
+                    ssh;
+                }
+            }
+            interfaces {
+                irb.999;
+                ip-0/0/0.0;
+            }
+        }
+    }
+}
+interfaces {
+    ge-0/0/0 {
+        description "Link to ex-mdf-01";
+        unit 0 {
+            family ethernet-switching {
+                interface-mode trunk;
+                vlan {
+                    members [ exInfra exMDF ];
+                }
+            }
+        }
+    }
+    ip-0/0/0 {
+        unit 0 {
+            description "HE IPv6 Tunnel Broker";
+            point-to-point;
+            tunnel {
+                source 38.98.46.150;
+                destination 66.220.18.42;
+                path-mtu-discovery;
+            }
+            family inet6 {
+                address 2001:470:c:1049::2/64;
+            }
+        }
+    }
+    ge-0/0/1 {
+        unit 0 {
+            family ethernet-switching {
+                interface-mode trunk;
+                vlan {
+                    members [ exInfra exMDF ];
+                }
+            }
+        }
+    }
+    ge-0/0/2 {
+        description "Internet Link for Akamai Cluster";
+        unit 0 {
+            family ethernet-switching {
+                interface-mode access;
+                vlan {
+                    members COGENT;
+                }
+            }
+        }
+    }
+    ge-0/0/3 {
+        description "Not in Use";
+        unit 0 {
+            family ethernet-switching;
+        }
+    }
+    ge-0/0/4 {
+        description "Not in Use";
+        unit 0 {
+            family ethernet-switching;
+        }
+    }
+    ge-0/0/5 {
+        description "Physical uplink to convention center (PSAV/Cogent)";
+        unit 0 {
+            family ethernet-switching {
+                interface-mode access;
+                vlan {
+                    members COGENT;
+                }
+            }
+        }
+    }
+    ge-0/0/6 {
+        unit 0 {
+            family ethernet-switching;
+        }
+    }
+    ge-0/0/7 {
+        description "Trunk Expo to Conference Center";
+        unit 0 {
+            family ethernet-switching {
+                interface-mode trunk;
+                vlan {
+                    members [ MDF_LINK HAM_BRIDGE ];
+                }
+            }
+        }
+    }
+    irb {
+        unit 103 {
+            family inet {
+                address 10.0.3.2/24;
+            }
+            family inet6 {
+                address 2001:470:f325:103::2/64;
+            }
+        }
+        unit 104 {
+            family inet {
+                address 10.0.4.1/24;
+            }
+            family inet6 {
+                address 2001:470:f325:104::1/64 {
+                    primary;
+                    preferred;
+                }
+                address 2001:470:f325:104::/64 {
+                    eui-64;
+                }
+            }
+        }
+        unit 900 {
+            description "IP Link between buildings";
+            family inet {
+                address 172.20.0.1/24;
+            }
+            family inet6 {
+                address 2001:470:f325:8000::1/64;
+            }
+        }
+        unit 999 {
+            description "Internet Link to PSAV / Cogent";
+            family inet {
+                address 38.98.46.150/25;
+            }
+        }
+    }
+}
+snmp {
+    community Junitux {
+        authorization read-only;
+        clients {
+            2001:470:f325:103::/64;
+            2001:470:f325:503::/64;
+        }
+    }
+}
+routing-options {
+    rib inet6.0 {
+        static {
+            route ::/0 next-hop 2001:470:c:1049::1;
+        }
+    }
+    static {
+        route 0.0.0.0/0 next-hop 38.98.46.129;
+    }
+}
+protocols {
+    ospf {
+        export DEFAULT-ORIGINATE-v4;
+        area 0.0.0.0 {
+            interface irb.104;
+            interface irb.900;
+            interface irb.103;
+        }
+    }
+    ospf3 {
+        export DEFAULT-ORIGINATE-v6;
+        area 0.0.0.0 {
+            interface irb.104;
+            interface irb.900;
+            interface irb.103;
+        }
+    }
+    l2-learning {
+        global-mode switching;
+    }
+    lldp {
+        enable;
+        interface all;
+    }
+    lldp-med;
+}
+policy-options {
+    policy-statement DEFAULT-ORIGINATE-v4 {
+        from {
+            protocol static;
+            route-filter 0.0.0.0/0 exact;
+        }
+        then accept;
+    }
+    policy-statement DEFAULT-ORIGINATE-v6 {
+        from {
+            route-filter ::/0 exact;
+        }
+        then accept;
+    }
+}
+vlans {
+    COGENT {
+        description "Internet link to Cogent (PSAV)";
+        vlan-id 999;
+        l3-interface irb.999;
+    }
+    HAM_BRIDGE {
+        description "Link between N6S station and Ham Booth in Expo";
+        vlan-id 950;
+    }
+    MDF_LINK {
+        description "Link between MDF in Conference and Expo Centers";
+        vlan-id 900;
+        l3-interface irb.900;
+    }
+    exInfra {
+        description "Infrastructure Network";
+        vlan-id 103;
+        l3-interface irb.103;
+    }
+    exMDF {
+        description "IP Layer 3 Link between Border Router and Expo MDF Router";
+        vlan-id 104;
+        l3-interface irb.104;
+    }
+}

--- a/router-configuration/backups/cf-mdf-01
+++ b/router-configuration/backups/cf-mdf-01
@@ -1,0 +1,659 @@
+## Last changed: 2019-10-02 18:40:42 UTC
+version 15.1X49-D70.3;
+system {
+    host-name cf-mdf-01;
+    root-authentication {
+    }
+    name-server {
+        8.8.8.8;
+        8.8.4.4;
+    }
+    login {
+        user dlang {
+            uid 2002;
+            class super-user;
+            authentication {
+                ssh-rsa "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDFyz75cUD5pMz7bWdNVc9pLZ9QNS+scMMHHbVvZ060tYlbD2YS1FuIXcyisKYLr29/3O+/ciKOIcw/Q2pzsxgL8mO0ATJzwtvtyhWIcMhJBZNR2jbPwIeKp7Z5NBk8fMDRpWI6i9saLLMr9XtZ2B9RLewIqAAZs0vujJKauaLWVYVFQwkkqKL0WIGP/7fCf1BUHz3vrA1fQDwzhCMayNUBtYwzXtk1Cc0alSLvs1AiqEBWr/n+sduhyUERlFVgvATsH0j1AnLbESathqX4DIatVdHdkAkNaiOAWbguqLDtUiJqcU+eahPFJTeDpLqp6KNP5ZfOr2EQwXZt5mhACjHP davidlang@T470-op-07";
+            }
+        }
+        user kyle {
+            uid 2003;
+            class super-user;
+            authentication {
+                ssh-rsa "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDoQAOVBAEF/HANG4eWBZ6eSoL+7RLpVTMdYC4SZTX5cQqAuxhC3QUEW0ol64eka8/6MELe7Q0UlQ7gH1GpGlB01fGYAJyb0rjVauaS4UisRrZVrP/kLH1TcOJz/AZVQQiOp/XJUCM/KIaTvTUUaadgwPeTunsofzkXQm0WKI1Zqmzs2kj3Q2Tt6P253JvsjOxUV1s7S/oRLiBO9YGkdyCnxJwY7ulgsC9MyvopPsxSm8ta+OQfApQZOoo6T38vq2JrG41bzRlHzn5Bc1Elzkzj1bViX4gnbwooCuw60BjGkunv1bpQclM81jyWUNZ+0rUc/1Id3kFWMQhT5BBcaODoNh0JD62B01iFqovSseOCMDTHvDB497DPGQmQnyb+fMfPHYlx2T3zThMUz40je9h3IniOLnvBTfoAdqwqRsJD6JZ4G/CBcrY11kCzJg5W3I8jAhLs7o90lOGVaL23DvcRMAmIT33B2BHXcUyIF45CYcJYxDuTBn1TlkXoWRF4tWE9v9YPMqYDzLQAplgMK4GRUZA4nJ+JGzzvQz6AcgiTe1YRWO3TjVfqapLTTU6vlvsefI6swyjJW5U5VmqncNQqSiaI8YQIkTCkrTKPtKX4zfj0xa/KoSObnxigsgii11lK6YgS5WbZTnSUH8xJDLjifXKA1XIRbR6Q+YhTbvF1mw==";
+            }
+        }
+        user owen {
+            uid 2004;
+            class super-user;
+            authentication {
+                ssh-rsa "1024 35 114870125079119497064743730551404181721672323637756765961033342070324890531075442741038312582198068761882520928459647324479322148555144455780494777680624949377326717543633178036569565385043021169776538604325865960174754107961471683552906040905706631227199019520404589625948590225853880518583702852911526808117 owen@owen.delong.sj.ca.us";
+                ssh-ecdsa "ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBBjjcUJLTENGrV6K/nrPOswcBVMMuS4sLSs0UyTRw8wU87PDUzJz8Ht2SgHqeEQJdRm1+b6iLsx2uKOf+/pU8qE= root@kiev.delong.com";
+            }
+        }
+        user rob {
+            uid 2005;
+            class super-user;
+            authentication {
+                ssh-rsa "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDBP0XP83nOtxnsGJ7AG+FuT7dbAEO8BrIHlPbhCGhKjFKcq8g6LWa0htx3iwHJB2VfasIVSqWAC7SwX81XfSTwpvNSNVXvrIcMNdYOpEBHx5W94iVP2ooVVsGIeK/M+Eu9toiHebtVFT45hQ8VO5DwqbG6xPgEp1PmLsPhyBwP0LyC8Q4tA2ttftC6/fJa6fa1G54c7D/euIhZnyM/ovcpYfNYTlarX/yLJoYaOEk5ByYJPYnpQtm2GQX8CdT/U14nDtJ/VjzW8kP/R6+ZsmGpxBrWp2Mn03LjL4CzTSN3cbE2CAKKSjkIcaaoohRZS+JXnxm5+TXF/6QmN0MPU3SSThKWIzOhzfMrLqOu6hsw16x9lF1eJreUZr/WysWOswM4WNoffBv6mKvVsMR8Z8tgERR8+sIxUaoVOfChR9wRoD5lcNnVxrC6rcF+rBxeY4JiPS3zpyamwteyR0n2YspT9Dl0MlZb4cWml2aBnvYk0TmoCC3eGs+2/wssL4s+64TiFC8WkK7U7RW0eYODwPJQbzNGZBjcsVlKD4whs5cNGlgjkZJzTdFt49EwIKmFnSd9Ly/NY3zhByFS/MN3Mj9I2AqMRZ/i4iT72gATE9aLle1xViGxjK7bHmHT2H1yqQhJ5bMcorpDzSZyTkyBTDDnOgh8tM+tBG204kYywQW/RQ==";
+            }
+        }
+    }
+    services {
+        ssh {
+            protocol-version v2;
+        }
+        netconf {
+            ssh;
+        }
+    }
+    syslog {
+        archive size 100k files 3;
+        user * {
+            any emergency;
+        }
+        host loghost {
+            any any;
+        }
+        file messages {
+            any notice;
+            authorization info;
+        }
+        file interactive-commands {
+            interactive-commands any;
+        }
+    }
+    max-configurations-on-flash 5;
+    max-configuration-rollbacks 5;
+    license {
+        autoupdate {
+            url https://ae1.juniper.net/junos/key_retrieval;
+        }
+    }
+}
+security {
+    alg {
+        dns disable;
+        ftp disable;
+        h323 disable;
+        mgcp disable;
+        msrpc disable;
+        sunrpc disable;
+        rsh disable;
+        rtsp disable;
+        sccp disable;
+        sip disable;
+        sql disable;
+        talk disable;
+        tftp disable;
+        pptp disable;
+    }
+    forwarding-options {
+        family {
+            inet6 {
+                mode packet-based;
+            }
+            mpls {
+                mode packet-based;
+            }
+        }
+    }
+    flow {
+        allow-dns-reply;
+        tcp-session {
+            no-syn-check;
+            no-syn-check-in-tunnel;
+            no-sequence-check;
+        }
+    }
+}
+interfaces {
+    ge-0/0/0 {
+        description "Trunk to cfIDF switch";
+        unit 0 {
+            family ethernet-switching {
+                interface-mode trunk;
+                vlan {
+                    members [ cfInfra HAM_BRIDGE cfAVLAN cfCTF cfDWCC cfHam_N6S cfNOC cfSCALE-FAST cfSCALE-SLOW cfSigns cfSpeaker cfStaff ];
+                }
+            }
+        }
+    }
+    ge-0/0/1 {
+        unit 0 {
+            family ethernet-switching;
+        }
+    }
+    ge-0/0/2 {
+        unit 0 {
+            family ethernet-switching;
+        }
+    }
+    ge-0/0/3 {
+        unit 0 {
+            family ethernet-switching;
+        }
+    }
+    ge-0/0/4 {
+        unit 0 {
+            family ethernet-switching;
+        }
+    }
+    ge-0/0/5 {
+        unit 0 {
+            family ethernet-switching;
+        }
+    }
+    ge-0/0/6 {
+        unit 0 {
+            family ethernet-switching;
+        }
+    }
+    ge-0/0/7 {
+        description "Trunk Expo to Conference Center";
+        unit 0 {
+            family ethernet-switching {
+                interface-mode trunk;
+                vlan {
+                    members [ MDF_LINK HAM_BRIDGE ];
+                }
+            }
+        }
+    }
+    irb {
+        unit 4;
+        unit 500 {
+            description "cfSCALE-SLOW 2.4G WiFi Network";
+            family inet {
+                address 10.128.128.1/21;
+            }
+            family inet6 {
+                address 2001:470:f325:500::/64 {
+                    eui-64;
+                }
+                address 2001:470:f325:500::1/64 {
+                    primary;
+                    preferred;
+                }
+            }
+        }
+        unit 501 {
+            description "cfSCALE-FAST 5G WiFi Network";
+            family inet {
+                address 10.128.136.1/21;
+            }
+            family inet6 {
+                address 2001:470:f325:501::1/64;
+                address 2001:470:f325:501::/64 {
+                    eui-64;
+                }
+            }
+        }
+        unit 502 {
+            description "cfSpeaker Speaker Network";
+            family inet {
+                address 10.128.2.1/24;
+            }
+            family inet6 {
+                address 2001:470:f325:502::1/64;
+                address 2001:470:f325:502::/64 {
+                    eui-64;
+                }
+            }
+        }
+        unit 503 {
+            family inet {
+                address 10.128.3.1/24;
+            }
+            family inet6 {
+                address 2001:470:f325:503::1/64;
+                address 2001:470:f325:503::/64 {
+                    eui-64;
+                }
+            }
+        }
+        unit 504 {
+            description "cfCTF Capture the Flag";
+            family inet {
+                filter {
+                    input ctf-to-internet;
+                    output ctf-from-internet;
+                }
+                address 10.128.4.1/24;
+            }
+            family inet6 {
+                filter {
+                    input ctf-to-internet6;
+                    output ctf-from-internet6;
+                }
+                address 2001:470:f325:504::1/64;
+                address 2001:470:f325:504::/64 {
+                    eui-64;
+                }
+            }
+        }
+        unit 505 {
+            description "cfAVLAN Audio Visual VLAN";
+            family inet {
+                address 10.128.5.1/24;
+            }
+            family inet6 {
+                address 2001:470:f325:505::1/64;
+                address 2001:470:f325:505::/64 {
+                    eui-64;
+                }
+            }
+        }
+        unit 506 {
+            description "cfNOC -- Network Operations Center";
+            family inet {
+                address 10.128.6.1/24;
+            }
+            family inet6 {
+                address 2001:470:f325:506::1/64;
+                address 2001:470:f325:506::/64 {
+                    eui-64;
+                }
+            }
+        }
+        unit 507 {
+            description "cfSigns -- Sign Network";
+            family inet {
+                address 10.128.7.1/24;
+            }
+            family inet6 {
+                address 2001:470:f325:507::1/64;
+                address 2001:470:f325:507::/64 {
+                    eui-64;
+                }
+            }
+        }
+        unit 508 {
+            description "cfStaff -- Staff Wifi Network";
+            family inet {
+                address 10.128.8.1/24;
+            }
+            family inet6 {
+                address 2001:470:f325:508::1/64;
+                address 2001:470:f325:508::/64 {
+                    eui-64;
+                }
+            }
+        }
+        unit 509 {
+            description "HAM Radio station in Conference Center;";
+            family inet {
+                address 10.128.9.1/24;
+            }
+            family inet6 {
+                address 2001:470:f325:509::1/64;
+                address 2001:470:f325:509::/64 {
+                    eui-64;
+                }
+            }
+        }
+        unit 600 {
+            description "Zach's Distributed Wifi Capability Collector;";
+            family inet {
+                address 10.128.100.1/24;
+            }
+            family inet6 {
+                address 2001:470:f325:600::1/64;
+                address 2001:470:f325:600::/64 {
+                    eui-64;
+                }
+            }
+        }
+        unit 900 {
+            description "IP Link between buildings";
+            family inet {
+                address 172.20.0.2/24;
+            }
+            family inet6 {
+                address 2001:470:f325:8000::2/64;
+            }
+        }
+    }
+}
+snmp {
+    community Junitux {
+        authorization read-only;
+        clients {
+            2001:470:f325:103::/64;
+            2001:470:f325:503::/64;
+        }
+    }
+}
+forwarding-options {
+    dhcp-relay {
+        dhcpv6 {
+            group all {
+                interface irb.500;
+                interface irb.501;
+                interface irb.502;
+                interface irb.503;
+                interface irb.504;
+                interface irb.506;
+                interface irb.507;
+                interface irb.508;
+                interface irb.509;
+                interface irb.600;
+            }
+            group AV {
+                active-server-group AV;
+                interface irb.505;
+            }
+            server-group {
+                Conference {
+                    2001:470:f325:503::5;
+                }
+                Expo {
+                    2001:470:f325:103::5;
+                }
+                AV {
+                    2001:470:f325:105::10;
+                }
+            }
+            active-server-group Conference;
+        }
+        server-group {
+            Conference {
+                10.128.3.5;
+            }
+            Expo {
+                10.0.3.5;
+            }
+            AV {
+                10.0.5.10;
+            }
+        }
+        active-server-group Conference;
+        group all {
+            interface irb.500;
+            interface irb.501;
+            interface irb.502;
+            interface irb.503;
+            interface irb.504;
+            interface irb.506;
+            interface irb.507;
+            interface irb.508;
+            interface irb.509;
+            interface irb.600;
+        }
+        group AV {
+            active-server-group AV;
+            interface irb.505;
+        }
+    }
+}
+protocols {
+    router-advertisement {
+        interface irb.503 {
+            other-stateful-configuration;
+            dns-server-address 2001:470:f325:503::5;
+            dns-server-address 2001:470:f325:103::5;
+            prefix 2001:470:f325:503::/64 {
+                on-link;
+                autonomous;
+            }
+        }
+        interface irb.500 {
+            other-stateful-configuration;
+            dns-server-address 2001:470:f325:503::5;
+            dns-server-address 2001:470:f325:103::5;
+            prefix 2001:470:f325:500::/64 {
+                on-link;
+                autonomous;
+            }
+        }
+        interface irb.501 {
+            other-stateful-configuration;
+            dns-server-address 2001:470:f325:503::5;
+            dns-server-address 2001:470:f325:103::5;
+            prefix 2001:470:f325:501::/64 {
+                on-link;
+                autonomous;
+            }
+        }
+        interface irb.502 {
+            other-stateful-configuration;
+            dns-server-address 2001:470:f325:503::5;
+            dns-server-address 2001:470:f325:103::5;
+            prefix 2001:470:f325:502::/64 {
+                on-link;
+                autonomous;
+            }
+        }
+        interface irb.504 {
+            other-stateful-configuration;
+            dns-server-address 2001:470:f325:503::5;
+            dns-server-address 2001:470:f325:103::5;
+            prefix 2001:470:f325:504::/64 {
+                on-link;
+                autonomous;
+            }
+        }
+        interface irb.505 {
+            other-stateful-configuration;
+            dns-server-address 2001:470:f325:503::5;
+            dns-server-address 2001:470:f325:103::5;
+            prefix 2001:470:f325:505::/64 {
+                on-link;
+                autonomous;
+            }
+        }
+        interface irb.506 {
+            other-stateful-configuration;
+            dns-server-address 2001:470:f325:503::5;
+            dns-server-address 2001:470:f325:103::5;
+            prefix 2001:470:f325:506::/64 {
+                on-link;
+                autonomous;
+            }
+        }
+        interface irb.507 {
+            other-stateful-configuration;
+            dns-server-address 2001:470:f325:503::5;
+            dns-server-address 2001:470:f325:103::5;
+            prefix 2001:470:f325:507::/64 {
+                on-link;
+                autonomous;
+            }
+        }
+        interface irb.508 {
+            other-stateful-configuration;
+            dns-server-address 2001:470:f325:503::5;
+            dns-server-address 2001:470:f325:103::5;
+            prefix 2001:470:f325:508::/64 {
+                on-link;
+                autonomous;
+            }
+        }
+        interface irb.509 {
+            other-stateful-configuration;
+            dns-server-address 2001:470:f325:503::5;
+            dns-server-address 2001:470:f325:103::5;
+            prefix 2001:470:f325:509::/64 {
+                on-link;
+                autonomous;
+            }
+        }
+        interface irb.600 {
+            other-stateful-configuration;
+            dns-server-address 2001:470:f325:503::5;
+            dns-server-address 2001:470:f325:103::5;
+            prefix 2001:470:f325:600::/64 {
+                on-link;
+                autonomous;
+            }
+        }
+    }
+    ospf {
+        area 0.0.0.0 {
+            interface irb.900;
+            interface irb.503;
+            interface irb.500;
+            interface irb.501;
+            interface irb.502;
+            interface irb.504;
+            interface irb.505;
+            interface irb.506;
+            interface irb.507;
+            interface irb.508;
+            interface irb.509;
+            interface irb.600;
+        }
+    }
+    ospf3 {
+        area 0.0.0.0 {
+            interface irb.900;
+            interface irb.503;
+            interface irb.500;
+            interface irb.501;
+            interface irb.502;
+            interface irb.504;
+            interface irb.505;
+            interface irb.506;
+            interface irb.507;
+            interface irb.508;
+            interface irb.509;
+            interface irb.600;
+        }
+    }
+    l2-learning {
+        global-mode switching;
+    }
+    lldp {
+        enable;
+        interface all;
+    }
+    lldp-med;
+}
+firewall {
+    family inet {
+        filter ctf-to-internet {
+            term block_appliance {
+                from {
+                    source-address {
+                        10.128.4.8/29;
+                    }
+                }
+                then {
+                    discard;
+                }
+            }
+            term allow_everything_else {
+                then accept;
+            }
+        }
+        filter ctf-from-internet {
+            term block_appliance {
+                from {
+                    destination-address {
+                        10.128.4.8/29;
+                    }
+                }
+                then {
+                    discard;
+                }
+            }
+            term allow_everything_else {
+                then accept;
+            }
+        }
+    }
+    family inet6 {
+        filter ctf-to-internet6 {
+            term block_appliance {
+                from {
+                    source-address {
+                        2001:470:f325:504::8/125;
+                    }
+                }
+                then discard;
+            }
+            term allow_everything_else {
+                then accept;
+            }
+        }
+        filter ctf-from-internet6 {
+            term block_appliance {
+                from {
+                    destination-address {
+                        2001:470:f325:504::8/125;
+                    }
+                }
+                then discard;
+            }
+            term allow_everything_else {
+                then accept;
+            }
+        }
+    }
+}
+vlans {
+    HAM_BRIDGE {
+        description "Link between N6S station and Ham Booth in Expo";
+        vlan-id 950;
+    }
+    MDF_LINK {
+        description "Link between MDF in Conference and Expo Centers";
+        vlan-id 900;
+        l3-interface irb.900;
+    }
+    cfAVLAN {
+        description "AV Network";
+        vlan-id 505;
+        l3-interface irb.505;
+    }
+    cfCTF {
+        description "Capture the Flag VLAN";
+        vlan-id 504;
+        l3-interface irb.504;
+    }
+    cfDWCC {
+        description "Zach's Distributed WiFi capability collector";
+        vlan-id 600;
+        l3-interface irb.600;
+    }
+    cfHam_N6S {
+        description "HAM radio station in Conference Center";
+        vlan-id 509;
+        l3-interface irb.509;
+    }
+    cfInfra {
+        description "Infrastructure Network";
+        vlan-id 503;
+        l3-interface irb.503;
+    }
+    cfNOC {
+        description "Staff Wireless Network";
+        vlan-id 506;
+        l3-interface irb.506;
+    }
+    cfSCALE-FAST {
+        description "5G Wireless Network in Expo Center";
+        vlan-id 501;
+        l3-interface irb.501;
+    }
+    cfSCALE-SLOW {
+        description "2.4G Wireless Network in Expo Center";
+        vlan-id 500;
+        l3-interface irb.500;
+    }
+    cfSigns {
+        description "Signs Network";
+        vlan-id 507;
+        l3-interface irb.507;
+    }
+    cfSpeaker {
+        description "Speaker Network";
+        vlan-id 502;
+        l3-interface irb.502;
+    }
+    cfStaff {
+        description "Staff Wireless Network";
+        vlan-id 508;
+        l3-interface irb.508;
+    }
+}

--- a/router-configuration/backups/ex-mdf-01
+++ b/router-configuration/backups/ex-mdf-01
@@ -1,0 +1,622 @@
+## Last changed: 2019-03-08 23:59:58 UTC
+version 15.1X49-D70.3;
+system {
+    host-name ex-mdf-01;
+    root-authentication {
+    }
+    name-server {
+        8.8.8.8;
+        8.8.4.4;
+    }
+    login {
+        user dlang {
+            uid 2002;
+            class super-user;
+            authentication {
+                ssh-rsa "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDFyz75cUD5pMz7bWdNVc9pLZ9QNS+scMMHHbVvZ060tYlbD2YS1FuIXcyisKYLr29/3O+/ciKOIcw/Q2pzsxgL8mO0ATJzwtvtyhWIcMhJBZNR2jbPwIeKp7Z5NBk8fMDRpWI6i9saLLMr9XtZ2B9RLewIqAAZs0vujJKauaLWVYVFQwkkqKL0WIGP/7fCf1BUHz3vrA1fQDwzhCMayNUBtYwzXtk1Cc0alSLvs1AiqEBWr/n+sduhyUERlFVgvATsH0j1AnLbESathqX4DIatVdHdkAkNaiOAWbguqLDtUiJqcU+eahPFJTeDpLqp6KNP5ZfOr2EQwXZt5mhACjHP davidlang@T470-op-07";
+            }
+        }
+        user kyle {
+            uid 2003;
+            class super-user;
+            authentication {
+                ssh-rsa "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDoQAOVBAEF/HANG4eWBZ6eSoL+7RLpVTMdYC4SZTX5cQqAuxhC3QUEW0ol64eka8/6MELe7Q0UlQ7gH1GpGlB01fGYAJyb0rjVauaS4UisRrZVrP/kLH1TcOJz/AZVQQiOp/XJUCM/KIaTvTUUaadgwPeTunsofzkXQm0WKI1Zqmzs2kj3Q2Tt6P253JvsjOxUV1s7S/oRLiBO9YGkdyCnxJwY7ulgsC9MyvopPsxSm8ta+OQfApQZOoo6T38vq2JrG41bzRlHzn5Bc1Elzkzj1bViX4gnbwooCuw60BjGkunv1bpQclM81jyWUNZ+0rUc/1Id3kFWMQhT5BBcaODoNh0JD62B01iFqovSseOCMDTHvDB497DPGQmQnyb+fMfPHYlx2T3zThMUz40je9h3IniOLnvBTfoAdqwqRsJD6JZ4G/CBcrY11kCzJg5W3I8jAhLs7o90lOGVaL23DvcRMAmIT33B2BHXcUyIF45CYcJYxDuTBn1TlkXoWRF4tWE9v9YPMqYDzLQAplgMK4GRUZA4nJ+JGzzvQz6AcgiTe1YRWO3TjVfqapLTTU6vlvsefI6swyjJW5U5VmqncNQqSiaI8YQIkTCkrTKPtKX4zfj0xa/KoSObnxigsgii11lK6YgS5WbZTnSUH8xJDLjifXKA1XIRbR6Q+YhTbvF1mw==";
+            }
+        }
+        user owen {
+            uid 2004;
+            class super-user;
+            authentication {
+                ssh-rsa "1024 35 114870125079119497064743730551404181721672323637756765961033342070324890531075442741038312582198068761882520928459647324479322148555144455780494777680624949377326717543633178036569565385043021169776538604325865960174754107961471683552906040905706631227199019520404589625948590225853880518583702852911526808117 owen@owen.delong.sj.ca.us";
+                ssh-ecdsa "ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBBjjcUJLTENGrV6K/nrPOswcBVMMuS4sLSs0UyTRw8wU87PDUzJz8Ht2SgHqeEQJdRm1+b6iLsx2uKOf+/pU8qE= root@kiev.delong.com";
+            }
+        }
+        user rob {
+            uid 2005;
+            class super-user;
+            authentication {
+                ssh-rsa "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDBP0XP83nOtxnsGJ7AG+FuT7dbAEO8BrIHlPbhCGhKjFKcq8g6LWa0htx3iwHJB2VfasIVSqWAC7SwX81XfSTwpvNSNVXvrIcMNdYOpEBHx5W94iVP2ooVVsGIeK/M+Eu9toiHebtVFT45hQ8VO5DwqbG6xPgEp1PmLsPhyBwP0LyC8Q4tA2ttftC6/fJa6fa1G54c7D/euIhZnyM/ovcpYfNYTlarX/yLJoYaOEk5ByYJPYnpQtm2GQX8CdT/U14nDtJ/VjzW8kP/R6+ZsmGpxBrWp2Mn03LjL4CzTSN3cbE2CAKKSjkIcaaoohRZS+JXnxm5+TXF/6QmN0MPU3SSThKWIzOhzfMrLqOu6hsw16x9lF1eJreUZr/WysWOswM4WNoffBv6mKvVsMR8Z8tgERR8+sIxUaoVOfChR9wRoD5lcNnVxrC6rcF+rBxeY4JiPS3zpyamwteyR0n2YspT9Dl0MlZb4cWml2aBnvYk0TmoCC3eGs+2/wssL4s+64TiFC8WkK7U7RW0eYODwPJQbzNGZBjcsVlKD4whs5cNGlgjkZJzTdFt49EwIKmFnSd9Ly/NY3zhByFS/MN3Mj9I2AqMRZ/i4iT72gATE9aLle1xViGxjK7bHmHT2H1yqQhJ5bMcorpDzSZyTkyBTDDnOgh8tM+tBG204kYywQW/RQ==";
+            }
+        }
+    }
+    services {
+        ssh {
+            protocol-version v2;
+        }
+        netconf {
+            ssh;
+        }
+    }
+    syslog {
+        archive size 100k files 3;
+        user * {
+            any emergency;
+        }
+        host loghost {
+            any any;
+        }
+        file messages {
+            any notice;
+            authorization info;
+        }
+        file interactive-commands {
+            interactive-commands any;
+        }
+    }
+    max-configurations-on-flash 5;
+    max-configuration-rollbacks 5;
+    license {
+        autoupdate {
+            url https://ae1.juniper.net/junos/key_retrieval;
+        }
+    }
+}
+security {
+    alg {
+        dns disable;
+        ftp disable;
+        h323 disable;
+        mgcp disable;
+        msrpc disable;
+        sunrpc disable;
+        rsh disable;
+        rtsp disable;
+        sccp disable;
+        sip disable;
+        sql disable;
+        talk disable;
+        tftp disable;
+        pptp disable;
+    }
+    forwarding-options {
+        family {
+            inet6 {
+                mode packet-based;
+            }
+            mpls {
+                mode packet-based;
+            }
+        }
+    }
+    flow {
+        allow-dns-reply;
+        tcp-session {
+            no-syn-check;
+            no-syn-check-in-tunnel;
+            no-sequence-check;
+        }
+    }
+}
+interfaces {
+    ge-0/0/0 {
+        unit 0 {
+            family ethernet-switching {
+                interface-mode trunk;
+                vlan {
+                    members [ exInfra exMDF ];
+                }
+            }
+        }
+    }
+    ge-0/0/1 {
+        description "Trunk to IDF-4 (Show Floor IDF)";
+        unit 0 {
+            family ethernet-switching {
+                interface-mode trunk;
+                vlan {
+                    members [ exSCALE-SLOW exSCALE-FAST exSpeaker exInfra exMDF exAVLAN exSigns exStaff exRegistration vendor_backbone ];
+                }
+            }
+        }
+    }
+    ge-0/0/2 {
+        description "Trunk to IDF-5 (Catwalk IDF)";
+        unit 0 {
+            family ethernet-switching {
+                interface-mode trunk;
+                vlan {
+                    members [ exSCALE-SLOW exSCALE-FAST exSpeaker exInfra exMDF exAVLAN exSigns exStaff exRegistration vendor_backbone ];
+                }
+            }
+        }
+    }
+    ge-0/0/3 {
+        description "Akamai Cache IPv6 interface";
+        unit 0 {
+            family ethernet-switching {
+                vlan {
+                    members exAkamai;
+                }
+            }
+        }
+    }
+    ge-0/0/4 {
+        unit 0 {
+            family ethernet-switching {
+                interface-mode access;
+                vlan {
+                    members exAVLAN;
+                }
+            }
+        }
+    }
+    ge-0/0/5 {
+        unit 0 {
+            family ethernet-switching {
+                interface-mode access;
+                vlan {
+                    members exInfra;
+                }
+            }
+        }
+    }
+    ge-0/0/6 {
+        description "Trunk to NE-IDF";
+        unit 0 {
+            family ethernet-switching {
+                interface-mode trunk;
+                vlan {
+                    members [ exSCALE-SLOW exSCALE-FAST exSpeaker exInfra exMDF exAVLAN exSigns exStaff exRegistration vendor_backbone ];
+                }
+            }
+        }
+    }
+    ge-0/0/7 {
+        description "Trunk to NW-IDF";
+        unit 0 {
+            family ethernet-switching {
+                interface-mode trunk;
+                vlan {
+                    members [ exSCALE-SLOW exSCALE-FAST exSpeaker exInfra exMDF exAVLAN exSigns exStaff exRegistration vendor_backbone ];
+                }
+            }
+        }
+    }
+    irb {
+        unit 100 {
+            description exSCALE-SLOW;
+            family inet {
+                address 10.0.128.1/21;
+            }
+            family inet6 {
+                address 2001:470:f325:100::1/64;
+                address 2001:470:f325:100::/64 {
+                    eui-64;
+                }
+            }
+        }
+        unit 101 {
+            description exSCALE-FAST;
+            family inet {
+                address 10.0.136.1/21;
+            }
+            family inet6 {
+                address 2001:470:f325:101::1/64;
+                address 2001:470:f325:101::/64 {
+                    eui-64;
+                }
+            }
+        }
+        unit 102 {
+            description exSpeaker;
+            family inet {
+                address 10.0.2.1/24;
+            }
+            family inet6 {
+                address 2001:470:f325:102::1/64;
+                address 2001:470:f325:102::/64 {
+                    eui-64;
+                }
+            }
+        }
+        unit 103 {
+            description exInfra;
+            family inet {
+                address 10.0.3.1/24;
+            }
+            family inet6 {
+                address 2001:470:f325:103::/64 {
+                    eui-64;
+                }
+                address 2001:470:f325:103::1/64;
+            }
+        }
+        unit 104 {
+            description exMDF;
+            family inet {
+                address 10.0.4.2/24;
+            }
+            family inet6 {
+                address 2001:470:f325:104::2/64;
+            }
+        }
+        unit 105 {
+            description exAVLAN;
+            family inet {
+                address 10.0.5.1/24;
+            }
+            family inet6 {
+                address 2001:470:f325:105::1/64;
+                address 2001:470:f325:105::/64 {
+                    eui-64;
+                }
+            }
+        }
+        unit 107 {
+            description exSigns;
+            family inet6 {
+                address 2001:470:f325:107::1/64;
+                address 2001:470:f325:107::/64 {
+                    eui-64;
+                }
+            }
+        }
+        unit 108 {
+            description exStaff;
+            family inet {
+                address 10.0.8.1/24;
+            }
+            family inet6 {
+                address 2001:470:f325:108::1/64;
+                address 2001:470:f325:108::/64 {
+                    eui-64;
+                }
+            }
+        }
+        unit 110 {
+            description exRegistration;
+            family inet {
+                address 10.0.10.1/24;
+            }
+            family inet6 {
+                address 2001:470:f325:110::1/64;
+                address 2001:470:f325:110::/64 {
+                    eui-64;
+                }
+            }
+        }
+        unit 111 {
+            description exAkamai;
+            family inet6 {
+                address 2001:470:f325:111::1/64;
+                address 2001:470:f325:111::/64 {
+                    eui-64;
+                }
+            }
+        }
+        inactive: unit 200 {
+            description "VLANs 200-398 are on Expo switches and not directly routed here.";
+        }
+        unit 499 {
+            description vendor_backbone;
+            family inet {
+                address 10.1.0.1/24;
+            }
+        }
+    }
+}
+snmp {
+    community Junitux {
+        authorization read-only;
+        clients {
+            2001:470:f325:103::/64;
+            2001:470:f325:503::/64;
+        }
+    }
+}
+forwarding-options {
+    dhcp-relay {
+        dhcpv6 {
+            group all {
+                interface irb.100;
+                interface irb.101;
+                interface irb.102;
+                interface irb.103;
+                interface irb.104;
+                interface irb.107;
+                interface irb.108;
+                interface irb.110;
+                interface irb.200;
+                interface irb.300;
+            }
+            group AV {
+                active-server-group AV;
+                interface irb.105;
+            }
+            server-group {
+                Conference {
+                    2001:470:f325:503::5;
+                }
+                Expo {
+                    2001:470:f325:103::5;
+                }
+                AV {
+                    2001:470:f325:105::10;
+                }
+            }
+            active-server-group Expo;
+        }
+        server-group {
+            Conference {
+                10.128.3.5;
+            }
+            Expo {
+                10.0.3.5;
+            }
+            AV {
+                10.0.5.10;
+            }
+        }
+        active-server-group Expo;
+        group all {
+            interface irb.100;
+            interface irb.101;
+            interface irb.102;
+            interface irb.103;
+            interface irb.104;
+            interface irb.107;
+            interface irb.108;
+            interface irb.110;
+            interface irb.200;
+            interface irb.300;
+        }
+        group AV {
+            active-server-group AV;
+            interface irb.105;
+        }
+    }
+}
+protocols {
+    router-advertisement {
+        interface irb.100 {
+            other-stateful-configuration;
+            dns-server-address 2001:470:f325:103::5;
+            dns-server-address 2001:470:f325:503::5;
+            prefix 2001:470:f325:100::/64 {
+                on-link;
+                autonomous;
+            }
+        }
+        interface irb.101 {
+            other-stateful-configuration;
+            dns-server-address 2001:470:f325:103::5;
+            dns-server-address 2001:470:f325:503::5;
+            prefix 2001:470:f325:101::/64 {
+                on-link;
+                autonomous;
+            }
+        }
+        interface irb.102 {
+            other-stateful-configuration;
+            dns-server-address 2001:470:f325:103::5;
+            dns-server-address 2001:470:f325:503::5;
+            prefix 2001:470:f325:102::/64 {
+                on-link;
+                autonomous;
+            }
+        }
+        interface irb.103 {
+            other-stateful-configuration;
+            dns-server-address 2001:470:f325:103::5;
+            dns-server-address 2001:470:f325:503::5;
+            prefix 2001:470:f325:103::/64 {
+                on-link;
+                autonomous;
+            }
+        }
+        interface irb.104 {
+            other-stateful-configuration;
+            dns-server-address 2001:470:f325:103::5;
+            dns-server-address 2001:470:f325:503::5;
+            prefix 2001:470:f325:104::/64 {
+                on-link;
+                autonomous;
+            }
+        }
+        interface irb.105 {
+            other-stateful-configuration;
+            dns-server-address 2001:470:f325:103::5;
+            dns-server-address 2001:470:f325:503::5;
+            prefix 2001:470:f325:105::/64 {
+                on-link;
+                autonomous;
+            }
+        }
+        interface irb.107 {
+            other-stateful-configuration;
+            dns-server-address 2001:470:f325:103::5;
+            dns-server-address 2001:470:f325:503::5;
+            prefix 2001:470:f325:107::/64 {
+                on-link;
+                autonomous;
+            }
+        }
+        interface irb.108 {
+            other-stateful-configuration;
+            dns-server-address 2001:470:f325:103::5;
+            dns-server-address 2001:470:f325:503::5;
+            prefix 2001:470:f325:108::/64 {
+                on-link;
+                autonomous;
+            }
+        }
+        interface irb.110 {
+            other-stateful-configuration;
+            dns-server-address 2001:470:f325:103::5;
+            dns-server-address 2001:470:f325:503::5;
+            prefix 2001:470:f325:110::/64 {
+                on-link;
+                autonomous;
+            }
+        }
+        interface irb.111 {
+            other-stateful-configuration;
+            dns-server-address 2001:470:f325:103::5;
+            dns-server-address 2001:470:f325:503::5;
+            prefix 2001:470:f325:111::/64 {
+                on-link;
+                autonomous;
+            }
+        }
+        interface irb.200 {
+            other-stateful-configuration;
+            dns-server-address 2001:470:f325:103::5;
+            dns-server-address 2001:470:f325:503::5;
+            prefix 2001:470:f325:200::/64 {
+                on-link;
+                autonomous;
+            }
+        }
+        interface irb.300 {
+            other-stateful-configuration;
+            solicit-router-advertisement-unicast;
+            dns-server-address 2001:470:f325:103::5;
+            dns-server-address 2001:470:f325:503::5;
+            prefix 2001:470:f325:300::/64 {
+                on-link;
+                autonomous;
+            }
+        }
+    }
+    ospf {
+        area 0.0.0.0 {
+            interface irb.103;
+            interface irb.104;
+            interface irb.100 {
+                passive;
+            }
+            interface irb.101 {
+                passive;
+            }
+            interface irb.102 {
+                passive;
+            }
+            interface irb.105 {
+                passive;
+            }
+            interface irb.107 {
+                passive;
+            }
+            interface irb.108 {
+                passive;
+            }
+            interface irb.110 {
+                passive;
+            }
+            interface irb.499;
+        }
+    }
+    ospf3 {
+        area 0.0.0.0 {
+            interface irb.100 {
+                passive;
+            }
+            interface irb.101 {
+                passive;
+            }
+            interface irb.102 {
+                passive;
+            }
+            interface irb.103;
+            interface irb.104;
+            interface irb.105 {
+                passive;
+            }
+            interface irb.107 {
+                passive;
+            }
+            interface irb.108 {
+                passive;
+            }
+            interface irb.110 {
+                passive;
+            }
+            interface irb.499;
+        }
+    }
+    l2-learning {
+        global-mode switching;
+    }
+    lldp {
+        enable;
+        interface all;
+    }
+    lldp-med;
+}
+vlans {
+    exAVLAN {
+        description "AV Network";
+        vlan-id 105;
+        l3-interface irb.105;
+    }
+    exAkamai {
+        description "Akamai Cache IPv6 Network";
+        vlan-id 111;
+        l3-interface irb.111;
+    }
+    exInfra {
+        description "Infrastructure Network";
+        vlan-id 103;
+        l3-interface irb.103;
+    }
+    exMDF {
+        description "Link to Border Router";
+        vlan-id 104;
+        l3-interface irb.104;
+    }
+    exRegistration {
+        description "Registration Network";
+        vlan-id 110;
+        l3-interface irb.110;
+    }
+    exSCALE-FAST {
+        description "5G Wireless Network in Expo Center";
+        vlan-id 101;
+        l3-interface irb.101;
+    }
+    exSCALE-SLOW {
+        description "2.4G Wireless Network in Expo Center";
+        vlan-id 100;
+        l3-interface irb.100;
+    }
+    exSigns {
+        description "Signs Network";
+        vlan-id 107;
+        l3-interface irb.107;
+    }
+    exSpeaker {
+        description "Speaker Network";
+        vlan-id 102;
+        l3-interface irb.102;
+    }
+    exStaff {
+        description "Staff Wireless Network";
+        vlan-id 108;
+        l3-interface irb.108;
+    }
+    vendor_backbone {
+        description "Vendor Backbone VLAN";
+        vlan-id 499;
+        l3-interface irb.499;
+    }
+}

--- a/switch-configuration/config/scripts/build_switch_configs.pl
+++ b/switch-configuration/config/scripts/build_switch_configs.pl
@@ -2,7 +2,7 @@
 #
 # This script will iterate through each of the switches named in the switchtypes
 # file and produce a configuration file for that switch named <switchname>.conf
-# It will also produce a port map file for each switch named <switchname>-map.pdf
+# It will also produce a port map file for each switch named <switchname>-map.ps
 #
 # Switch configurations are stored in ./output/
 # Port map files are stored in ./switch-maps/
@@ -29,7 +29,7 @@ if (scalar(@ARGV))
     foreach $file (@{$switchlist})
     {
         push @outputs, "output/".$file.".conf";
-        push @maps, "switch-maps/".$file."-map.pdf";
+        push @maps, "switch-maps/".$file."-map.ps";
     }
 }
 else
@@ -107,7 +107,7 @@ foreach $switch (@{$switchlist})
              die("Couldn't write configuration for ".$switch." $!\n");
     print OUTPUT $cf;
     close OUTPUT;
-    open MAP, ">switch-maps/$switch-map.pdf" ||
+    open MAP, ">switch-maps/$switch-map.ps" ||
              die("Couldn't write port map for ".$switch." $!\n");
     print MAP $portmap;
     close MAP;

--- a/switch-configuration/config/scripts/switch_pinger
+++ b/switch-configuration/config/scripts/switch_pinger
@@ -8,19 +8,14 @@
 # I, J no network switch
 #
 
-require "./scripts/switch_template.pl";
+require "scripts/switch_template.pl";
 use Data::Dumper qw/Dumper/;
 
-set_debug_level(0);
+set_debug_level(7);
 
 # Parse switchtypes file and extract hierarchy from comments.
 open TYPES, "<switchtypes" || die("Failed to open \"switchtypes\" file for read.");
 my %Hierarchy = ();
-
-# Don't continue the loop on interrupt
-$SIG{INT}      = sub { exit 2; };
-$SIG{QUIT}     = sub { exit 2; };
-$SIG{TERM}     = sub { exit 2; };
 
 debug(7, "Empty Hierarchy: ".Dumper(%Hierarchy)."\n");
 foreach(<TYPES>)
@@ -71,7 +66,7 @@ foreach(sort(keys(%Hierarchy)))
             print " " x (10+(4*$i)), $i, " -> ";
             printf "Name: %-20s Addr: %-40s", ${$sw}[0], ${$sw}[1];
             debug(9, "Pinging ${$sw}[1]\n");
-            my $r = system('ping6 -c 1 -i 1 -W 1 -n -q  '.${$sw}[1].' >/dev/null');
+            my $r = system('ping6 -c 1 -W 1 -n -q -o '.${$sw}[1].' >/dev/null');
             if ($r == -1)
             {
                 print "\tNOSTART: $!";
@@ -80,12 +75,11 @@ foreach(sort(keys(%Hierarchy)))
             {
                 print "\tSIGNAL: ", ($r & 127), ($r & 128) ? " with " : " without ",
                     "coredump";
-                exit 2;
             }
             else
             {
                 my $rc = $r >> 8;
-                print (($rc) ? "..down..($rc) <-----------!!!!!!!!!!!!" : "...OK...");
+                print (($rc) ? "..down..($rc)\n" : "...OK...");
             }
             print "\n";
         }

--- a/switch-configuration/config/scripts/update_switches
+++ b/switch-configuration/config/scripts/update_switches
@@ -1,0 +1,111 @@
+#!/usr/bin/perl
+#
+# Push an updated copy of the configuration file to a switch and activate it.
+#
+
+# Not yet ready for use... Do not use
+die "Don't use this script yet. It's not ready"
+
+# Ideally this will eventually be obviated by ansible
+
+# Pull in dependencies
+use strict;
+require "./scripts/switch_template.pl";
+use FileHandle;
+use IPC::Open2;
+
+# Constants
+my @sections = (
+    "chassis",
+    "system",
+    "interfaces",
+    "snmp",
+    "forwarding-options",
+    "routing-options",
+    "protocols",
+    "firewall",
+    "ethernet-switching-options",
+    "vlans",
+);
+
+my $pipe_reader;
+my $pipe_writer;
+# Parse arguments (if any) or default to all switches
+##FIXME## Allow for exception syntax on command line
+my @list = @ARGV;
+if (scalar(@list) == 0)
+{
+    @list = get_switchlist();
+}
+
+# This works in three phases for each switch...
+#
+# Assertions:
+#   output/* contains valid configuratin files for each switch
+#   Switches are accessible via SSH at their management address in the switchtypes file.
+# Phase 1: Push new configuration file to switch.
+# Phase 2: Remove possibly conflicting old configuration remnants
+# Phase 3: Merge new configuration file and commit
+#
+foreach my $switch (@list)
+{
+    my ($Name, $Num, $MgtVL, $IPv6Addr, $Type) = get_switchtype($switch) ||
+        die("Error: Couldn't get type for $switch\n");
+
+    # Phase 1: Copy configuration to device
+    if (!-f "output/$Name.conf")
+    {
+        die("Error: Couldn't read configuration file for $NAME");
+    }
+    ##FIXME## Using system is an attrocious hack -- do something better
+    system("scp \"$output/$Name.conf\" $Name".":/tmp") ||
+        die("Failed to copy configuration to device $Name ($!)\n");
+
+    # Connect to the switch
+    pipe($pipe_reader, $pipe_writer);
+
+    $pid = fork;
+    if ( $pid ) {
+        ##FIXME## Currently using delays and making assumptions about time to get output back from switch
+        ##FIXME## Should switch to using an asynchronous select driven approach.
+
+        # Phase 2: Remove possibly conflicting old configuration remnants
+        my $response = check_switch_output(2);
+        print Writer "edit\n";
+        foreach(@sections)
+        {
+            $command_seq.= "delete $_\n";
+        }
+    
+        # Phase 3: Merge new configuration file and commit
+        $command_seq .= <<EOF;
+load merge /tmp/$Name.conf
+commit confirm 2
+EOF
+
+    }
+    else
+    {
+        # Child -- Connect to switch
+        exec("ssh $Name");
+    }
+}
+
+sub check_switch_output
+{
+    my $timeout   = shift @_;
+    my $response  = "";
+    my $startTime = time();
+    my $interval  = 25;
+    my $t = time() + $timeout;
+    my $first = 1;
+
+    my $sel = IO::Select->new;
+    $sel->add($pipe_reader);
+
+    while ($t > time() || $first)
+    {
+        # Make sure we make at least one attempt regardless of timeout
+        $first = 0;
+    }
+}

--- a/switch-configuration/config/types/Booth
+++ b/switch-configuration/config/types/Booth
@@ -3,6 +3,7 @@ TRUNK	ge-0/0/0	exSCALE-SLOW,exSCALE-FAST,exSpeaker,exInfra,exAVLAN, \
 				exSigns,exStaff,vendor_backbone
 TRUNK	ge-0/0/1	exSCALE-SLOW,exSCALE-FAST,exSpeaker,exInfra,exAVLAN, \
 				exSigns,exStaff,vendor_backbone
+RSRVD	6
 TRUNK	ge-0/0/8	exInfra,exSCALE-SLOW,exSCALE-FAST,exStaff	// AP
 TRUNK	ge-0/0/9	exInfra,exSCALE-SLOW,exSCALE-FAST,exStaff	// AP
 TRUNK	ge-0/0/10	exInfra,exSCALE-SLOW,exSCALE-FAST,exStaff	// AP
@@ -15,4 +16,4 @@ TRUNK	ge-0/0/16	exInfra,exSCALE-SLOW,exSCALE-FAST,exStaff	// AP
 TRUNK	ge-0/0/17	exInfra,exSCALE-SLOW,exSCALE-FAST,exStaff	// AP
 RSRVD	6
 VVLAN	16			// Dynamically assigned Vendor VLAN ports
-
+RSRVD	8

--- a/switch-configuration/config/types/Catwalk
+++ b/switch-configuration/config/types/Catwalk
@@ -89,3 +89,4 @@ TRUNK	ge-0/0/28	exSCALE-SLOW,exSCALE-FAST,exSpeaker,exInfra, \
 TRUNK	ge-0/0/29	exSCALE-SLOW,exSCALE-FAST,exSpeaker,exInfra, \
 			exAVLAN,exStaff, vendor_backbone \
 			exSigns,HAM_BRIDGE // 
+RSRVD	18

--- a/switch-configuration/config/types/cfAV
+++ b/switch-configuration/config/types/cfAV
@@ -1,4 +1,4 @@
-// Room Switch Template -- All conference rooms Conference Center
+// Room Switch Template -- AV Room Switch
 TRUNK	ge-0/0/0	cfSCALE-SLOW,cfSCALE-FAST,cfSpeaker,cfInfra,cfAVLAN,cfStaff,cfSigns,HAM_BRIDGE	// Uplink
 TRUNK	ge-0/0/1	cfSCALE-SLOW,cfSCALE-FAST,cfSpeaker,cfInfra,cfAVLAN,cfStaff,cfSigns,HAM_BRIDGE	// Downlink
 TRUNK	ge-0/0/2	cfInfra,cfSCALE-SLOW,cfSCALE-FAST,cfStaff,cfAVLAN				// AP

--- a/switch-configuration/config/types/cfIDF
+++ b/switch-configuration/config/types/cfIDF
@@ -19,4 +19,5 @@ TRUNK	ge-0/0/14	cfSCALE-SLOW,cfSCALE-FAST,cfSpeaker,cfInfra,cfAVLAN,cfStaff,cfSi
 TRUNK	ge-0/0/15	cfSCALE-SLOW,cfSCALE-FAST,cfSpeaker,cfInfra,cfAVLAN,cfStaff,cfSigns
 TRUNK	ge-0/0/16	cfSCALE-SLOW,cfSCALE-FAST,cfSpeaker,cfInfra,cfAVLAN,cfStaff,cfSigns
 TRUNK	ge-0/0/17	cfSCALE-SLOW,cfSCALE-FAST,cfSpeaker,cfInfra,cfAVLAN,cfStaff,cfSigns
-VLAN	cfCTF		4	// ge-0/0/{18-21}
+VLAN	cfCTF		6	// ge-0/0/{18-23}
+RSRVD	24

--- a/switch-configuration/config/types/cfRoom
+++ b/switch-configuration/config/types/cfRoom
@@ -17,4 +17,4 @@ VLAN	cfAVLAN		6	// ge-0/0/{22-27}
 VLAN	cfSpeaker	2	// ge-0/0/{28,29}
 VLAN	cfHam_N6S	1	// ge-0/0/30						// N6S Station
 VLAN	HAM_BRIDGE	1	// ge-0/0/31						// HAM Link N6S to Expo
-
+RSRVD	16

--- a/switch-configuration/config/types/exIDF
+++ b/switch-configuration/config/types/exIDF
@@ -34,6 +34,7 @@ TRUNK	ge-0/0/15	exSCALE-SLOW,exSCALE-FAST,exInfra,exStaff // AP
 TRUNK	ge-0/0/16	exSCALE-SLOW,exSCALE-FAST,exInfra,exStaff // AP
 TRUNK	ge-0/0/17	exSCALE-SLOW,exSCALE-FAST,exInfra,exStaff // AP
 VLAN	exSigns		4		// ge-0/0/{18-21}
+RSRVD	26
 FIBER	ge-0/1/0	exSCALE-SLOW,exSCALE-FAST,exSpeaker,exInfra, \
             		exAVLAN,exStaff, \
 			        exSigns,HAM_BRIDGE,exRegistration // Uplink to ExMDF Switch

--- a/switch-configuration/config/types/exRoom
+++ b/switch-configuration/config/types/exRoom
@@ -15,4 +15,4 @@ TRUNK	ge-0/0/17	exInfra,exSCALE-SLOW,exSCALE-FAST,exStaff				// AP
 VLAN	exSigns		4	// ge-0/0/{18-21}
 VLAN	exAVLAN		6	// ge-0/0/{22-27}
 VLAN	exSpeaker	2	// ge-0/0/{28,29}
-
+RSRVD	18

--- a/switch-configuration/config/types/registration
+++ b/switch-configuration/config/types/registration
@@ -1,6 +1,7 @@
 // Registration Desk Switch Template
 TRUNK	ge-0/0/0	exSCALE-SLOW,exSCALE-FAST,exSpeaker,exInfra,exAVLAN,exSigns,exStaff,exRegistration
 TRUNK	ge-0/0/1	exSCALE-SLOW,exSCALE-FAST,exSpeaker,exInfra,exAVLAN,exSigns,exStaff,exRegistration
+RSRVD	6
 TRUNK	ge-0/0/8	exInfra,exSCALE-SLOW,exSCALE-FAST,exStaff				// AP
 TRUNK	ge-0/0/9	exInfra,exSCALE-SLOW,exSCALE-FAST,exStaff				// AP
 TRUNK	ge-0/0/10	exInfra,exSCALE-SLOW,exSCALE-FAST,exStaff				// AP
@@ -12,7 +13,7 @@ TRUNK	ge-0/0/15	exInfra,exSCALE-SLOW,exSCALE-FAST,exStaff				// AP
 VLAN	exSigns		2					//ge-0/0/{16,17}
 RSRVD	2
 VLAN	exRegistration	20					//ge-0/0/20 thru ge-0/0/39
-RSRVD 7                   //ge-0/0/{40-46}
-VLAN  exInfra 1           //ge-0/0/47
+RSRVD	7                   //ge-0/0/{40-46}
+VLAN	exInfra		1           //ge-0/0/47
 
 

--- a/switch-configuration/todo
+++ b/switch-configuration/todo
@@ -1,17 +1,19 @@
 x   1.	Network Prefixes (assign and add to VLANS)
 K    2.	DNS -- scale.lan local domain, Authoritative servers for Show Network and in-addr/ip6.arpa
 x       Set up local servers
-        Produce data to feed to Kyle
-        Point RDNS to appropriate servers
+x       Produce data to feed to Kyle
+x       Point RDNS to appropriate servers
 x   3.	L3 Interfaces for management VLAN on switches
-    4.	Scripts to build configuration files
+x   4.	Scripts to build configuration files
 x       Switches
 x       Routers
     5.	Scripts for switch installation and maintenance (Robert)
-P   6.  PVLAN support for Expo floor
-x   7.  V6 only VLANs (Staff, Signs, Registration)
+            Started, but likely replace with ansible
+x   7.  V6 only VLANs (Staff, Signs, Registration (-Reg due to eBay))
     8.  Firewall Rules
+    9.  Troubleshoot LAN connectivity issues (SRX policy?)
 O  10.  Verify Tabs in TDF (vim on Mac tends to produce spaces instead)
+   11.  Add postscript port map generation to switch config builder
 
 #### Notes
 


### PR DESCRIPTION
## Description of PR
Fixes: #266 

Adds the ability to auto-generate printed switch maps (PostScript files) from configuration
Also includes backups of the router configuration files and some checkpointing of new scripts that aren't yet in use.

## Previous Behavior
This feature did not exist

## New Behavior
This feature works

## Tests
Manual review of a complete set of generated PS files
