### PR TITLE
[READY] - init flash utils and nix-shell pkgs updates

### DIFF
--- a/openwrt/flash
+++ b/openwrt/flash
@@ -1,6 +1,13 @@
 #!/usr/bin/env expect
-spawn /usr/sbin/arp -d 192.168.1.1
-spawn ./ping -n 192.168.1.1
+
+set timeout 120
+
+spawn arp -d 192.168.1.1
+# Leverage the nix-shell ping for this script
+# ubuntu ping as of 18.04,20.04 doesnt seem to
+# return the malformed packet
+# TODO: Could us single ping and then look at arp table
+spawn ping -n 192.168.1.1
 expect {
   Unreachable exp_continue
   "taking countermeasures"
@@ -9,7 +16,7 @@ close
 send_user "enter the name,serial of this AP: "
 expect_user -timeout -1 -re "(.*)\n"
 set ap $expect_out(1,string)
-spawn /usr/sbin/arp -n 192.168.1.1
+spawn arp -n 192.168.1.1
 expect -re "192.168.1.1 *ether *(\[^ \]*) "
 set mac $expect_out(1,string)
 set file [open aplist a]
@@ -23,5 +30,5 @@ send "put factory.img\n"
 expect tftp
 send "quit\n"
 close
-spawn /usr/sbin/arp -d 192.168.1.1
+spawn arp -d 192.168.1.1
 send_user "\n\nfinished, do the next AP\n\n"

--- a/shell.nix
+++ b/shell.nix
@@ -10,7 +10,7 @@ let
   # Trying to keep these pkg sets separate for later
   global = [ bash curl git jq kermit  screen glibcLocales ] ++ [ scale_python ];
   ansible_sub = [ansible_2_11 ansible-lint];
-  openwrt_sub = [ expect gomplate magic-wormhole tftp-hpa ];
+  openwrt_sub = [ expect gomplate magic-wormhole tftp-hpa nettools unixtools.ping];
   network_sub = [ perl532 ];
 in
 mkShell {


### PR DESCRIPTION
## Description of PR

Needed to solo flash (old process) 4 APs that didnt take with the massflash. Leveraging the nix-shell as well since the ping util in ubuntu still seem to be broken and doesnt show malformed ping packets :/ see: https://github.com/socallinuxexpo/scale-network/issues/295

## Previous Behavior
- flash util was only workable from the rpi
- no net tools in nix-shell

## New Behavior
- flash util leverages path for vars
- net tools in nix-shell

## Tests
- Flashed the 4 remaining APs
