### PR TITLE
[WIP] Correctly handle case for single dns server

### DIFF
--- a/ansible/roles/dhcpserver/templates/dhcpd.conf.subnets.j2
+++ b/ansible/roles/dhcpserver/templates/dhcpd.conf.subnets.j2
@@ -7,7 +7,7 @@ subnet {{ vlan["ipv4prefix"] }} netmask {{ vlan["ipv4netmask"]}} {
 {% else %}
     range {{ vlan["ipv4dhcp2a"] }} {{ vlan["ipv4dhcp2b"] }};
 {% endif %}
-    option domain-name-servers {{ vlan["ipv4dns1"] }}, {{ vlan["ipv4dns2"] }}; 
+    option domain-name-servers {{ vlan["ipv4dns1"] + vlan["ipv4dns2"] | join(',')}};
     option routers {{ vlan["ipv4router"]}};
 }
 {% endif %}

--- a/ansible/roles/dhcpserver/templates/dhcpd6.conf.subnets.j2
+++ b/ansible/roles/dhcpserver/templates/dhcpd6.conf.subnets.j2
@@ -7,7 +7,7 @@ subnet6 {{ vlan["ipv6prefix"] }}/{{ vlan["ipv6bitmask"] }} {
 {% else %}
     range6 {{ vlan["ipv6dhcp2a"] }} {{ vlan["ipv6dhcp2b"] }};
 {% endif %}
-    option dhcp6.name-servers {{ vlan["ipv6dns1"] }}, {{ vlan["ipv6dns2"] }}; 
+    option dhcp6.name-servers {{ vlan["ipv6dns1"] + vlan["ipv6dns2"] | join(',')}};
 }
 {% endif %}
 {% endfor %}


### PR DESCRIPTION
## Description of PR
Since we are running only a partial network for the workparty (at least at this point) I ran into a case where a jinja template was always assuming two dns servers. I believe this fixes it but needs more testing

## Previous Behavior
* Assumes two dns servers for dhcp config

## New Behavior
* Handles cases for both single and multiple dns servers

## Tests
* Only tested the single case
* TBD on multiple once we get to scale18x
