### PR TITLE
[READY] - [Issue-414] - Redux for phasing out circleci

### DIFF
--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -49,4 +49,4 @@ jobs:
       - name: lint_ansible_python_unittests
         run: pytest -vv
       - name: ansible_inventory_properly_formed
-        run: ./inventory.py | jq
+        run: ./inventory.py | jq .

--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -4,6 +4,7 @@ name: ansible-test
 on:
   pull_request:
     paths:
+      - '.github/**'
       - 'ansible/**'
       - 'facts/**'
       - 'tests/**'
@@ -21,7 +22,7 @@ jobs:
       run:
         working-directory: facts/
     container:
-      - image: kylerisse/ansible-tester@sha256:f6a9507ec1d7a2dd0570cd88cb19746840c4f97e7618f53158616b9e1f5a3618
+      image: kylerisse/ansible-tester@sha256:f6a9507ec1d7a2dd0570cd88cb19746840c4f97e7618f53158616b9e1f5a3618
     steps:
       - name: checkout
         id: checkout
@@ -34,7 +35,7 @@ jobs:
     name: ansible_tests
     runs-on: ubuntu-latest
     container:
-      - image: kylerisse/ansible-tester@sha256:f6a9507ec1d7a2dd0570cd88cb19746840c4f97e7618f53158616b9e1f5a3618
+      image: kylerisse/ansible-tester@sha256:f6a9507ec1d7a2dd0570cd88cb19746840c4f97e7618f53158616b9e1f5a3618
     defaults:
       run:
         working-directory: ansible/

--- a/.github/workflows/openwrt-build.yml
+++ b/.github/workflows/openwrt-build.yml
@@ -1,4 +1,6 @@
 ---
+name: openwrt-build
+
 on:
   workflow_dispatch:
   schedule:

--- a/.github/workflows/openwrt-golden.yml
+++ b/.github/workflows/openwrt-golden.yml
@@ -4,6 +4,7 @@ name: openwrt-golden
 on:
   pull_request:
     paths:
+      - '.github/**'
       - 'openwrt/**'
       - 'facts/**'
       - 'tests/**'
@@ -26,14 +27,16 @@ jobs:
         uses: actions/checkout@v2
       - name: install_diffutils
         id: diffutils
-        shell: bash
+        shell: sh
         run: |
           apk update && apk add diffutils
       - name: openwrt_golden_ar71xx
-        shell: bash
+        shell: sh
+        run: |
           cd tests/unit/openwrt
-          bash -x test.sh -t ar71xx
+          sh -x test.sh -t ar71xx
       - name: openwrt_golden_ipq806x
-        shell: bash
+        shell: sh
+        run: |
           cd tests/unit/openwrt
-          bash -x test.sh -t ipq806x
+          sh -x test.sh -t ipq806x

--- a/.github/workflows/switches.yml
+++ b/.github/workflows/switches.yml
@@ -4,7 +4,8 @@ name: switches
 on:
   pull_request:
     paths:
-      - 'switch-configurations/**'
+      - '.github/**'
+      - 'switch-configuration/**'
   push:   # This is only run when PRs are merged into master
     branches:
       - master
@@ -23,7 +24,7 @@ jobs:
         id: checkout
         uses: actions/checkout@v2
       - name: lint
-        working_directory: switch-configuration
+        working-directory: switch-configuration
         run: make lint
   build:
     name: switch_build
@@ -36,5 +37,5 @@ jobs:
         id: checkout
         uses: actions/checkout@v2
       - name: build_switch_configs
-        working_directory: switch-configuration
+        working-directory: switch-configuration
         run: make build-switch-configs


### PR DESCRIPTION
## Description of PR

Follow up to PR: #413 
Relates to Issues: #377 #373

Because of course this was going to be done in more than one PR

@kylerisse was right about the decoupling for circleCI: https://github.com/socallinuxexpo/scale-network/pull/413#issuecomment-1010200826 I will be reaching out to Ilan for assistance since I dont have the permissions to unlink this repo from circleCI

## Previous Behavior
- GHA syntax was incorrect for `container` attribute.
- GHA syntax errors in various other places
- Odd failure with `jq` in ansible tests due to tty differences in CI tools
- Workflows do not necessarily trigger when their own file in `.github` changes

## New Behavior
- Reference container attribute correctly
- Fix any GHA syntax errors now that we can test in the actual PR
- Add `.` to make inventory test pass: `jq .` (see https://github.com/stedolan/jq/issues/1110 for more details)
- Make all lint and syntax actions fire on any changes in `.github` since thatll most likely be related to some kind of workflow

## Tests
- ~~Hopefully tests fire off here and make me look good~~ Tests work! :shipit:  (ignore any circleCI test since those are expected to fail)
