### PR TITLE
[READY] - Building openwrt imgs using github actions

### DIFF
--- a/.github/workflows/openwrt-build.yml
+++ b/.github/workflows/openwrt-build.yml
@@ -1,0 +1,35 @@
+---
+on:
+  workflow_dispatch:
+  schedule:
+    # * is a special character in YAML so you have to quote this string
+    - cron:  '15 3 * * 0'
+
+jobs:
+  build:
+    name: Building openwrt img
+    runs-on: ubuntu-18.04
+    strategy:
+      matrix:
+        target: ["ar71xx", "ipq806x"]
+    container:
+      image: sarcasticadmin/openwrt-build@sha256:bab6de3f66f5365d866de646bb9fd1f2000061d1a5fe8a07b6a714661a9a9a63
+      # Since user is openwrt and gets 1001 from inside container
+      options: --user 1001
+    steps:
+      - uses: actions/checkout@v1
+        with:
+          ref: ${{ env.BRANCH }}
+      - name: Build openwrt
+        run: |
+          cd ${GITHUB_WORKSPACE}/openwrt
+          TARGET=${{ matrix.target }} make templates build-img 2>&1 | tee ${{ matrix.target }}-build.log
+      - name: 'Upload Artifact'
+        uses: actions/upload-artifact@v2
+        with:
+          name: artifacts
+          # Cant use relative pathing .. or . for artifacts action
+          path: |
+            /__w/action_sanity/scale-network/openwrt/${{ matrix.target }}-build.log
+            /__w/action_sanity/scale-network/openwrt/build/source-${{ matrix.target }}-*/bin/targets/*/generic/
+          retention-days: 30


### PR DESCRIPTION
## Description of PR

Part of: #377 

As an alternative to our existing circleci builds we current have:
https://github.com/socallinuxexpo/scale-network/blob/a745d0437f1f02da9f290354dda09ab8370eae6b/.circleci/config.yml#L29-L76

There seems to be a good amount of usefulness to doing this in github actions:

1. We get to trigger the builds via `workflow_dispatch` (https://github.blog/changelog/2020-07-06-github-actions-manual-triggers-with-workflow_dispatch/) for any given branch in addition to doing periodic `cron` builds weekly like we current have in circleci. Anyone write access to the repo can now trigger this `workflow_dispatch`. **Example:** if a team member makes a change in a PR, they can trigger this workflow (a build) and then make artifacts for testing. Previously you would have had to do that build locally or after we merge to master with how circleci is currently configured.
1. Authentication is native to github while within the workflows
1. Build times for our images are more or less the same from cicleci what I can tell +-10min (seems to depend on time of day for the github shared runners but there specs are comprebable to circleci: https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners#supported-runners-and-hardware-resources

If this is approved by the wider team then I think we would leave this in place for a few weeks to see how it compares to circleci. I have some other additional changes coming into to the openwrt image so I can test the build process triggers then.

Eventually these `workflow_dispatch` builds will be able to utilized by the `/tux` command to trigger via pr comments like our tests.

## Previous Behavior
- openwrt image builds only happened via circleci crons

## New Behavior
- openwrt image builds via github actions in addition to existing circleci crons

## Tests
- Tested this in a separate repo (private) per the limitation of some of this needed to be in the default branch to run
![Screen Shot 2021-07-23 at 1 24 12 AM](https://user-images.githubusercontent.com/30531572/126755985-ba511ac5-c804-4a9a-9013-e916161abd51.png)
