### PR TITLE
Od.18.p8 -  flag to override_switches

### DIFF
--- a/switch-configuration/config/scripts/override_switches
+++ b/switch-configuration/config/scripts/override_switches
@@ -14,11 +14,15 @@ use strict;
 require "./scripts/switch_template.pl";
 use FileHandle;
 use IPC::Open2;
+use Getopt::Std;
+our $opt_l;
+getopts('l');
 
 STDERR->autoflush(1);   # Turn on autoflush for STDERR
 
 # Parse arguments (if any) or default to all switches
 ##FIXME## Allow for exception syntax on command line
+
 my @list = @ARGV;
 if (scalar(@list) == 0)
 {
@@ -28,6 +32,11 @@ if (scalar(@list) == 0)
 else
 {
     print "Have ", scalar(@list), " Switch names from command line.\n";
+}
+
+if ($opt_l && scalar(@list) != 1)
+{
+    print STDERR "Use of -l option requires exactly one switch be specified.\n";
 }
 
 # This works in three phases for each switch...
@@ -69,11 +78,26 @@ foreach my $switch (@list)
     }
     ##FIXME## Using system is an attrocious hack -- do something better
     print STDERR "Sending configuration file to $Name\n";
-    die("Failed to copy configuration to device $Name ($? : $!)\n") if 
-        system("scp \"output/$Name.conf\" $Name".":/tmp/new_config.conf");
+    if ($opt_l) # If -l is specified, install configuration via directly attached management port
+    {
+        die("Failed to copy configuration to device $Name ($? : $!)\n") if 
+            system("scp \"output/$Name.conf\" 192.168.255.76".":/tmp/new_config.conf");
+    }
+    else
+    {
+        die("Failed to copy configuration to device $Name ($? : $!)\n") if 
+            system("scp \"output/$Name.conf\" $Name".":/tmp/new_config.conf");
+    }
     
     print STDERR "Activating...\n";
-    open(JUNIPER, "| ssh $Name");
+    if ($opt_l) # If -l is specified, activate configuration via directly attached management port
+    {
+        open(JUNIPER, "| ssh 192.168.255.76");
+    }
+    else
+    {
+        open(JUNIPER, "| ssh $Name");
+    }
     print JUNIPER $SWITCH_COMMANDS;
     print STDERR "Finished sending commands to switch...\n";
     close JUNIPER || warn "Switch $Name Bad exit from SSH: $! $?\n";

--- a/switch-configuration/config/switchtypes
+++ b/switch-configuration/config/switchtypes
@@ -28,15 +28,15 @@ Rm211		19	503	2001:470:f325:503::200:19	cfRoom			//	I.9		Normal
 Rm104		20	503	2001:470:f325:503::200:20	cfRoom			//	I.9		Quiet
 NOC		21	503	2001:470:f325:503::200:21	cfIDF			//	I.2		Normal
 ExpoB1		22	103	2001:470:f325:103::200:22	Booth			//	W.9		Loud
-CTF1		23	504	2001:470:f325:504::200:23	cfCTF			//	I.9		Normal
+CTF1		23	504	2001:470:f325:504::200:23	cfCTF			//	I.4		Normal
 ExpoC1		24	103	2001:470:f325:103::200:24	Booth			//	W.9		Loud
 Rm106		25	503	2001:470:f325:503::200:25	cfRoom			//	I.9		Quiet
-CTF2		26	504	2001:470:f325:504::200:26	cfCTF			//	I.9		Normal
-CTF3		27	504	2001:470:f325:504::200:27	cfCTF			//	I.9		Normal
+CTF2		26	504	2001:470:f325:504::200:26	cfCTF			//	I.5		Normal
+CTF3		27	504	2001:470:f325:504::200:27	cfCTF			//	I.6		Normal
 ExpoA2		28	103	2001:470:f325:103::200:28	Booth			//	W.9		Loud
 ExpoB2		29	103	2001:470:f325:103::200:29	Booth			//	W.9		Loud
-CTF4		30	504	2001:470:f325:504::200:30	cfCTF			//	I.9		Normal
-Rm107		31	503	2001:470:f325:503::200:31	cfRoom			//	I.9		Quiet
+CTF4		30	504	2001:470:f325:504::200:30	cfCTF			//	I.7		Normal
+Rm107		31	503	2001:470:f325:503::200:31	cfRoom			//	I.2		Quiet
 RegDesk		32	103	2001:470:f325:103::200:32	registration		//	X.9		Normal
 ExpoC2		33	103	2001:470:f325:103::200:33	Booth			//	W.9		Normal
 ExpoA3		34	103	2001:470:f325:103::200:34	Booth			//	W.9		Loud
@@ -51,5 +51,5 @@ ExpoA5		42	103	2001:470:f325:103::200:42	Booth			//	W.9		Normal
 ExpoB5		43	103	2001:470:f325:103::200:43	Booth			//	W.9		Normal
 ExpoC5		44	103	2001:470:f325:103::200:44	Booth			//	W.9		Loud
 ExpoAW		45	103	2001:470:f325:103::200:45	Booth			//	W.9		Normal
-CTF5		46	504	2001:470:f325:504::200:46	cfCTF			//	I.9		Loud
+CTF5		46	504	2001:470:f325:504::200:46	cfCTF			//	I.8		Loud
 CTF6		47	504	2001:470:f325:504::200:47	cfCTF			//	I.9		Normal


### PR DESCRIPTION
## Description of PR
Adds -l flag to override_switches

## Previous Behavior
Could only send config to DNS name of switch

## New Behavior
Allows sending config via Management Port on the back of the switch

## Tests
Configured 6 switches using this method.
