### PR TITLE
[READY] issue-119 - Support new build target type for circle path

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,8 +45,9 @@ jobs:
           name: copy ar71xx artifacts
           command: |
               mkdir -p /tmp/ar71xx
-              cp /home/openwrt/scale-network/openwrt/build/source-ar71xx-*/bin/targets/ar71xx/generic/*factory.img /tmp/ar71xx
-              cp /home/openwrt/scale-network/openwrt/build/source-ar71xx-*/bin/targets/ar71xx/generic/sha256sums /tmp/ar71xx
+              # TODO: unify build refs with new ath79 type
+              cp /home/openwrt/scale-network/openwrt/build/source-ar71xx-*/bin/targets/ath79/generic/*factory.img /tmp/ar71xx
+              cp /home/openwrt/scale-network/openwrt/build/source-ar71xx-*/bin/targets/ath79/generic/sha256sums /tmp/ar71xx
 
       - store_artifacts:
           path: /tmp/ar71xx


### PR DESCRIPTION
## Description of PR
Fixes: #119 

This was fallout from #263 since I  forgot to update the path for the build artifacts from circle, this resulted in a failed build from saturday nights weekly build.

## Previous Behavior
* Failed build: https://circleci.com/gh/socallinuxexpo/scale-network/899

## New Behavior
* Build needs to have ath79 path instead of the old `ar17xx` path

## Tests
* At the moment it needs to be merged until the next weekly build takes place. But path confirmed to work on building locally.
