### PR TITLE
[READY] - Adding ref to dwg PCC CAD diagrams from Ilan

### DIFF
--- a/MAPS.md
+++ b/MAPS.md
@@ -9,6 +9,8 @@ Maps of the layout for SCaLE 16x/17x at Pasadena Convention Center maps can be f
 * [ballroom-diagram-5](http://sarcasticadmin.com/scale/maps/16x/ballroom-diagram-5-scale.pdf)
 * [ballroom-diagram-6](http://sarcasticadmin.com/scale/maps/16x/ballroom-diagram-6-scale.pdf)
 * [expohall-diagram-1](http://sarcasticadmin.com/scale/maps/17x/expohall-diagram-1-scale.pdf)
+* [Zpasadena-cc-exp_GES.dwg](http://sarcasticadmin.com/scale/maps/Zpasadena-cc-exp_GES.dwg)
+* [Zpasadena-cc_GES.dwg](http://sarcasticadmin.com/scale/maps/Zpasadena-cc_GES.dwg)
 
 ## Updates
 


### PR DESCRIPTION
## Description of PR

Originated from @irabinovitch via https://github.com/socallinuxexpo/scale-network/pull/363 but would prefer to keep these binaries out of the code repo and have them hosted in s3 until #286 is dealt with.

At the time of adding these files to s3 there sha256sums are as follows:

```
bf4566e553a14e35dc6fcb3b876dbd898fc44e183c3039c0c9486a9d14df43f4 Zpasadena-cc-exp_GES.dwg
fd6f85989ce7a87d6f0027feff672218052b2b4f859c7ec62463edf9f11b21bc Zpasadena-cc_GES.dwg
```

Excluding the following from the original PR https://github.com/socallinuxexpo/scale-network/pull/363 since it was a duplicate:

```
fd6f85989ce7a87d6f0027feff672218052b2b4f859c7ec62463edf9f11b21bc pasadena-cc-lower-and-upper-level_GES.dwg
```

## Previous Behavior
- Missing these CAD files

## New Behavior
- CAD drawings pushed to s3
- Links to CADS add to `MAPS.md`

## Tests
All links work to download the appropriate files
