### PR TITLE
[READY] - Updating dnsmasq leasetime to reflect min

### DIFF
--- a/openwrt/autoflash
+++ b/openwrt/autoflash
@@ -74,7 +74,8 @@ sleep 2
 
 # Our DHCP server to the AP
 # This will fail without the full path to dnsmasq, unsure why
-spawn /usr/local/sbin/dnsmasq -u gitlab-runner -i flash0.503 --dhcp-range=192.168.254.100,192.168.254.100,255.255.255.0,30s --dhcp-option=3,192.168.254.1
+# Lease time must be >=120s otherwise its set this min
+spawn /usr/local/sbin/dnsmasq -u gitlab-runner -i flash0.503 --dhcp-range=192.168.254.100,192.168.254.100,255.255.255.0,120s --dhcp-option=3,192.168.254.1
 
 # Ping wait will be set to 10 sec
 # Make sure expect timeout is longer than

--- a/openwrt/docs/AUTOFLASH.md
+++ b/openwrt/docs/AUTOFLASH.md
@@ -109,7 +109,16 @@ $ sudo -u gitlab-runner -H /usr/local/bin/gitlab-runner register
 > Reach out to Rob for registration token for the gitlab-runner
 
 ```
-$ cat << EOF >> /etc/rc.conf
+$ cat << EOF > /etc/rc.conf
+hostname="generic"
+#ifconfig_DEFAULT="DHCP"
+ifconfig_genet0="DHCP"
+sshd_enable="YES"
+sendmail_enable="NONE"
+sendmail_submit_enable="NO"
+sendmail_outbound_enable="NO"
+sendmail_msp_queue_enable="NO"
+growfs_enable="YES"
 gitlab_runner_enable="YES"
 ntpdate_enable="YES"
 ntpdate_hosts="in.pool.ntp.org"
@@ -117,6 +126,7 @@ ifconfig_ue0_name="flash0"
 EOF
 ```
 > Set the `flash0` interface to `ue0` but your interface might be different
+> Ensure that dhclient isnt defaulting to all interfaces, just genet0
 
 Enable `sudo` elevation without password for gitlab-runner using `visudo` and add:
 
@@ -146,3 +156,15 @@ If you choose to run on the rpi2 (armv6) youll need to manually build the gitlab
 
 1. Build gitlab-runner from source and instructions here: https://gitlab.com/gitlab-org/gitlab-runner/-/issues/6694#note_307517264 (go 1.13 required)
 2. Copy gitlab-runner binary to pi2
+
+## Troubleshooting
+
+- Checking AP for renewals that are being unanswered:
+
+Startup `tcpdump` on each side:
+
+```
+tcpdump -vvv -n -i <IF> udp port 67 or udp port 68
+```
+
+Uncomment the rsyslog local log on the AP by uncomment confg in `/etc/rsyslog`


### PR DESCRIPTION
## Description of PR

Fixes: #433 

Ensure that dnsmasq in autoflasher is set correctly for min leasetime. It only supports leasetimes of >=120s

## Previous Behavior
- Leasetime was 30s
- rpi setup has dhclient defaulting on all interfaces

## New Behavior
- Leasetime is now 120s (min of dnsmasq)
- rpi dhclient only enabled on interface going to external network

## Tests
- rpi dhclient was disabled
- rpi tcpdump and ping for 8 hours to ensure stability
- apply to AP hardware: https://gitlab.com/socallinuxexpo/scale-network/-/jobs/2334815375
