### PR TITLE
[READY] CSV validation

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -74,6 +74,23 @@ jobs:
       - store_artifacts:
           path: /tmp/ipq806x
 
+  validate_datafiles:
+    docker:
+    - image: kylerisse/ansible-tester@sha256:f6a9507ec1d7a2dd0570cd88cb19746840c4f97e7618f53158616b9e1f5a3618
+    resource_class: small
+    working_directory: ~/scale-network/facts
+    steps:
+    - checkout:
+        path: ~/scale-network
+    
+    - run:
+        name: lint python files
+        command: pylint *.py
+    
+    - run:
+        name: data file unit tests
+        command: pytest -vv 
+
   ansible_tests:
     docker:
     - image: kylerisse/ansible-tester@sha256:f6a9507ec1d7a2dd0570cd88cb19746840c4f97e7618f53158616b9e1f5a3618
@@ -129,7 +146,10 @@ workflows:
   test_all:
     jobs:
       - gomplate_tests
-      - ansible_tests
+      - validate_datafiles
+      - ansible_tests:
+          requires:
+            - validate_datafiles
       - perl_lint
   weekly:
     triggers:

--- a/facts/datasource.py
+++ b/facts/datasource.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python3
+'''
+CSV validation library
+'''
+import ipaddress
+import re
+
+
+def isuntested(value):
+    # pylint: disable=unused-argument
+    ''' dummy function for untested values'''
+    return True
+
+
+def isvalidhostname(hostname):
+    '''
+    test for valid short hostname with letters, numbers, and dashes
+    cannot begin or end with a dash
+    '''
+    pattern = r"^([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]*[a-zA-Z0-9])$"
+    result = re.match(pattern, hostname)
+    if result:
+        return True
+    return False
+
+
+def isvalidip(addr):
+    '''test for valid v4 or v6 ip'''
+    try:
+        ipaddress.ip_address(addr)
+    except ValueError:
+        return False
+    return True
+
+
+def isvalidiporempty(val):
+    '''test for valid ip or empty'''
+    return isvalidip(val) or val == ''
+
+
+def isvalidmac(macaddr):
+    '''test for valid colon seperate mac address'''
+    pattern = r"^([0-9A-Fa-f]{2}[:]){5}([0-9A-Fa-f]{2})$"
+    result = re.match(pattern, macaddr)
+    if result:
+        return True
+    return False
+
+
+def isvalidwifi24chan(chan):
+    '''test for valid 2.4Ghz WiFi channel'''
+    return int(chan) >= 1 and int(chan) <= 11
+
+
+def isvalidwifi5chan(chan):
+    '''
+    test for valid 5Ghz WiFi channel
+    allows DFS channels
+    '''
+    return ((int(chan) >= 36 and int(chan) <= 144) and int(chan) %2 == 0) or \
+        ((int(chan) >= 149 and int(chan) <= 165) and int(chan) %2 == 1)
+
+
+def isint(val):
+    '''test for integer'''
+    return val.isdigit()
+
+
+def isintorempty(val):
+    '''test for integer or empty'''
+    return val.isdigit() or val == ''
+
+
+def test_csvfile(meta):
+    '''
+    test a file using the supplied metadata
+    structured as:
+    {
+        file: file's path
+        header: True if top row is a header, skip field validation
+        count: number of expected columns
+        cols: [] a list of validations functions to be applied to the
+                corresponding column index.
+    }
+    '''
+    fha = open(meta["file"])
+    lines = fha.readlines()
+    fha.close()
+    for linenum, line in enumerate(lines):
+        elems = re.split(',', line)
+        # check for expected number of columns
+        if len(elems) != meta["count"]:
+            return False, "invalid col count at line " + str(linenum)
+        # skip validators for header row
+        if meta["header"] and linenum == 0:
+            continue
+        # run the validators for each column
+        for i, val in enumerate(elems):
+            if not meta["cols"][i](val.rstrip('\n')):
+                return False, "invalid field " + val + " at line " + str(linenum)
+    return True, ""

--- a/facts/test_datasources.py
+++ b/facts/test_datasources.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python3
+'''
+CSV data source tests
+'''
+import datasource as ds
+
+
+def test_aplist_csv():
+    '''test aplist.csv'''
+    meta = {
+        "file": "./aps/aplist.csv",
+        "header": True,
+        "count": 9,
+        "cols": [
+            ds.isvalidhostname,
+            ds.isvalidmac,
+            ds.isvalidip,
+            ds.isvalidwifi24chan,
+            ds.isvalidwifi5chan,
+            ds.isint,
+            ds.isintorempty,
+            ds.isintorempty,
+            ds.isintorempty
+        ]
+    }
+    result, err = ds.test_csvfile(meta)
+    assert result, err
+
+
+def test_pilist_csv():
+    '''test pilist.csv'''
+    meta = {
+        "file": "./pi/pilist.csv",
+        "header": True,
+        "count": 2,
+        "cols": [
+            ds.isvalidhostname,
+            ds.isvalidip
+        ]
+    }
+    result, err = ds.test_csvfile(meta)
+    assert result, err
+
+
+def test_routerlist_csv():
+    '''test routerlist.csv'''
+    meta = {
+        "file": "./routers/routerlist.csv",
+        "header": True,
+        "count": 2,
+        "cols": [
+            ds.isvalidhostname,
+            ds.isvalidip
+        ]
+    }
+    result, err = ds.test_csvfile(meta)
+    assert result, err
+
+
+def test_serverlist_csv():
+    '''test serverlist.csv'''
+    meta = {
+        "file": "./servers/serverlist.csv",
+        "header": True,
+        "count": 5,
+        "cols": [
+            ds.isvalidhostname,
+            ds.isvalidmac,
+            ds.isvalidiporempty,
+            ds.isvalidiporempty,
+            ds.isuntested
+        ]
+    }
+    result, err = ds.test_csvfile(meta)
+    assert result, err


### PR DESCRIPTION
## Description of PR
Fixes #274 

- Adds CSV validation to Circle as a bare minimum to tackle #274 . Tests are executed in a generic pytest wrapper that I created which can be easily extended for new data sources, while leveraging the same validation functions across files. No need to change regexes everywhere or write a ton of code. The goal was to make adding new files as simple as created a standardized dictionary along with 2 lines of boilerplate code. 
- ansible_test ci phase is now dependent on the data validation. If data is bad, no need to continue testing inventory.
- This PR does not tackle any of the TSV files used by Ansible or Switch configuration, only CSV for now. I'd like to see if the team likes the approach to testing data files before moving on to that portion. I may have stretched the intention of pytest a bit too far and would love some constructive feedback on how useful others find it. 
- We can open another issue and PRs for the rest once we nail this part down.

## Previous Behavior
No CSV validation in CI pipeline

## New Behavior
CSV validation in CI pipeline

## Tests
- locally using pylint and pytest
- circle config validated with the `circleci validate config` command
- review of this PR to monitor CI workflow
