### PR TITLE
redirect housekeeping info to stderr

### DIFF
--- a/openwrt/scripts/local/ap_command.sh
+++ b/openwrt/scripts/local/ap_command.sh
@@ -5,7 +5,7 @@ UP=()
 
 tally_down(){
   DOWN+=($1)
-  echo "Can't ping $1"
+  echo "Can't ping $1" >&2
 }
 
 tally_up(){
@@ -27,9 +27,9 @@ do
   fi
 done
 
-echo "------"
+(echo "------"
 echo "Down list: ${DOWN[@]}"
 echo "Down total: ${#DOWN[@]}"
 echo "------"
 echo "Up list: ${UP[@]}"
-echo "Up total: ${#UP[@]}"
+echo "Up total: ${#UP[@]}") >&2


### PR DESCRIPTION
this is so that you can capture the stdout to use for other things
without having the up/down/summary data captured in your output

## Description of PR
move housekeeping info from stdout to stderr so you can redirect stdout to capture the scripted output without capturing the housekeeping 

## Previous Behavior
housekkeping messages go to stdout and are mixed with the ap command output 

## New Behavior

couldn't ping messages and final summary data goes to stderr instead of stdout

## Tests
How was this PR tested?

in prod
