### PR TITLE
[Ready] Create 19x T-Shirt Front.svg

### DIFF
--- a/graphics/19x T-Shirt Front.svg
+++ b/graphics/19x T-Shirt Front.svg
@@ -1,0 +1,169 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="13in"
+   height="5in"
+   viewBox="0 0 330.20001 127"
+   version="1.1"
+   id="svg55558"
+   inkscape:version="1.1.2 (b8e25be8, 2022-02-05)"
+   sodipodi:docname="T-Shirt 2022 (19x) Front.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <sodipodi:namedview
+     id="namedview55560"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:document-units="in"
+     showgrid="false"
+     units="in"
+     inkscape:zoom="2.0396181"
+     inkscape:cx="461.36088"
+     inkscape:cy="215.9718"
+     inkscape:window-width="2551"
+     inkscape:window-height="1387"
+     inkscape:window-x="2565"
+     inkscape:window-y="240"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="layer1-2" />
+  <defs
+     id="defs55555" />
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1">
+    <g
+       inkscape:label="Layer 1"
+       id="layer1-2"
+       transform="matrix(0.13625726,0,0,0.13625726,-18.079933,-13.8502)">
+      <path
+         id="path18514-9"
+         style="display:inline;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:none"
+         d="m 369.63633,174.15945 c -0.6125,-0.011 -1.2125,0 -1.85,0.031 -23.3,1.0588 -35.3375,19.225 -39.5375,34.2375 -4.5625,16.3013 -1.3,26.5888 -4.9625,31.4275 -9.075,11.9738 -34.525,22.0588 -50.625,25.6863 0,0 2.7,19.1187 6.8,30.5225 4.1125,11.4037 8.875,18.57 5.875,35.5487 -3,16.97879 -26.8125,63.99379 -45.9375,104.74004 -22.1125,47.105 -54.08751,117.855 -53.93751,203.86125 0.0625,32.88875 4.07501,62.995 9.58751,88.88625 0.65,1.0375 1.075,1.93625 1.2125,2.715 2.0375,11.555 39.0625,39.3625 96.3125,45.0975 51.05,5.11375 81.15,-3.83 80.8625,-52.245 -0.5375,-90.76125 -73.0875,-182.92875 -69.9125,-240.47125 6.875,-123.49375 99.575,-212.91999 98.1625,-271.18129 -0.4875,-20.2025 -12.975,-38.56 -32.05,-38.8562 0,0 0,0 0,0 z"
+         inkscape:connector-curvature="0" />
+      <path
+         id="path18516-4"
+         style="display:inline;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:10.183;stroke-miterlimit:2.82;stroke-dasharray:none"
+         d="m 348.63633,153.34195 c -20.9625,0 -44.4375,7.47 -56.925,23.72 -18.225,23.72 -19.975,64.105 -19.975,64.105 0,0 -17.475,5.555 -13.475,16.5412 3.45,9.5038 11.5875,8.4513 13.725,7.99 0.025,-0.013 0.075,-0.026 0.1,-0.031 0.2875,-0.066 0.4625,-0.125 0.4625,-0.125 16.1,-3.6275 41.55,-13.7125 50.625,-25.6863 3.6625,-4.8375 0.4,-15.1262 4.9625,-31.4275 4.2,-15.0125 16.2375,-33.1787 39.55,-34.2375 20.125,-0.915 33.3875,17.9713 33.8875,38.825 1.4125,58.2613 -91.2875,147.68754 -98.15,271.18129 -3.1875,57.5425 69.375,149.71 69.9,240.47125 0.2875,48.415 -29.8125,57.35875 -80.8625,52.245 -57.25,-5.735 -94.275,-33.5425 -96.3125,-45.0975 -0.1375,-0.77875 -0.5625,-1.6775 -1.2125,-2.715 12.2625,57.58125 31.95,94.285 31.95,94.285 0,0 -34.3,9.30625 -33.3,16.0725 0.725,4.87 41.25,23.1625 46.0375,22.5025 5.4375,-0.75125 26.1375,-23.99 36.6125,-26.9975 12.875,-3.6975 174.9875,14.665 187.7625,23.22 3.725,2.50125 0.8125,23.46625 8.9875,29.7125 4.2375,3.24625 70.7875,-6.92125 73.9,-10.98625 2.45,-3.19875 -24.4,-22.97 -24.4,-22.97 10.5,-24.5225 23.15,-46.5975 22.4,-106.8625 -1.15,-93.75625 -38.95,-188.37375 -77.9125,-250.93 22.7,4.3575 65.925,-7.23625 66.175,-14.9775 0.3,-8.98375 -16.225,-11.735 -23.2125,-12.7325 -6.9875,-0.99875 -61.6125,-31.465 -86.8875,-57.1775 -3.6375,-13.8925 -5.4,-26.4525 -4.75,-48.4375 0.75,-24.96749 12.7375,-86.88629 13.7375,-129.08249 0.85,-36 -22.725,-79.3988 -83.4,-80.3975 z"
+         inkscape:connector-curvature="0" />
+      <path
+         id="path18518-7"
+         style="fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#000000"
+         d="m 238.92383,437.44569 c -17.5375,4.685 -45.3375,13.445 -45.45,22.0025 -0.0875,7.5125 19.2875,7.14625 32.675,5.99125 4.4125,-10.08125 8.7375,-19.4075 12.775,-27.99375 z"
+         inkscape:connector-curvature="0" />
+      <path
+         id="path18520-9"
+         style="fill:none;stroke:#000000;stroke-width:10.1835;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:2.81799;stroke-dasharray:none;stroke-opacity:1"
+         d="m 225.63315,820.22608 c -10.825,-28.20875 -37.52501,-83.5375 -40.97501,-169.87875 -5.8,-145.14 82.47501,-250.55375 85.56251,-294.71875"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="csc" />
+      <path
+         id="path18524-0"
+         style="fill:none;stroke:#000000;stroke-width:10.1835;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:2.81799;stroke-dasharray:none;stroke-opacity:1"
+         d="m 284.37383,302.98695 c -5.8,-10.3625 -9.4875,-23.3138 -11.125,-37.4363"
+         inkscape:connector-curvature="0" />
+      <path
+         id="path18526-2"
+         style="fill:none;stroke:#000000;stroke-width:10.1835;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:2.81799;stroke-dasharray:none;stroke-opacity:1"
+         d="m 237.89001,435.65858 c -25.775,8.93125 -48.025,15.63125 -48.025,23.4425 0,7.815 28.1125,5.58125 35.1375,3.35"
+         inkscape:connector-curvature="0" />
+      <path
+         id="path18530-1"
+         style="fill:none;stroke:#000000;stroke-width:10.1835;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:2.81799;stroke-dasharray:none;stroke-opacity:1"
+         d="m 466.97383,496.14694 c -21.5125,-3.01125 -55.35,-18.2625 -55.35,-18.2625"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cc" />
+      <path
+         id="path18532-1"
+         style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#000000"
+         d="m 382.07383,223.24695 c -6.5875,3.6887 -15.9,-0.4 -20.7875,-9.1375 -4.9,-8.7338 -3.5375,-18.805 3.0375,-22.4938 6.5875,-3.6937 15.8875,0.3938 20.7875,9.1313 4.9,8.7362 3.5375,18.8062 -3.0375,22.5 z"
+         inkscape:connector-curvature="0" />
+      <path
+         id="path18528-7"
+         style="fill:none;stroke:#000000;stroke-width:10.1835;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:2.81799;stroke-dasharray:none;stroke-opacity:1"
+         d="m 301.87039,234.67161 c -9.725,-0.3875 -22.575,3.18275 -32.54461,7.48967"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cc" />
+      <text
+         xml:space="preserve"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:279.618px;line-height:1.25;font-family:OCR-A;-inkscape-font-specification:'OCR-A, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;stroke-width:1.94179"
+         x="631.5177"
+         y="848.79559"
+         id="text61527"><tspan
+           sodipodi:role="line"
+           id="tspan61525"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:279.618px;font-family:OCR-A;-inkscape-font-specification:'OCR-A, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;stroke-width:1.94179"
+           x="631.5177"
+           y="848.79559">!krowten</tspan></text>
+      <text
+         xml:space="preserve"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:186.412px;line-height:1.25;font-family:Helvetica;-inkscape-font-specification:Helvetica;stroke-width:1.94179"
+         x="594.3244"
+         y="492.17728"
+         id="text63865"><tspan
+           sodipodi:role="line"
+           id="tspan63863"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-family:Helvetica;-inkscape-font-specification:Helvetica;stroke-width:1.94179"
+           x="594.3244"
+           y="492.17728">WiFi Password:</tspan></text>
+      <circle
+         style="fill:#000000;stroke:none;stroke-width:0.276172"
+         id="path66003"
+         cx="790.72437"
+         cy="369.70801"
+         r="13.980906" />
+      <circle
+         style="fill:#000000;stroke:none;stroke-width:0.276172"
+         id="path66003-7"
+         cx="946.15503"
+         cy="369.70801"
+         r="13.980906" />
+      <path
+         style="fill:none;stroke:#000000;stroke-width:9.3206;stroke-miterlimit:4;stroke-dasharray:none"
+         id="path66289"
+         sodipodi:type="arc"
+         sodipodi:cx="946.19208"
+         sodipodi:cy="374.22415"
+         sodipodi:rx="34.882412"
+         sodipodi:ry="34.901321"
+         sodipodi:start="3.9269908"
+         sodipodi:end="5.4977871"
+         sodipodi:arc-type="arc"
+         d="m 921.52649,349.54519 a 34.882412,34.901321 0 0 1 24.66559,-10.22236 34.882412,34.901321 0 0 1 24.66559,10.22236"
+         sodipodi:open="true" />
+      <path
+         style="fill:none;stroke:#000000;stroke-width:9.3206;stroke-miterlimit:4;stroke-dasharray:none"
+         id="path66289-2"
+         sodipodi:type="arc"
+         sodipodi:cx="946.19208"
+         sodipodi:cy="375.90784"
+         sodipodi:rx="51.263325"
+         sodipodi:ry="51.263325"
+         sodipodi:start="3.9269908"
+         sodipodi:end="5.4977871"
+         sodipodi:arc-type="arc"
+         sodipodi:open="true"
+         d="m 909.94343,339.65919 a 51.263325,51.263325 0 0 1 72.49729,0" />
+      <path
+         style="fill:none;stroke:#000000;stroke-width:9.3206;stroke-miterlimit:4;stroke-dasharray:none"
+         id="path66289-2-2"
+         sodipodi:type="arc"
+         sodipodi:cx="946.19208"
+         sodipodi:cy="375.90784"
+         sodipodi:rx="65.244232"
+         sodipodi:ry="65.244232"
+         sodipodi:start="3.9269908"
+         sodipodi:end="5.4977871"
+         sodipodi:arc-type="arc"
+         sodipodi:open="true"
+         d="m 900.05744,329.7732 a 65.244232,65.244232 0 0 1 92.26927,0" />
+    </g>
+  </g>
+</svg>


### PR DESCRIPTION
Design for T-Shirt Front for SCaLE 19x
Does not contain digitizing for Embroidery.

## Description of PR
Add T-Shirt Front design.

## Previous Behavior
We did not have a design file for the front of our T-Shirts.

## New Behavior
We now have a design for the front of our T-Shirts.

## Tests
Extensive analysis of signals in the 380 to 700 nanometer wavelengths emitted from a collection of LEDs and filtered through a matrix of liquid crystal elements triggered according to render the included file using one each mark one oculus dexter and oculus sinister.