### PR TITLE
[READY] Ansible 19x fixes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -103,7 +103,7 @@ jobs:
 
     - run:
         name: lint ansible playbook
-        command: ansible-lint -x 503 scale.yml
+        command: ansible-lint -x 403 -x 503 scale.yml
 
     - run:
         name: lint python files

--- a/ansible/roles/signs/tasks/main.yml
+++ b/ansible/roles/signs/tasks/main.yml
@@ -4,10 +4,18 @@
   apt:
     name: ['docker.io', 'python3-pip', 'git']
     state: present
+    update_cache: yes
+  register: pip
+
+- name: upgrade pip
+  pip:
+    name: 'pip'
+    state: latest
+  when: pip.changed
 
 - name: install docker-compose
   pip:
-    name: docker-compose
+    name: 'docker-compose'
     state: present
 
 - name: pull scale-signs repo
@@ -37,6 +45,9 @@
   file:
     path: "{{ scale_signs_root }}/secrets.env"
     state: touch
+    owner: root
+    group: root
+    mode: 0640
   when: not signs_secrets.stat.exists
 
 - name: copy scale-signs systemd unit file

--- a/ansible/roles/techteam/tasks/main.yml
+++ b/ansible/roles/techteam/tasks/main.yml
@@ -6,12 +6,8 @@
     state: present
     gid: "900"
 
-- name: create tech team users
-  user:
-    name: "{{ item }}"
-    home: "/home/{{ item }}"
-    groups: tech
-    shell: /bin/bash
+- include_tasks:
+    file: users.yml
   with_items:
     - owen
     - rob
@@ -26,20 +22,6 @@
     owner: root
     group: root
     mode: 0700
-
-# Owen's key is currently invalid
-
-- name: copy tech team rsa keys
-  authorized_key:
-    user: "{{ item }}"
-    state: present
-    key: "{{ lookup('file', '{{ inventory_dir }}/../facts/keys/{{ item }}_id_rsa.pub') }}"
-  with_items:
-    # - owen
-    - rob
-    - dlang
-    - kyle
-    - steveb
 
 - name: copy tech team sudoers file
   copy:

--- a/ansible/roles/techteam/tasks/users.yml
+++ b/ansible/roles/techteam/tasks/users.yml
@@ -1,0 +1,26 @@
+---
+
+- name: create tech team users
+  user:
+    name: "{{ item }}"
+    home: "/home/{{ item }}"
+    groups: tech
+    shell: /bin/bash
+
+- name: get all ssh keys
+  find:
+    path: "{{ inventory_dir }}/../facts/keys/"
+    file_type: file
+    patterns: "*{{ item }}*.pub"
+  delegate_to: localhost
+  become: no
+  register: found_keys
+
+- name: copy ssh keys
+  authorized_key:
+    user: "{{ item }}"
+    state: present
+    key: "{{ lookup('file', keyfile.path) }}"
+  loop: "{{ found_keys.files }}"
+  loop_control:
+    loop_var: keyfile

--- a/ansible/roles/zabbixagent/tasks/main.yml
+++ b/ansible/roles/zabbixagent/tasks/main.yml
@@ -4,6 +4,7 @@
   apt:
     name: zabbix-agent
     state: present
+    update_cache: yes
 
 - name: copy zabbix_agentd.conf
   template:


### PR DESCRIPTION
Fixes #394 

## Description of PR
Ansible 19x fixes.

## Previous Behavior
- SSH keys only supported RSA/DSA
- Zabbix and Docker installs failed on fresh installs

## New Behavior
- More robust SSH key management, supporting multiple keys per user and/or multiple format
- Anisble no longer failing

## Tests
- vagrant up
- vagrant provision
- verify functionality via ssh
