### PR TITLE
[READY] removes -W 1 from ping on osx

### DIFF
--- a/switch-configuration/config/scripts/switch_pinger
+++ b/switch-configuration/config/scripts/switch_pinger
@@ -66,7 +66,14 @@ foreach(sort(keys(%Hierarchy)))
             print " " x (10+(4*$i)), $i, " -> ";
             printf "Name: %-20s Addr: %-40s", ${$sw}[0], ${$sw}[1];
             debug(9, "Pinging ${$sw}[1]\n");
-            my $r = system('ping6 -c 1 -W 1 -n -q '.${$sw}[1].' >/dev/null');
+            if ($^O == "darwin")
+            {
+                my $r = system('ping6 -c 1 -n -q '.${$sw}[1].' >/dev/null');
+            }
+            else
+            {
+                my $r = system('ping6 -c 1 -W 1 -n -q '.${$sw}[1].' >/dev/null');
+            }
             if ($r == -1)
             {
                 print "\tNOSTART: $!";


### PR DESCRIPTION
## Description of PR
swith_pinger now detects if it's on OSX and removes -W 1 from the ping command

## Tests
Tested on osx and using an ubuntu vm
