### PR TITLE
[READY] - Fix artifact uploads for openwrt builds

### DIFF
--- a/.github/workflows/openwrt-build.yml
+++ b/.github/workflows/openwrt-build.yml
@@ -20,16 +20,23 @@ jobs:
       - uses: actions/checkout@v1
         with:
           ref: ${{ env.BRANCH }}
-      - name: Build openwrt
+      - name: 'Build openwrt'
         run: |
-          cd ${GITHUB_WORKSPACE}/openwrt
-          TARGET=${{ matrix.target }} make templates build-img 2>&1 | tee ${{ matrix.target }}-build.log
-      - name: 'Upload Artifact'
+          cd openwrt
+          TARGET=${{ matrix.target }} make templates build-img package 2>&1 | tee ${{ matrix.target }}-build.log
+      - name: 'Upload openwrt build artifact tarball'
         uses: actions/upload-artifact@v2
         with:
-          name: artifacts
+          name:  ${{ matrix.target }}-openwrt-build-artifacts
           # Cant use relative pathing .. or . for artifacts action
+          # Also dont bother with '${{ github.workspace }}'
           path: |
-            /__w/action_sanity/scale-network/openwrt/${{ matrix.target }}-build.log
-            /__w/action_sanity/scale-network/openwrt/build/source-${{ matrix.target }}-*/bin/targets/*/generic/
+            openwrt/build/artifacts/*.tar.gz
+          retention-days: 30
+      - name: 'Upload openwrt build log'
+        uses: actions/upload-artifact@v2
+        with:
+          name:  ${{ matrix.target }}-openwrt-buildlog
+          path: |
+            openwrt/*build.log
           retention-days: 30

--- a/.github/workflows/trigger.yml
+++ b/.github/workflows/trigger.yml
@@ -59,7 +59,7 @@ jobs:
         echo ::set-output name=pipeline::$PIPELINE
     - name: Create status PR Comment
       if: ${{ success() }}
-      uses: jungwinter/comment@5acbb  # SHA ref v1.0.2
+      uses: jungwinter/comment@5acbb5699b76c111821fb2540534cb339e2b32ed  # SHA ref v1.0.2
       with:
         type: create
         body: |
@@ -69,7 +69,7 @@ jobs:
         issue_number: ${{ github.event.issue.number }}
     - name: Create status PR comment failure
       if: ${{ failure() }}
-      uses: jungwinter/comment@5acbb  # SHA ref v1.0.2
+      uses: jungwinter/comment@5acbb5699b76c111821fb2540534cb339e2b32ed  # SHA ref v1.0.2
       with:
         type: create
         body: |

--- a/openwrt/Makefile
+++ b/openwrt/Makefile
@@ -80,6 +80,14 @@ build-img: $(BUILD_DIR)/$(IMAGEBUILDER)/.config
 	  && $(MAKE) download \
 	  && $(MAKE) V=s -j 2
 
+# Common way to package up the build artifacts due to the various limits of
+# some CI tools
+package:
+	mkdir -p $(BUILD_DIR)/artifacts
+	# TODO: Look into striping path to only be from targets/ onward
+	tar zcvf $(BUILD_DIR)/artifacts/$(TARGET)-$(SHORT_VER)-artifacts.tar.gz \
+	  -C $(BUILD_DIR)/$(IMAGEBUILDER)/bin/targets/*/generic ./
+
 $(BUILD_DIR):
 	mkdir -p $(BUILD_DIR)
 

--- a/openwrt/autoflash
+++ b/openwrt/autoflash
@@ -13,7 +13,8 @@ file mkdir $workdir
 file attributes $workdir -owner gitlab-runner
 log_file -noappend $workdir/autoflash.log
 spawn gpioctl -c 2 OUT
-spawn gpioctl -c 3 OUT
+# set Pulldown to keep pin 2 from effecting pin 3
+spawn gpioctl -c 3 OUT PD
 
 # Off
 spawn gpioctl -p 2 1

--- a/openwrt/include/tests.mk
+++ b/openwrt/include/tests.mk
@@ -1,12 +1,25 @@
+GITLAB_TOKEN ?= empty
+# gitlab mirror project id
+GITLAB_PROJECT ?= 17362342
+WORMHOLE_CODE ?= empty
+
 REPO_ROOT := $(shell git rev-parse --show-toplevel)
+REPO_BRANCH := $(shell git rev-parse --abbrev-ref HEAD)
 
 golden-test:
 	@cd $(REPO_ROOT)/tests/unit/openwrt && \
 	    sh test.sh -t ar71xx && \
 	    sh test.sh -t ipq806x
 
-
 golden-update:
 	@cd $(REPO_ROOT)/tests/unit/openwrt && \
 	    sh test.sh -u -t ar71xx && \
 	    sh test.sh -u -t ipq806x
+
+autoflash-test:
+	curl --request POST \
+	  --form token=$(GITLAB_TOKEN) \
+	  --form "ref=$(REPO_BRANCH)" \
+	  --form "variables[OPENWRT_INTEG]=YES" \
+	  --form "variables[WORMHOLE_CODE]=$(WORMHOLE_CODE)" \
+	  https://gitlab.com/api/v4/projects/$(GITLAB_PROJECT)/trigger/pipeline


### PR DESCRIPTION
## Description of PR
Forget to remove my test repo (appropriately named: `actions_sanity`) from the artifact path. As a result the new build job in actions succeeded but not artifacts were found: https://github.com/socallinuxexpo/scale-network/actions/runs/1070055388

We should not have to depend on the various CI tools approaches to package up artifacts. Adding a new make recipe to ensure that its now common for the openwrt side of things. The results of the build can now be found in openwrt/build/artifacts

The upload workflow within github actions leaves a lot to be desired. There were many initial assumptions with GITHUB_WORKSPACE, paths from test repos, etc. that were originally left here. These more or less have been vetted now and this is the best result I have found to date for `scale-network`.

I am watching a few upstream stories in the upload actions repo just to see if it improves things for us in the near term:
      - https://github.com/actions/upload-artifact/issues/109
      - https://github.com/actions/upload-artifact/issues/21

Lastly, I included a fix for a floating pin on the `autoflash` raspberry pi. I noticed some inconsistent behavior where toggling GPIO pin 2 would effect pin 3 due to pin 3 being floating (At least thats my theory). This would result it in the reset button being held open when it should have been shut. This fixes the behavior and makes the flashing process much more consistent.

## Previous Behavior
- Artifact path was point to incorrect path
- Pin 3 was floating on `autoflash` pi configuration

## New Behavior
- Add separate make recipe for packaging `make package` which should be run post build of openwrt
- Adding github actions upload workflows to account for new`make package` location `openwrt/build/artifacts`
- Adding github actions upload workflow for separate build log
- Setting pin 3 to `pulldown` during `autoflash` since I was getting some inconsistency during my autoflash tests. I know this is somewhat unrelated but wanted to include it here since its part of the whole build openwrt process

## Tests
-  ~~Testing path and artifacts by trigger the workflow manually via the `workflow_dispatch` since `I think` it should read the workflow file from this branch~~ Confirmed, I am able to iterate on this workflow (`workflow_dispatch`) now that its initial workflow .yaml is in `master`

- Temporarily created a job so that I didnt have to wait the 1.5hrs for the openwrt build:

```
  - name: 'Build openwrt'
        run: |
          echo "hi from here" > ${{ matrix.target }}-build.log
          mkdir -p build/source-${{ matrix.target }}-b4c0d37/bin/targets/ath79/generic/
          touch build/source-${{ matrix.target }}-b4c0d37/bin/targets/ath79/generic/test.img
          ls -lah build/source-${{ matrix.target }}-b4c0d37/bin/targets/ath79/generic/
          TARGET=${{ matrix.target }} make package
```
> Was able to confirm this works as expected from this small test: https://github.com/socallinuxexpo/scale-network/actions/runs/1180574666

- Ran actual openwrt build triggered via `workflow_dispatch` https://github.com/socallinuxexpo/scale-network/actions/runs/1180629571 . This was a success and then passed the artifacts onto the `autoflash` (see the next bullet). shasums were also good from the tarball that was generated:

```
$ tar zxvf ar71xx-b4c0d37-artifacts.tar.gz
...
$ sha256sum -c sha256sums 
config.buildinfo: OK
feeds.buildinfo: OK
openwrt-ath79-generic-netgear_wndr3700-v2-initramfs-kernel.bin: OK
openwrt-ath79-generic-netgear_wndr3700-v2-squashfs-factory.img: OK
openwrt-ath79-generic-netgear_wndr3700-v2-squashfs-sysupgrade.bin: OK
openwrt-ath79-generic-netgear_wndr3800-initramfs-kernel.bin: OK
openwrt-ath79-generic-netgear_wndr3800-squashfs-factory.img: OK
openwrt-ath79-generic-netgear_wndr3800-squashfs-sysupgrade.bin: OK
openwrt-ath79-generic-netgear_wndr3800ch-initramfs-kernel.bin: OK
openwrt-ath79-generic-netgear_wndr3800ch-squashfs-factory.img: OK
openwrt-ath79-generic-netgear_wndr3800ch-squashfs-sysupgrade.bin: OK
openwrt-ath79-generic.manifest: OK
version.buildinfo: OK
```
- `autoflash` ran: https://gitlab.com/socallinuxexpo/scale-network/-/pipelines/362209805 youll also notice that a green checkmark was also added to this PR from our gitlab runner :slightly_smiling_face: 
