### PR TITLE
[READY] Autoflash on actual WNDR hardware

### DIFF
--- a/.github/workflows/trigger.yml
+++ b/.github/workflows/trigger.yml
@@ -1,0 +1,34 @@
+name: PR comments to trigger gitlab-ci jobs
+
+on:
+  issue_comment:
+    types: [created]
+
+jobs:
+  build:
+  # if comment string starts with "build"
+  # event must be a pull request (not a regular issue)
+    if: >
+      startsWith(github.event.comment.body, 'tux')
+      && startsWith(github.event.issue.pull_request.url, 'https://')
+      && github.actor == "sarcasticadmin"
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: 'Call gitlab API with event data'
+      id: event-data
+      run: |
+        set -eu
+        JOB=$( cut -d ' ' -f 2 <<< "${{ github.event.comment.body }}" )
+        JOB_ARG=$( cut -d ' ' -f 3 <<< "${{ github.event.comment.body }}" )
+        RESP=$(curl -sSf \
+          --url ${{ github.event.issue.pull_request.url }} \
+          --header 'content-type: application/json')
+        BRANCH=$(python3 -c "import sys, json; print(json.load(sys.stdin)['head']['ref'])" <<< "$RESP")
+        # Call gitlab
+        curl --request POST \
+          --form token=${{ secrets.GITLAB_TOKEN }}  \
+          --form "ref=$BRANCH" \
+          --form "variables[$JOB]=YES" \
+          --form "variables[WORMHOLE_CODE]=$JOB_ARG" \
+          https://gitlab.com/api/v4/projects/17362342/trigger/pipeline

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,45 @@
+---
+#shallow clones to speed up build
+variables:
+    GIT_DEPTH: 10
+
+# Keep all jobs within these 3 stages
+stages:
+  - test
+  - build
+  - integ
+
+# This build takes a long time and should be done
+# outside of initial PR CI testing
+openwrt-ar71xx-build:
+  stage: build
+  # Takes more than 1 hr to build on gitlab shared runners
+  timeout: 3 hours
+  only:
+    variables:
+      - $OPENWRT_BUILD == "YES"
+  image:
+    name: sarcasticadmin/openwrt-build@sha256:bab6de3f66f5365d866de646bb9fd1f2000061d1a5fe8a07b6a714661a9a9a63
+  script:
+    - cd ${CI_PROJECT_DIR}/openwrt
+    - TARGET=ar71xx make templates build-img 2>&1 | tee build.log | grep -i -E "^make.*(error|[12345]...Entering dir)"
+  artifacts:
+    paths:
+      - openwrt/build.log
+      - openwrt/build/source-ar71xx-*/bin/targets/ath79/generic/
+    expire_in: 1 week
+
+openwrt-3800ch-integ:
+  variables:
+    CI_DEBUG_TRACE: "false"
+  stage: integ
+  only:
+    variables:
+      - $OPENWRT_INTEG == "YES"
+  tags:
+    - openwrt
+  script:
+    - cd ${CI_PROJECT_DIR}/openwrt/
+    - sudo -s ./autoflash
+    - cd ${CI_PROJECT_DIR}/tests/serverspec
+    - rake spec TEST_TYPE=openwrt TARGET_HOST=192.168.254.100

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -40,6 +40,7 @@ openwrt-3800ch-integ:
     - openwrt
   script:
     - cd ${CI_PROJECT_DIR}/openwrt/
+    - ${CI_PROJECT_DIR}/openwrt/scripts/local/gather-artifact.sh
     - sudo -s ./autoflash
     - cd ${CI_PROJECT_DIR}/tests/serverspec
     - rake spec TEST_TYPE=openwrt TARGET_HOST=192.168.254.100

--- a/facts/secrets/ar71xx-openwrt-example.yaml
+++ b/facts/secrets/ar71xx-openwrt-example.yaml
@@ -1,18 +1,14 @@
 # scale
 root_hash: "$1$zh0PjBbB$f9aFGDX9vNYNdSRexhib8/"
-
-# Bump for each year for scale
 scale: 18
 
 rsyslog:
-  server: 'server2.scale.lan'
+  server: 'loghost.scale.lan'
   port: '514'
   protocol: 'udp'
 
 zabbix:
-  server: 'server3.scale.lan'
-
-nameserver: '8.8.8.8'
+  server: 'zabbix.scale.lan'
 
 ntp:
   server: '0.openwrt.pool.ntp.org'
@@ -27,31 +23,80 @@ wired:
       enable_vlan: '1'
       enable_vlan4k: '1'
       blinkrate: '2'
-  switch_vlans: {}
+  switch_vlans:
+    - device: 'rtl8366s'
+      vlan: '100'
+      ports: '0t 3t 5t'
+    - device: 'rtl8366s'
+      vlan: '500'
+      ports: '0t 3t 5t'
+    - device: 'rtl8366s'
+      vlan: '101'
+      ports: '0t 3t 5t'
+    - device: 'rtl8366s'
+      vlan: '501'
+      ports: '0t 3t 5t'
+    - device: 'rtl8366s'
+      vlan: '102'
+      ports: '0t 3t 5t'
+    - device: 'rtl8366s'
+      vlan: '502'
+      ports: '0t 3t 5t'
+    - device: 'rtl8366s'
+      vlan: '103'
+      ports: '0t 3t 5t'
+    - device: 'rtl8366s'
+      vlan: '503'
+      ports: '0t 3t 5t'
+    - device: 'rtl8366s'
+      vlan: '105'
+      ports: '0t 3t 5t'
+    - device: 'rtl8366s'
+      vlan: '505'
+      ports: '0t 3t 5t'
+    - device: 'rtl8366s'
+      vlan: '107'
+      ports: '0t 1 2 3t 5t'
+    - device: 'rtl8366s'
+      vlan: '507'
+      ports: '0t 1 2 3t 5t'
+    - device: 'rtl8366s'
+      vlan: '108'
+      ports: '0t 3t 5t'
+    - device: 'rtl8366s'
+      vlan: '508'
+      ports: '0t 3t 5t'
+
 # Ports on netgears are reversed.
 # i.e. physical port 4 maps to 0 in openwrt
   networks:
     # interface names cant have special characters
     - name: 'mgmt'
-      ifname: 'eth1'
+      ifname: 'eth0.103 eth0.503 eth1.103 eth1.503'
       type: 'bridge'
       proto: 'dhcp'
+      reqopts: '224 225'
     - name: 'mgmt6'
       ifname: '@mgmt'
       proto: 'dhcpv6'
       reqprefix: 'no'
     - name: 'staffwifi'
-      ifname: 'eth1.108 eth1.508'
+      ifname: 'eth0.108 eth0.508 eth1.108 eth1.508'
       type: 'bridge'
       proto: 'none'
     - name: 'scaleslow'
-      ifname: 'eth1.100 eth1.500'
+      ifname: 'eth0.100 eth0.500 eth1.100 eth1.500'
       type: 'bridge'
       proto: 'none'
     - name: 'scalefast'
-      ifname: 'eth1.101 eth1.501'
+      ifname: 'eth0.101 eth0.501 eth1.101 eth1.501'
       type: 'bridge'
       proto: 'none'
+    - name: 'backdoor'
+      ifname: 'eth1.3517'
+      proto: 'static'
+      ipaddr: '192.168.255.76'
+      netmask: '255.255.255.0'
 
 wireless:
   radios:

--- a/openwrt/Makefile
+++ b/openwrt/Makefile
@@ -78,7 +78,7 @@ build-img: $(BUILD_DIR)/$(IMAGEBUILDER)/.config
 	  && echo SCALE_VER=$(shell git rev-parse HEAD) > $(TMPL_SRC_DIR)/etc/scale-release \
 	  && echo OPENWRT_VER=$(OPENWRT_VER) >> $(TMPL_SRC_DIR)/etc/scale-release \
 	  && $(MAKE) download \
-	  && $(MAKE) V=s -j 4
+	  && $(MAKE) V=s -j 2
 
 $(BUILD_DIR):
 	mkdir -p $(BUILD_DIR)

--- a/openwrt/autoflash
+++ b/openwrt/autoflash
@@ -1,0 +1,50 @@
+#!/usr/bin/env expect
+log_file -noappend /tmp/autoflash.log
+spawn gpioctl -c 2 OUT
+spawn gpioctl -c 3 OUT
+# Off
+spawn gpioctl -p 2 1
+spawn sudo service isc-dhcpd onestop
+spawn /usr/sbin/arp -d 192.168.254.100
+sleep 5
+# on
+spawn ifconfig ue1 192.168.1.2 255.255.255.0
+spawn gpioctl -p 2 0
+spawn gpioctl -p 3 0
+spawn /usr/sbin/arp -d 192.168.1.1
+spawn ping -n 192.168.1.1
+expect {
+  Unreachable exp_continue
+  "taking countermeasures"
+}
+close
+# Wait for AP light to be blinking green
+sleep 30
+spawn gpioctl -p 3 1
+spawn tftp 192.168.1.1
+expect tftp
+send "bin\n"
+expect tftp
+send "put factory.img\n"
+expect {
+  Sent exp_continue
+  tftp {
+    send "quit\n\n"
+  }
+}
+close
+spawn /usr/sbin/arp -d 192.168.1.1
+spawn sudo ifconfig ue1.503 create
+spawn sudo ifconfig ue1.503 inet 192.168.254.1 255.255.255.0
+spawn sudo service isc-dhcpd onestart
+sleep 5
+spawn ping -n 192.168.254.100
+expect {
+  Unreachable exp_continue
+  ping exp_continue
+  PING exp_continue
+  "taking countermeasures"
+  "64 bytes"
+}
+close
+send_user "\n\nFinished flashing AP!\n\n"

--- a/openwrt/scripts/local/dhcpd_net.sh
+++ b/openwrt/scripts/local/dhcpd_net.sh
@@ -1,11 +1,18 @@
 #!/bin/sh
 
+#####
+#
+# dhcpd service setup during flashing
+# this currently has issue being called via the gitlab-runner
+# so only use this for local testing for now
+#
+#####
+
 usage(){
   cat << EOF
 usage: $(basename $0) [OPTIONS] ARGS
 
-
-Simple template of getopts
+dhcpd service setup during flashing
 
 OPTIONS:
   -h      Show this message
@@ -47,12 +54,12 @@ option domain-name "example.org";
 option domain-name-servers 8.8.8.8, 8.8.4.4;
 option subnet-mask 255.255.255.0;
 
-default-lease-time 600;
-max-lease-time 72400;
+default-lease-time 30;
+max-lease-time 60;
 ddns-update-style none;
 
 subnet 192.168.254.0 netmask 255.255.255.0 {
-  range 192.168.254.100 192.168.254.200;
+  range 192.168.254.100 192.168.254.100;
   option routers 192.168.254.1;
 }
 EOF

--- a/openwrt/scripts/local/gather-artifact.sh
+++ b/openwrt/scripts/local/gather-artifact.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+#####
+#
+# Compile all the ways to grab artifacts for openwrt imgs
+# with the goal of setting update factory.img for flashing
+#
+#####
+
+if [ -n "${WORMHOLE_CODE}" ]; then
+  # Assumes runner has magic-wormhole installed
+  wormhole receive --accept-file ${WORMHOLE_CODE} -o factory.img
+else
+  echo "TODO: other things with artifacts"
+  #curl https://gitlab.com/socallinuxexpo/scale-network/-/jobs/artifacts/${BRANCH}/download?job=${OPENWRT_BUILD_JOB}
+fi

--- a/tests/serverspec/spec/spec_helper.rb
+++ b/tests/serverspec/spec/spec_helper.rb
@@ -35,6 +35,19 @@ else
   # But ok to assume this user for now
   options[:user] = 'ubuntu'
 end
+
+if ENV['ASK_LOGIN_PASSWORD']
+  begin
+    require 'highline/import'
+  rescue LoadError
+    fail "highline is not available. Try installing it."
+  end
+
+  options[:password] = ask("\nEnter login password: ") { |q| q.echo = false }
+else
+  options[:password] = ENV['LOGIN_PASSWORD']
+end
+
 # Set environment variables
 # set :env, :LANG => 'C', :LC_MESSAGES => 'C'
 

--- a/tests/unit/openwrt/golden/ar71xx/etc/config/network.0
+++ b/tests/unit/openwrt/golden/ar71xx/etc/config/network.0
@@ -19,11 +19,82 @@ config switch
         
 
 
+config switch_vlan
+        option device 'rtl8366s'
+        option ports '0t 3t 5t'
+        option vlan '100'
+        
+config switch_vlan
+        option device 'rtl8366s'
+        option ports '0t 3t 5t'
+        option vlan '500'
+        
+config switch_vlan
+        option device 'rtl8366s'
+        option ports '0t 3t 5t'
+        option vlan '101'
+        
+config switch_vlan
+        option device 'rtl8366s'
+        option ports '0t 3t 5t'
+        option vlan '501'
+        
+config switch_vlan
+        option device 'rtl8366s'
+        option ports '0t 3t 5t'
+        option vlan '102'
+        
+config switch_vlan
+        option device 'rtl8366s'
+        option ports '0t 3t 5t'
+        option vlan '502'
+        
+config switch_vlan
+        option device 'rtl8366s'
+        option ports '0t 3t 5t'
+        option vlan '103'
+        
+config switch_vlan
+        option device 'rtl8366s'
+        option ports '0t 3t 5t'
+        option vlan '503'
+        
+config switch_vlan
+        option device 'rtl8366s'
+        option ports '0t 3t 5t'
+        option vlan '105'
+        
+config switch_vlan
+        option device 'rtl8366s'
+        option ports '0t 3t 5t'
+        option vlan '505'
+        
+config switch_vlan
+        option device 'rtl8366s'
+        option ports '0t 1 2 3t 5t'
+        option vlan '107'
+        
+config switch_vlan
+        option device 'rtl8366s'
+        option ports '0t 1 2 3t 5t'
+        option vlan '507'
+        
+config switch_vlan
+        option device 'rtl8366s'
+        option ports '0t 3t 5t'
+        option vlan '108'
+        
+config switch_vlan
+        option device 'rtl8366s'
+        option ports '0t 3t 5t'
+        option vlan '508'
+        
 
 
 config interface 'mgmt'
-        option ifname 'eth1'
+        option ifname 'eth0.103 eth0.503 eth1.103 eth1.503'
         option proto 'dhcp'
+        option reqopts '224 225'
         option type 'bridge'
         
 config interface 'mgmt6'
@@ -32,19 +103,25 @@ config interface 'mgmt6'
         option reqprefix 'no'
         
 config interface 'staffwifi'
-        option ifname 'eth1.108 eth1.508'
+        option ifname 'eth0.108 eth0.508 eth1.108 eth1.508'
         option proto 'none'
         option type 'bridge'
         
 config interface 'scaleslow'
-        option ifname 'eth1.100 eth1.500'
+        option ifname 'eth0.100 eth0.500 eth1.100 eth1.500'
         option proto 'none'
         option type 'bridge'
         
 config interface 'scalefast'
-        option ifname 'eth1.101 eth1.501'
+        option ifname 'eth0.101 eth0.501 eth1.101 eth1.501'
         option proto 'none'
         option type 'bridge'
+        
+config interface 'backdoor'
+        option ifname 'eth1.3517'
+        option ipaddr '192.168.255.76'
+        option netmask '255.255.255.0'
+        option proto 'static'
         
 
 

--- a/tests/unit/openwrt/golden/ar71xx/etc/rsyslog.conf
+++ b/tests/unit/openwrt/golden/ar71xx/etc/rsyslog.conf
@@ -5,4 +5,4 @@ $ActionFileDefaultTemplate RSYSLOG_TraditionalFileFormat
 
 #/var/log/messages
 
-@server2.scale.lan:514
+@loghost.scale.lan:514

--- a/tests/unit/openwrt/golden/ar71xx/etc/zabbix_agentd.conf
+++ b/tests/unit/openwrt/golden/ar71xx/etc/zabbix_agentd.conf
@@ -13,8 +13,8 @@ HostMetadata=ap
 RefreshActiveChecks=60
 
 # List of comma delmited IP addressses of Zabbix servers
-Server=server3.scale.lan
-ServerActive=server3.scale.lan
+Server=zabbix.scale.lan
+ServerActive=zabbix.scale.lan
 
 # How often list of active checks is refreshed, in seconds.
 RefreshActiveChecks=60


### PR DESCRIPTION
## Description of PR
Putting up some of the work that was done during 18x around `autoflashing` the wndr3800ch.

There are a lot of things going on in the MR so Ill try to cover all of the methods to my madness:



## Previous Behavior
* Had to do flashing manually
* Configs for wndr builds didnt reflect conference configs

## New Behavior

1. First and foremost we have successfully integrated automated flash of the WNDR 3800ch that we modified during Scale 18x. It is being done via a gitlab-ci runner running on a raspberry pi 2 that we had laying around. Thats controlling a relay to toggle the power and the GPIO pins to "press" the reset button. This is all coordinated via `openwrt/autoflash` script being called via the gitlab ci pipeline.

2. The `gitlab-ci` pipeline is broken down into two components: `openwrt-ar71xx-build` and `openwrt-3800ch-integ`. For now `openwrt-ar71xx-build` should be ignored since the shared-runners provided by gitlab lack the oomph to build openwrt in a timely manner. It took about 2 hr 45min: https://gitlab.com/socallinuxexpo/scale-network/pipelines/139993816 . The logs from the job are also limited to 4mb: https://gitlab.com/gitlab-com/support-forum/issues/2790 so I ended up piping the output to `tee | grep` and just checking for errors. The build artifacts will include a complete `build.log` instead.

3. Going on the more relevant pieces of this PR: `openwrt-3800ch-integ` is the gitlab-ci job that needs to be triggered with the following environment variables: `OPENWRT_INTEG` set to `YES` and `WORMHOLE_CODE` set to a magic wormhole code (this will be optional soon). The idea here is to only trigger this job when one is ready and it allows the ability for the user to pass in a img of there choosing to `openwrt-3800ch-integ` which has always been the most awkward part of this process.

So what you can now do is something like pre-triggering the pipeline:

```
wormhole send openwrt-ath79-generic-netgear_wndr3800ch-squashfs-factory.img
On the other computer, please run: wormhole receive (or wormhole-william recv)
Wormhole code is: 6-bifocals-endow
```

Then trigger the pipeline in the UI setting the following setting:

```
Branch: Set your branch to the one that matches the PR
Environment variables: `OPENWRT_INTEG` = `YES` and `WORMHOLE_CODE` = `6-bifocals-endow`
Select run pipeline
```
Then the job will fire running `openwrt-3800ch-integ` on the pi and pull the image via magic wormhole.

Eventually I will add logic to `gather-artifact.sh` so that if `WORMHOLE_CODE` is not defined then it just uses the last image build on the current branch or lastest build off `master`. This will require us to reconcile where the builds are generated from (circleci, gitlab, etc.).

3. I am introducing a github actions workflow bot Im calling `tux` (open to suggestions here on the name). I thought would be useful to help trigger some of these builds like  `openwrt-3800ch-integ` in gitlab and do other tasks related to PRs in the future. This seems to be the easiest way to act on comment in a PR and that trigger other APIs. I dont think this gets registered until it lands in `master`: https://github.community/t5/GitHub-Actions/Workflow-files-only-picked-up-from-master/td-p/30348 but the idea would be in a PR you can comment: `tux openwrt-integ` which would trigger the workflow for the autoflash discussing in Item 2 against the existing branch. I testing the POST via curl directly, see below.

4. Reconcile the wndr default config to reflect what we have used in past Scale conference deployments. This is exactly what we used during scale-18x minus the root password and wifi passwords.

## Tests
* Successfully passed existing CI tests
* Gitlab private runner job: `openwrt-3800ch-integ` works as expected and includes `serverspec` tests: https://gitlab.com/socallinuxexpo/scale-network/pipelines/140025531
* Gitlab shared runner job: https://gitlab.com/socallinuxexpo/scale-network/pipelines/139993816 works but not going to be used until solutions to speed up are figured out. 
* Github actions test: `curl --request POST --form token=<redacted> --form "ref=sa/autoflash" --form "variables[OPENWRT_INTEG]=YES" --form "vari
ables[WORMHOLE_CODE]=7-detergent-pluto"  https://gitlab.com/api/v4/projects/17362342/trigger/pipeline` triggers the pipeline and works as expected. This is a close as I can test until the actions lands in `master`. See CI results: https://gitlab.com/socallinuxexpo/scale-network/-/jobs/527325894