### PR TITLE
[READY] - Enable dynamic apinger gateway check

### DIFF
--- a/facts/secrets/ar71xx-openwrt-example.yaml
+++ b/facts/secrets/ar71xx-openwrt-example.yaml
@@ -13,9 +13,6 @@ zabbix:
 ntp:
   server: '0.openwrt.pool.ntp.org'
 
-apinger:
-  endpoint: '8.8.8.8'
-
 wired:
   switches:
     - name: 'rtl8366s'

--- a/facts/secrets/ipq806x-openwrt-example.yaml
+++ b/facts/secrets/ipq806x-openwrt-example.yaml
@@ -17,9 +17,6 @@ nameserver: '8.8.8.8'
 ntp:
   server: '0.openwrt.pool.ntp.org'
 
-apinger:
-  endpoint: '8.8.8.8'
-
 wired:
   switches:
     - name: 'switch0'

--- a/facts/secrets/openwrt-example.yaml
+++ b/facts/secrets/openwrt-example.yaml
@@ -14,9 +14,6 @@ zabbix:
 
 nameserver: '8.8.8.8'
 
-apinger:
-  endpoint: '8.8.8.8'
-
 wired:
   switches:
     - name: 'switch0'

--- a/openwrt/files/etc/apinger.tmpl
+++ b/openwrt/files/etc/apinger.tmpl
@@ -16,12 +16,9 @@
 user "root"
 group "nogroup"
 
-## Location of the pid-file (default: "/var/run/apinger.pid")
-#pid_file "/var/run/apinger.pid"
-
 status {
 	## File where the status information whould be written to
-	file "/tmp/apinger.status"
+	file "/var/log/apinger.status"
 	## Interval between file updates
 	## when 0 or not set, file is written only when SIGUSR1 is received
 	interval 10s

--- a/openwrt/files/etc/apinger.tmpl
+++ b/openwrt/files/etc/apinger.tmpl
@@ -53,7 +53,7 @@ alarm down "wifi" {
 	combine 10s
 }
 
-target "{{ (datasource "openwrt").apinger.endpoint }}" {
+target "<DEFAULTGATEWAY>" {
         description "endpoint validation"
         alarms override "wifi"
 }

--- a/openwrt/files/etc/udhcpc.user
+++ b/openwrt/files/etc/udhcpc.user
@@ -1,7 +1,9 @@
 #!/bin/sh
 
 case "$1" in
-  "renew")
+  # Same actions for renew or bound for the time being
+  "renew"|"bound")
+    # dump params to tmp so its easier to troubleshoot
     set > /tmp/dhcp.params
     radio0=`uci show 'wireless.radio0.channel'|cut -f 2 -d "'"`
     radio1=`uci show 'wireless.radio1.channel'|cut -f 2 -d "'"`
@@ -13,27 +15,17 @@ case "$1" in
         wifi reload
       fi
     fi
-    if [ ! -z "$hostname" ]; then
-      uci set 'system.@system[0].hostname'="$hostname"
-      uci commit
-      if [ "$HOSTNAME" != "$hostname" ]; then reboot; fi
-    fi
-    if [ ! -z "$opt226" ]; then
-      /root/bin/config-version.sh -c $(printf %d "0x$opt226")
-    fi
-  ;;
-  "bound")
-    set > /tmp/dhcp.params
-    radio0=`uci show 'wireless.radio0.channel'|cut -f 2 -d "'"`
-    radio1=`uci show 'wireless.radio1.channel'|cut -f 2 -d "'"`
-    if [ ! -z "$opt224" ] || [ ! -z "$opt225" ]; then
-      if [ "$opt224" != "$radio0" ] || [ "$opt225" != "$radio1" ]; then
-        uci set 'wireless.radio0.channel'=$(printf %d "0x$opt224")
-        uci set 'wireless.radio1.channel'=$(printf %d "0x$opt225")
-        uci commit
-        wifi reload
+
+    # apinger template population
+    if [ ! -z "$router" ]; then
+      sed "s/<DEFAULTGATEWAY>/$router/g" /etc/apinger.tmpl > /tmp/apinger.conf
+      # Only restart apinger if compare has diff
+      if ! cmp /tmp/apinger.conf /etc/apinger.conf; then
+        # Cant use "service" since thats a shell function
+        cp /tmp/apinger.conf /etc/apinger.conf && /etc/init.d/apinger restart
       fi
     fi
+
     if [ ! -z "$hostname" ]; then
       uci set 'system.@system[0].hostname'="$hostname"
       uci commit

--- a/tests/serverspec/spec/shared/openwrt/init.rb
+++ b/tests/serverspec/spec/shared/openwrt/init.rb
@@ -124,6 +124,11 @@ RSpec.shared_examples "openwrt" do
     end
   end
 
+  # apinger target matches default gateway
+  describe command('cat /etc/apinger.conf | grep "^target \"$(ip route | grep default | cut -d \' \' -f 3)\""') do
+    its(:exit_status) { should eq 0 }
+  end
+
   # Make sure bash is roots shell
   describe command("awk -F: -v user='root' '$1 == user {print $NF}' /etc/passwd") do
       its(:stdout) { should match /\/bin\/bash/ }

--- a/tests/unit/openwrt/golden/ar71xx/etc/apinger.tmpl
+++ b/tests/unit/openwrt/golden/ar71xx/etc/apinger.tmpl
@@ -16,12 +16,9 @@
 user "root"
 group "nogroup"
 
-## Location of the pid-file (default: "/var/run/apinger.pid")
-#pid_file "/var/run/apinger.pid"
-
 status {
 	## File where the status information whould be written to
-	file "/tmp/apinger.status"
+	file "/var/log/apinger.status"
 	## Interval between file updates
 	## when 0 or not set, file is written only when SIGUSR1 is received
 	interval 10s
@@ -53,7 +50,7 @@ alarm down "wifi" {
 	combine 10s
 }
 
-target "8.8.8.8" {
+target "<DEFAULTGATEWAY>" {
         description "endpoint validation"
         alarms override "wifi"
 }

--- a/tests/unit/openwrt/golden/ar71xx/etc/udhcpc.user
+++ b/tests/unit/openwrt/golden/ar71xx/etc/udhcpc.user
@@ -1,7 +1,9 @@
 #!/bin/sh
 
 case "$1" in
-  "renew")
+  # Same actions for renew or bound for the time being
+  "renew"|"bound")
+    # dump params to tmp so its easier to troubleshoot
     set > /tmp/dhcp.params
     radio0=`uci show 'wireless.radio0.channel'|cut -f 2 -d "'"`
     radio1=`uci show 'wireless.radio1.channel'|cut -f 2 -d "'"`
@@ -13,27 +15,17 @@ case "$1" in
         wifi reload
       fi
     fi
-    if [ ! -z "$hostname" ]; then
-      uci set 'system.@system[0].hostname'="$hostname"
-      uci commit
-      if [ "$HOSTNAME" != "$hostname" ]; then reboot; fi
-    fi
-    if [ ! -z "$opt226" ]; then
-      /root/bin/config-version.sh -c $(printf %d "0x$opt226")
-    fi
-  ;;
-  "bound")
-    set > /tmp/dhcp.params
-    radio0=`uci show 'wireless.radio0.channel'|cut -f 2 -d "'"`
-    radio1=`uci show 'wireless.radio1.channel'|cut -f 2 -d "'"`
-    if [ ! -z "$opt224" ] || [ ! -z "$opt225" ]; then
-      if [ "$opt224" != "$radio0" ] || [ "$opt225" != "$radio1" ]; then
-        uci set 'wireless.radio0.channel'=$(printf %d "0x$opt224")
-        uci set 'wireless.radio1.channel'=$(printf %d "0x$opt225")
-        uci commit
-        wifi reload
+
+    # apinger template population
+    if [ ! -z "$router" ]; then
+      sed "s/<DEFAULTGATEWAY>/$router/g" /etc/apinger.tmpl > /tmp/apinger.conf
+      # Only restart apinger if compare has diff
+      if ! cmp /tmp/apinger.conf /etc/apinger.conf; then
+        # Cant use "service" since thats a shell function
+        cp /tmp/apinger.conf /etc/apinger.conf && /etc/init.d/apinger restart
       fi
     fi
+
     if [ ! -z "$hostname" ]; then
       uci set 'system.@system[0].hostname'="$hostname"
       uci commit

--- a/tests/unit/openwrt/golden/ipq806x/etc/apinger.tmpl
+++ b/tests/unit/openwrt/golden/ipq806x/etc/apinger.tmpl
@@ -16,12 +16,9 @@
 user "root"
 group "nogroup"
 
-## Location of the pid-file (default: "/var/run/apinger.pid")
-#pid_file "/var/run/apinger.pid"
-
 status {
 	## File where the status information whould be written to
-	file "/tmp/apinger.status"
+	file "/var/log/apinger.status"
 	## Interval between file updates
 	## when 0 or not set, file is written only when SIGUSR1 is received
 	interval 10s
@@ -53,7 +50,7 @@ alarm down "wifi" {
 	combine 10s
 }
 
-target "8.8.8.8" {
+target "<DEFAULTGATEWAY>" {
         description "endpoint validation"
         alarms override "wifi"
 }

--- a/tests/unit/openwrt/golden/ipq806x/etc/udhcpc.user
+++ b/tests/unit/openwrt/golden/ipq806x/etc/udhcpc.user
@@ -1,7 +1,9 @@
 #!/bin/sh
 
 case "$1" in
-  "renew")
+  # Same actions for renew or bound for the time being
+  "renew"|"bound")
+    # dump params to tmp so its easier to troubleshoot
     set > /tmp/dhcp.params
     radio0=`uci show 'wireless.radio0.channel'|cut -f 2 -d "'"`
     radio1=`uci show 'wireless.radio1.channel'|cut -f 2 -d "'"`
@@ -13,27 +15,17 @@ case "$1" in
         wifi reload
       fi
     fi
-    if [ ! -z "$hostname" ]; then
-      uci set 'system.@system[0].hostname'="$hostname"
-      uci commit
-      if [ "$HOSTNAME" != "$hostname" ]; then reboot; fi
-    fi
-    if [ ! -z "$opt226" ]; then
-      /root/bin/config-version.sh -c $(printf %d "0x$opt226")
-    fi
-  ;;
-  "bound")
-    set > /tmp/dhcp.params
-    radio0=`uci show 'wireless.radio0.channel'|cut -f 2 -d "'"`
-    radio1=`uci show 'wireless.radio1.channel'|cut -f 2 -d "'"`
-    if [ ! -z "$opt224" ] || [ ! -z "$opt225" ]; then
-      if [ "$opt224" != "$radio0" ] || [ "$opt225" != "$radio1" ]; then
-        uci set 'wireless.radio0.channel'=$(printf %d "0x$opt224")
-        uci set 'wireless.radio1.channel'=$(printf %d "0x$opt225")
-        uci commit
-        wifi reload
+
+    # apinger template population
+    if [ ! -z "$router" ]; then
+      sed "s/<DEFAULTGATEWAY>/$router/g" /etc/apinger.tmpl > /tmp/apinger.conf
+      # Only restart apinger if compare has diff
+      if ! cmp /tmp/apinger.conf /etc/apinger.conf; then
+        # Cant use "service" since thats a shell function
+        cp /tmp/apinger.conf /etc/apinger.conf && /etc/init.d/apinger restart
       fi
     fi
+
     if [ ! -z "$hostname" ]; then
       uci set 'system.@system[0].hostname'="$hostname"
       uci commit


### PR DESCRIPTION
## Description of PR

Fixes: #364 

Updating `apinger` to leverage local gateway instead of google

## Previous Behavior
- Leveraged google for apinger, was simplest path at the time to get this up and working at the time
- udhcpc.user had duplicate logic in the case
- set apinger inputs via `openwrt*.yaml`
- apinger status was logging to `/tmp/apinger.status`

## New Behavior
- Removed apinger inputs in `openwrt*.yaml`
- `/etc/apinger.conf` moved to `/etc/apinger.tmpl` so that gateway can be added during dhcp bound and renew
- Default gateway ($router) used in udhcpc.user scripts to create `/etc/apinger.conf` from `/etc/apinger.tmpl`
- serverspec test added for checking that default gateway defined in `/etc/apinger.conf`
- apinger status logging to `/var/log/apinger.status`

## Tests
- Built an image with the configuration: https://github.com/socallinuxexpo/scale-network/actions/runs/2182544523
- Test to ensure that everything works as intended: https://gitlab.com/socallinuxexpo/scale-network/-/jobs/2347799547
  - New serverspec tests confirms that gateway is set
  - Checked the runing instance via serial to confirm that gateway is properly set for apinger:
```
root@OpenWrt:/# cat /etc/scale-release 
SCALE_VER=e69c0c9271f3a603bedba307b217958fc2163d67
OPENWRT_VER=4a2cca78245e9291096e7c8c98627426df50ef58
root@OpenWrt:/# grep "^target \"$(ip route | grep default | cut -d ' ' -f 3)\"" 
/etc/apinger.conf 
target "192.168.254.1" {
```
- Confirm that downing the interface (gateway in our autoflash environment) works as intended (from the pi4):

pi4:
```
~ # ifconfig flash0.503 down
~ # ping 192.168.254.100
PING 192.168.254.100 (192.168.254.100): 56 data bytes
```

apinger log on the ap:
```
# tail -f /var/log/apinger.status 
Mon Apr 18 06:28:53 2022

Target: 192.168.254.1
Description: endpoint validation
Last reply received: #405 Mon Apr 18 06:28:41 2022
Average delay: 0.420ms
Average packet loss: 0.0%
Active alarms: "wifi"
Received packets buffer: ################################################## ###############.....
```
> `....` are each failed checks for apinger

stdout on the ap (meaning wifi down):
```
[  880.815746] br-staffwifi: port 6(wlan1-1) entered disabled state
[  880.826184] device wlan1-1 left promiscuous mode
[  880.830909] br-staffwifi: port 6(wlan1-1) entered disabled state
[  880.909821] device wlan1 left promiscuous mode
[  880.914459] br-scalefast: port 5(wlan1) entered disabled state
[  880.955415] br-staffwifi: port 5(wlan0-1) entered disabled state
[  880.971765] device wlan0-1 left promiscuous mode
[  880.976517] br-staffwifi: port 5(wlan0-1) entered disabled state
[  881.070729] device wlan0 left promiscuous mode
[  881.075452] br-scaleslow: port 5(wlan0) entered disabled state
```
Bring back up the interface on the pi beings the radio back as expected