### PR TITLE
[READY] - Update udhcpc.user

### DIFF
--- a/openwrt/files/etc/udhcpc.user
+++ b/openwrt/files/etc/udhcpc.user
@@ -29,7 +29,7 @@ case "$1" in
     if [ ! -z "$hostname" ]; then
       uci set 'system.@system[0].hostname'="$hostname"
       uci commit
-      if [ "$HOSTNAME" != "$hostname" ]; then reboot; fi
+      if [ `echo "$HOSTNAME" | tr '[A-Z]' '[a-z]'` != `echo "$hostname" | tr '[A-Z]' '[a-z]'` ]; then reboot; fi
     fi
     if [ ! -z "$opt226" ]; then
       /root/bin/config-version.sh -c $(printf %d "0x$opt226")

--- a/tests/unit/openwrt/golden/ar71xx/etc/udhcpc.user
+++ b/tests/unit/openwrt/golden/ar71xx/etc/udhcpc.user
@@ -29,7 +29,7 @@ case "$1" in
     if [ ! -z "$hostname" ]; then
       uci set 'system.@system[0].hostname'="$hostname"
       uci commit
-      if [ "$HOSTNAME" != "$hostname" ]; then reboot; fi
+      if [ `echo "$HOSTNAME" | tr '[A-Z]' '[a-z]'` != `echo "$hostname" | tr '[A-Z]' '[a-z]'` ]; then reboot; fi
     fi
     if [ ! -z "$opt226" ]; then
       /root/bin/config-version.sh -c $(printf %d "0x$opt226")

--- a/tests/unit/openwrt/golden/ipq806x/etc/udhcpc.user
+++ b/tests/unit/openwrt/golden/ipq806x/etc/udhcpc.user
@@ -29,7 +29,7 @@ case "$1" in
     if [ ! -z "$hostname" ]; then
       uci set 'system.@system[0].hostname'="$hostname"
       uci commit
-      if [ "$HOSTNAME" != "$hostname" ]; then reboot; fi
+      if [ `echo "$HOSTNAME" | tr '[A-Z]' '[a-z]'` != `echo "$hostname" | tr '[A-Z]' '[a-z]'` ]; then reboot; fi
     fi
     if [ ! -z "$opt226" ]; then
       /root/bin/config-version.sh -c $(printf %d "0x$opt226")


### PR DESCRIPTION
Fixes mixed-case problem with host name.

## Description of PR
See above

## Previous Behavior
Mixed case host names in config vs. lower case hostnames from KEA didn't compare equally causing erroneous reboots.

## New Behavior
Erroneous reboots from this cause are prevented.

## Tests
/bin/bash
