### PR TITLE
[READY] - init massflash for APs via kea dhcpd

### DIFF
--- a/openwrt/README.md
+++ b/openwrt/README.md
@@ -5,6 +5,7 @@ The SCaLE network teams build of openwrt for the APs for the conference.
 ## Table of Contents
 
 * [Autoflash](./docs/AUTOFLASH.md)
+* [Massflash](./docs/MASSFLASH.md)
 * [Build Openwrt](./docs/BUILD.md)
 * [Dynamic Network Config](./docs/DYNAMIC_CONFIG.md)
 * [TPLink c2600](./docs/IPQ806X.md)

--- a/openwrt/docs/MASSFLASH.md
+++ b/openwrt/docs/MASSFLASH.md
@@ -1,0 +1,59 @@
+# Massflash
+
+## Overview
+
+Leverages `openwrt/scripts/massflash` and `kea` to provide a way to flash openwrt APs with new images prior to the scale conference
+
+## Prereqs
+
+Place the following files in `openwrt/scripts/massflash`:
+
+1. `flash.bin` - An openwrt img for the sysupgrade.bin thats produced during a build. Currently the massflash is unable to distinguish
+   between multiple boards/architectures. 
+2. `passwords.txt` - A file that contains the ssh user password credentials. If you want it to try multiple then add one per line.
+3. `id_priv` - The private key for the ssh user credentials. This will probably be the main way to get in going forward. Might have to
+   support multiple keys in the future.
+4. `kea.tmpl` - Copy template to `kea.json` and update values accordingly based on your interfaces and file paths. Leverage tagged vlan `503`. Example values:
+
+```
+<INTERFACE> = enp5s0.503
+<LIBRUNSCRIPT> = /nix/store/5qr44w8fm0vf5whsa683444wv4q0bwns-kea-2.0.2/lib/kea/hooks/libdhcp_run_script.so
+<MASSFLASH> = /home/user/scale-network/scripts/massflash/massflash
+```
+
+Outside of the necessary files:
+
+5. Juniper switch needs to be setup for tagged vlan 503 on all ports
+6. Setup interface 503 vlan for dhcp on the massflash host:
+
+```
+sudo ip link add link enp5s0 name enp5s0.503 type vlan id 503
+sudo ip addr add 192.168.254.1/22 dev enp5s0.503
+sudo ip link set up enp5s0.503
+```
+> if you include a subnet mask during ip addr add then it wont default to 32
+> otherwise you need to add the route explicitly:
+> "ip route add 192.168.254.0/22 dev enp5s0.503"
+> 
+> if need to del route: "ip route del 192.168.254.0/24 dev enp5s0.503"
+
+## Start up
+
+```
+nix-shell
+sudo env "PATH=$PATH" kea-dhcp4 -c ./openwrt/scripts/massflash/kea.json
+```
+
+## Known issues
+
+- DHCP client requests are duplicated on AP startup. Its not uncommon to see this in the logs but there is no issue with this happening.
+  In the future it might be a good idea to investigate to see why the interfaces are yoyo'ing at boot and sending multiple requests.
+- `massflash` assumes its being called by kea script plugin. The following arg is passed to the `massflash` script and environment variables
+  are assumed to be present:
+
+```
+arg: lease4_renew
+env: QUERY4_TYPE, LEASE4_ADDRESS, LEASE4_HWADDR
+```
+
+- Hardcoded paths. These will get cleaned up in followups to the repo. Right now they will be left in for as references.

--- a/openwrt/scripts/massflash/kea.tmpl
+++ b/openwrt/scripts/massflash/kea.tmpl
@@ -1,0 +1,29 @@
+{
+    "Dhcp4": {
+        "interfaces-config": {
+            "interfaces": [ "<INTERFACE>" ],
+            "dhcp-socket-type": "raw"
+        },
+        "valid-lifetime": 600,
+        "renew-timer": 300,
+        "rebind-timer": 400,
+        "subnet4": [{
+           "pools": [ { "pool": "192.168.252.50-192.168.254.254" } ],
+           "subnet": "192.168.252.0/22"
+        }],
+
+       "loggers": [{
+            "name": "*",
+            "severity": "DEBUG"
+        }],
+      "hooks-libraries": [
+          {
+              "library": "<LIBRUNSCRIPT>",
+              "parameters": {
+                  "name": "<MASSFLASH>",
+                  "sync": false
+              }
+          }
+      ]
+    }
+}

--- a/openwrt/scripts/massflash/massflash
+++ b/openwrt/scripts/massflash/massflash
@@ -1,0 +1,156 @@
+#!/usr/bin/env expect
+
+# Set script to debug, equal to expect -d
+#exp_internal 1
+
+set hook [lindex $argv 0];
+
+switch $hook {
+  leases4_committed {
+    puts "lease4_commited"
+    puts $env(QUERY4_REMOTE_ADDR)
+    exit 0
+  }
+  # Renew is what we want
+  lease4_renew {
+    puts $hook
+    #puts $env(QUERY4_REMOTE_ADDR)
+    #puts $env(LEASE4_HOSTNAME)
+    #puts $env(LEASE4_ADDRESS)
+    if { $env(QUERY4_TYPE) ne "DHCPREQUEST" } { exit 0 }
+
+    # All the options passed via kea script plugin
+    # https://kea.readthedocs.io/en/latest/arm/hooks.html#run-script-support
+    #foreach { item value } [ array get env ] { puts "$item $value" }
+    #exit 0
+  }
+  default {
+    puts $hook
+    exit 0
+  }
+}
+
+set timeout 120
+set script_dir [file dirname [file normalize [info script]]]
+set sshuser "root"
+set host $env(LEASE4_ADDRESS)
+set port "22"
+
+# Read in passwords from password file
+set fp [open "$scripts_dir/passwords.txt" r]
+set passwords {}
+while { [gets $fp data] >= 0 } {
+  lappend passwords $data
+}
+
+# TODO: nc/ssh-keyscan until port 22 is up instead of sleeping
+sleep 20
+
+set success 0
+# Try to connect 5 times to the AP
+for {set i 0} {$i < 5} {incr i} {
+  spawn ssh -p $port \
+            -i $script_dir/id_priv \
+            -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no \
+            -o NumberOfPasswordPrompts=[llength $passwords] $sshuser@$host
+
+  set try 0
+  set goodpass "empty"
+  expect {
+      "*password: " {
+          if { $try >= [llength $passwords] } {
+              send_error ">>> wrong passwords\n"
+              exit 1
+          }
+
+          send [lindex $passwords $try]\r
+          incr try
+          exp_continue
+      }
+
+      "*:~#*" {
+          # TODO parse board/cpu info
+          # Also might be looking in /tmp/board.json
+          send { cat /tmp/cpuinfo | grep -E "machine" | cut -d " " -f3 }
+          send \r
+          # Reduce counter to get the right pass in the list
+          incr try -1
+          set goodpass [lindex $passwords $try]
+          # exit our for loop
+          set success 1
+          break
+
+          #TODO: This is fragile
+          #expect -re {^[^\n]+\n(.*)\r\n.*$}
+          #set arch $expect_out(1,string)
+          #interact
+      }
+
+      timeout {
+          send_error ">>> timed out\n"
+          exit 1
+      }
+  }
+  puts "failed $i time(s)"
+  sleep 5
+}
+
+# check if loop was successful
+if { $success } {
+  puts "connected"
+} else {
+  puts "failed connection $env(LEASE4_HWADDR)"
+  exit 1
+}
+
+send "\r\r"
+
+# Print out password that worked
+#puts "$goodpass"
+
+# TODO: Dynamic architecture/board detection
+#puts "$arch"
+#set archb [format "hello%s" $arch]
+# Concat the arch and a string (eventually will be flash .bin)
+#puts [format "hello%s" $arch]
+#set archb "hello"
+
+spawn scp -P $port \
+  -i $script_dir/id_priv \
+  -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no \
+  $script_dir/flash.bin $sshuser@$host:/tmp/
+expect {
+    "*password: " {
+        send $goodpass\r
+        exp_continue
+    }
+    timeout {
+        send_error ">>> scp timed out\n"
+        exit 1
+    }
+}
+
+puts "scp good!"
+
+# Warning: Be careful about the escaping when spawning an ssh connection and executing commands
+set pid [spawn ssh -i $script_dir/id_priv -p $port -t\
+  -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no \
+  $sshuser@$host "grep 7fdf577afb4bf2bd3134520eef929fb3b02090c6 /etc/scale-release; if \[ $? == 0 \]; then init 0; else sysupgrade -n -v /tmp/flash.bin; fi" ]
+expect {
+    "*password: " {
+        send $goodpass\r
+        exp_continue
+    }
+
+    "*:~#*" {
+        exp_continue
+    }
+
+    eof {
+      puts "eof received"
+    }
+    #timeout {
+    #    send_error ">>> scp timed out\n"
+    #    exit 1
+    #}
+}


### PR DESCRIPTION
## Description of PR
Fixes: #385

At the past scale work party we were able to `massflash` the entire set of 100+ APs in about 2 hours. The result of the teams efforts is the following script and configuration that made this possible

## Previous Behavior
- Used to have to update each AP via the existing flash (soloflash) script

## New Behavior
- `massflash` process exists
- `kea.tmpl` for setting up a `massflash` dhcpd server

## Tests
- Flashed 100+ aps at the last workparty for scale 19x
