### PR TITLE
[READY] - Adding option to toggle openwrt sshd PasswordAuth

### DIFF
--- a/facts/secrets/ar71xx-openwrt-example.yaml
+++ b/facts/secrets/ar71xx-openwrt-example.yaml
@@ -1,6 +1,8 @@
 # scale
 root_hash: "$1$zh0PjBbB$f9aFGDX9vNYNdSRexhib8/"
-scale: 18
+
+# Bump for each year for scale
+scale: 19
 
 rsyslog:
   server: 'loghost.scale.lan'

--- a/facts/secrets/ar71xx-openwrt-example.yaml
+++ b/facts/secrets/ar71xx-openwrt-example.yaml
@@ -4,6 +4,9 @@ root_hash: "$1$zh0PjBbB$f9aFGDX9vNYNdSRexhib8/"
 # Bump for each year for scale
 scale: 19
 
+sshd:
+ password_auth: true
+
 rsyslog:
   server: 'loghost.scale.lan'
   port: '514'

--- a/facts/secrets/ipq806x-openwrt-example.yaml
+++ b/facts/secrets/ipq806x-openwrt-example.yaml
@@ -2,7 +2,7 @@
 root_hash: "$1$zh0PjBbB$f9aFGDX9vNYNdSRexhib8/"
 
 # Bump for each year for scale
-scale: 18
+scale: 19
 
 rsyslog:
   server: 'server2.scale.lan'

--- a/facts/secrets/ipq806x-openwrt-example.yaml
+++ b/facts/secrets/ipq806x-openwrt-example.yaml
@@ -4,6 +4,9 @@ root_hash: "$1$zh0PjBbB$f9aFGDX9vNYNdSRexhib8/"
 # Bump for each year for scale
 scale: 19
 
+sshd:
+  password_auth: true
+
 rsyslog:
   server: 'server2.scale.lan'
   port: '514'

--- a/openwrt/files/etc/ssh/sshd_config
+++ b/openwrt/files/etc/ssh/sshd_config
@@ -1,6 +1,9 @@
 Port 22
 PermitRootLogin yes
+{{- if (datasource "openwrt").sshd.password_auth }}
 PasswordAuthentication yes
+{{- else }}
+PasswordAuthentication no
+{{- end }}
 AuthorizedKeysFile %h/.ssh/authorized_keys
 LogLevel VERBOSE
-

--- a/openwrt/files/etc/ssh/sshd_config
+++ b/openwrt/files/etc/ssh/sshd_config
@@ -2,8 +2,10 @@ Port 22
 PermitRootLogin yes
 {{- if (datasource "openwrt").sshd.password_auth }}
 PasswordAuthentication yes
+ChallengeResponseAuthentication yes
 {{- else }}
 PasswordAuthentication no
+ChallengeResponseAuthentication no
 {{- end }}
 AuthorizedKeysFile %h/.ssh/authorized_keys
 LogLevel VERBOSE

--- a/tests/unit/openwrt/golden/ar71xx/etc/config/system
+++ b/tests/unit/openwrt/golden/ar71xx/etc/config/system
@@ -26,5 +26,5 @@ config led 'led_usb'
 config led 'led_wps'
         option name 'WPS for build ID'
 	option 'sysfs' 'netgear:green:wps'
-        option default '1'
+        option default '0'
 

--- a/tests/unit/openwrt/golden/ar71xx/etc/ssh/sshd_config
+++ b/tests/unit/openwrt/golden/ar71xx/etc/ssh/sshd_config
@@ -3,4 +3,3 @@ PermitRootLogin yes
 PasswordAuthentication yes
 AuthorizedKeysFile %h/.ssh/authorized_keys
 LogLevel VERBOSE
-

--- a/tests/unit/openwrt/golden/ar71xx/etc/ssh/sshd_config
+++ b/tests/unit/openwrt/golden/ar71xx/etc/ssh/sshd_config
@@ -1,5 +1,6 @@
 Port 22
 PermitRootLogin yes
 PasswordAuthentication yes
+ChallengeResponseAuthentication yes
 AuthorizedKeysFile %h/.ssh/authorized_keys
 LogLevel VERBOSE

--- a/tests/unit/openwrt/golden/ipq806x/etc/config/system
+++ b/tests/unit/openwrt/golden/ipq806x/etc/config/system
@@ -40,5 +40,5 @@ config led 'led_lan'
 config led 'led_wps'
         option name 'WPS for build ID'
         option sysfs 'c2600:white:wps'
-        option default '1'
+        option default '0'
 

--- a/tests/unit/openwrt/golden/ipq806x/etc/ssh/sshd_config
+++ b/tests/unit/openwrt/golden/ipq806x/etc/ssh/sshd_config
@@ -3,4 +3,3 @@ PermitRootLogin yes
 PasswordAuthentication yes
 AuthorizedKeysFile %h/.ssh/authorized_keys
 LogLevel VERBOSE
-

--- a/tests/unit/openwrt/golden/ipq806x/etc/ssh/sshd_config
+++ b/tests/unit/openwrt/golden/ipq806x/etc/ssh/sshd_config
@@ -1,5 +1,6 @@
 Port 22
 PermitRootLogin yes
 PasswordAuthentication yes
+ChallengeResponseAuthentication yes
 AuthorizedKeysFile %h/.ssh/authorized_keys
 LogLevel VERBOSE


### PR DESCRIPTION
## Description of PR

Fixes: #388 

## Previous Behavior
- PasswordAuth for openwrt sshd was always enabled
- scale version in yaml config was 18

## New Behavior
- PasswordAuth for openwrt sshd can be toggled (default to enabled)
- scale version yaml config bumped to 19 for upcoming 19x conference in July

## Tests
- Will do a build and test locally since `autoflash` automation will break when password is disabled
