### PR TITLE
[READY] - Fixes for authorized_keys centralizing for openwrt

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,7 +30,7 @@ jobs:
   # outside of initial PR CI testing
   openwrt_build_ar71xx:
     docker:
-      - image: sarcasticadmin/openwrt-build@sha256:bab6de3f66f5365d866de646bb9fd1f2000061d1a5fe8a07b6a714661a9a9a63
+      - image: sarcasticadmin/openwrt-build@sha256:d5af9eb1228e31a959923c47e47e2b84fbe3c8b6c607416d79d8e55518810385
     resource_class: medium
     working_directory: ~/scale-network/openwrt
     steps:
@@ -54,7 +54,7 @@ jobs:
 
   openwrt_build_ipq806x:
     docker:
-      - image: sarcasticadmin/openwrt-build@sha256:bab6de3f66f5365d866de646bb9fd1f2000061d1a5fe8a07b6a714661a9a9a63
+      - image: sarcasticadmin/openwrt-build@sha256:d5af9eb1228e31a959923c47e47e2b84fbe3c8b6c607416d79d8e55518810385
     resource_class: medium
     working_directory: ~/scale-network/openwrt
     steps:

--- a/.github/workflows/openwrt-build.yml
+++ b/.github/workflows/openwrt-build.yml
@@ -13,7 +13,7 @@ jobs:
       matrix:
         target: ["ar71xx", "ipq806x"]
     container:
-      image: sarcasticadmin/openwrt-build@sha256:bab6de3f66f5365d866de646bb9fd1f2000061d1a5fe8a07b6a714661a9a9a63
+      image: sarcasticadmin/openwrt-build@sha256:d5af9eb1228e31a959923c47e47e2b84fbe3c8b6c607416d79d8e55518810385
       # Since user is openwrt and gets 1001 from inside container
       options: --user 1001
     steps:

--- a/openwrt/Makefile
+++ b/openwrt/Makefile
@@ -14,7 +14,7 @@ TARGET ?= ar71xx
 BUILD_DIR ?= build
 
 BUILD_SECRETS ?= ../facts/secrets/$(TARGET)-openwrt-example.yaml
-KEYFILE ?= ../facts/keys/
+KEYPATH ?= ../facts/keys/
 
 # bins
 GOMPLATE := $(shell command -v gomplate 2> /dev/null)

--- a/openwrt/docs/BUILD.md
+++ b/openwrt/docs/BUILD.md
@@ -28,9 +28,9 @@ for all members of the tech team.
 To start building:
 
 ```
-docker pull sarcasticadmin/openwrt-build:2aea1a2
+docker pull sarcasticadmin/openwrt-build:d25cfb5
 # Make sure to mount the git root inside this container
-docker run -v $(git rev-parse --show-toplevel):/home/openwrt/scale-network --rm -it sarcasticadmin/openwrt-build:2aea1a2 /bin/bash
+docker run -v $(git rev-parse --show-toplevel):/home/openwrt/scale-network --rm -it sarcasticadmin/openwrt-build:d25cfb5 /bin/bash
 cd /home/openwrt/scale-network
 ```
 > There is no latest tag so make sure to specify the version (short commit hash)

--- a/tests/unit/openwrt/test.sh
+++ b/tests/unit/openwrt/test.sh
@@ -51,7 +51,7 @@ gen_templates(){
   gomplate -d openwrt=../../../facts/secrets/${TARGET}-openwrt-example.yaml -d keys_dir=${KEYPATH} --input-dir=../../../openwrt/files --output-dir="./${1}"
 }
 
-if [ "${UPDATE}" == "1" ]; then
+if [ ${UPDATE} -eq 1 ]; then
   rm -rf "golden/${TARGET}"
   gen_templates "golden/${TARGET}"
 fi


### PR DESCRIPTION
## Description of PR

Relates to: https://github.com/socallinuxexpo/scale-network/pull/379

Was running into an error on the builds of our openwrt img: https://github.com/socallinuxexpo/scale-network/actions/runs/1299717141 this is from the `make templates` call:

```
mkdir -p build
curl -L -o build/b4c0d377f6bc13c555b69659ac001a25ab22bbd4.tar.gz https://github.com/openwrt/openwrt/archive/b4c0d377f6bc13c555b69659ac001a25ab22bbd4.tar.gz
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed

  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
100   157  100   157    0     0    846      0 --:--:-- --:--:-- --:--:--   848

  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
100 5873k    0 5873k    0     0  4695k      0 --:--:--  0:00:01 --:--:-- 5891k
100 9305k    0 9305k    0     0  5400k      0 --:--:--  0:00:01 --:--:-- 6334k
/bin/gomplate -d openwrt=../facts/secrets/ar71xx-openwrt-example.yaml -d keys_dir= --input-dir=files --output-dir=build/source-ar71xx-b4c0d37/files
template: files/root/.ssh/authorized_keys:1:42: executing "files/root/.ssh/authorized_keys" at <file.Read>: error calling Read: read failed for build: read build: is a directory
Makefile:110: recipe for target 'build/source-ar71xx-b4c0d37/files' failed
make: *** [build/source-ar71xx-b4c0d37/files] Error 1
```

And then ran into CAcert being stale: https://github.com/socallinuxexpo/scale-network/runs/3783739534?check_suite_focus=true Specifically:

```
Updating feed 'packages' from 'https://git.openwrt.org/feed/packages.git^fbdab5bb089bfd5060121d0cbf393c33a2e41600' ...
Cloning into './feeds/packages'...
fatal: unable to access 'https://git.openwrt.org/feed/packages.git/': server certificate verification failed. CAfile: /etc/ssl/certs/ca-certificates.crt CRLfile: none
failed.
Makefile:56: recipe for target 'build/source-ar71xx-b4c0d37/.config' failed
make: *** [build/source-ar71xx-b4c0d37/.config] Error 1
```

## Previous Behavior
- Getting build failure in the openwrt image builds for GA and circle
- CAcert bundle was old/stale

## New Behavior
- No longer getting a failure for openwrt builds
- New container built with updated CAcert build to work with openwrt pkgs

## Tests
- Manual Trigger of `openwrt build`
