### PR TITLE
[READY] - Owen 19x pre.04 -- Preparation for bulk loading configuration into switches

### DIFF
--- a/switch-configuration/config/scripts/bulk_local_load_switches
+++ b/switch-configuration/config/scripts/bulk_local_load_switches
@@ -1,0 +1,166 @@
+#!/usr/bin/perl
+#
+# Override the current configuration on a switch with the appropriate configuration file from
+# the output directory. Uses SCP to place the configuratino file and then uses SSH to load and
+# activate it.
+
+# Based on override_switches script, but optimized for sequential bulk loading of switches in sequence
+#
+# General theory:
+# 	Each switch should have a common configuration on the management ethernet interface (me-0):
+#		192.168.255.76/24
+#
+#	The system where this software is running should have an interface set up on that same network.
+#
+#	1. Delete 192.168.255.76 from the local ARP cache.
+#	2. ping 192.168.255.76 until success
+#	3. Get MAC address of 192.168.255.76 from ARP table.
+#	4. Identify switch name based on MAC address lookup in switchtypes file (column 9 Mgmt MAC -> Column 1 Name)
+#	5. Load appropriate configuration from "output" directory onto switch based on the name.
+#	6. When complete, notify user and ping 192.168.255.76 until failure.
+#	7. Repeat beginning with step 1 above.
+
+# Not yet ready for use... Do not use
+die "Don't use this script yet. It's not ready"
+
+print "This program requires privileged operations. As such, it uses sudo to gain privileges when necessary."
+print "The following test will confirm that you are able to provide the necessary credentials."
+my $result = system("sudo", "date");
+if ($result)
+{
+    die("SUDO result: $result -- fail\n");
+}
+
+# Ideally this will eventually be obviated by ansible
+
+# Pull in dependencies
+use strict;
+require "./scripts/switch_template.pl";
+use FileHandle;
+use IPC::Open2;
+use Getopt::Std;
+our $opt_n;
+our $opt_l = 1;
+getopts('n');
+
+# -n -- Don't actually apply the configuration, just show the compare and then roll back.
+
+STDERR->autoflush(1);   # Turn on autoflush for STDERR
+
+# Prime the switch database
+get_switchtype("anonymous");
+
+while (1) {
+    
+    # delete ARP entry for 192.168.255.76 (Requires sudo for privileges)
+    system("sudo", "arp","-d","192.168.255.76");
+    
+    # ping 192.168.255.76 until success
+    my $success = 0;
+    print "Looking for switch on line.\n";
+    do {
+        ## FIXME ## Clean this up to avoid using a shell call.
+        my $result = system("ping -t 1 -c 1 192.168.255.76 >/dev/null 2>/dev/null");
+        $success++ unless($result)
+        sleep 1; # Retry every second until success.
+    } until($success);
+    
+    print "Switch detected, identifying.\n";
+    my $arp = `arp 192.168.255.76`;
+    $arp =~ s@^.*at \(([0-9a-f]{2}:){5}[0-9a-f]\).*@\1@;
+    
+    print "Looking for MAC $arp in switchtypes table...";
+    my @switchname = get_switch_by_mac($arp);
+    if ($#switchname < 1)
+    {
+      print STDERR "Error: No switchtype entry matching $arp\n";
+      sleep 10;
+      continue; # Retry -- until file is corrected or a valid switch is provided
+    )
+    elsif ($#switchname > 1)
+    {
+      print STDERR "Error: $arp matches multiple switches (", join(", ", @switchname),").\n";
+      sleep 10;
+      continue; # Retry -- until file is corrected or a valid switch is provided
+    }
+    print "Found: $switchname[0].\n";
+    my $switch = $switchname[0];
+
+    # Assertions:
+    #   output/* contains valid configuration files for each switch
+    #   Switches are accessible via SSH at their management address in the switchtypes file.
+    #	(unless -l in which case accessible via SSH on attached management interface)
+    # Phase 1: Push new configuration file to switch.
+    # Phase 2: Apply new configuration file using "load override <filename>" and commit it.
+    #
+    
+    # Commands used for phase 2
+    my $SWITCH_COMMANDS;
+    unless ($opt_n) {
+        $SWITCH_COMMANDS = <<EOF;
+    edit
+    load override /tmp/new_config.conf
+    show | compare
+    commit and-quit
+    exit
+EOF
+    }
+    else
+    {
+        $SWITCH_COMMANDS = <<EOF;
+    edit
+    load override /tmp/new_config.conf
+    show | compare
+    rollback
+    exit
+    exit
+EOF
+    }
+    
+    $SIG{PIPE} = \&catch_pipe;
+    
+    ##FIXME## Optimize this to be done in one step above. This is an artifact of basing this on an earlier script.
+    my ($Name, $Num, $MgtVL, $IPv6Addr, $Type);
+    print "Looking up switch $switch\n";
+    ($Name, $Num, $MgtVL, $IPv6Addr, $Type) = (get_switchtype($switch));
+    die("Error: Couldn't get type for $switch (got $Name)\n") unless $Name eq $switch; 
+    print "Got Entry:  $Name, $Num, $MgtVL, $IPv6Addr, $Type for $switch\n";
+
+    # Phase 1: Copy configuration to device
+    if (!-f "output/$Name.conf")
+    {
+        die("Error: Couldn't read configuration file for $Name");
+    }
+    ##FIXME## Using system is an attrocious hack -- do something better
+    print STDERR "Sending configuration file to $Name\n";
+    if ($opt_l) # If -l is specified, install configuration via directly attached management port
+    {
+        die("Failed to copy configuration to device $Name ($? : $!)\n") if 
+            system("scp \"output/$Name.conf\" 192.168.255.76".":/tmp/new_config.conf");
+    }
+    else
+    {
+        die("Failed to copy configuration to device $Name ($? : $!)\n") if 
+            system("scp \"output/$Name.conf\" $Name".":/tmp/new_config.conf");
+    }
+    
+    print STDERR "Activating...\n";
+    if ($opt_l) # If -l is specified, activate configuration via directly attached management port
+    {
+        open(JUNIPER, "| ssh 192.168.255.76");
+    }
+    else
+    {
+        open(JUNIPER, "| ssh $Name");
+    }
+    print JUNIPER $SWITCH_COMMANDS;
+    print STDERR "Finished sending commands to switch...\n";
+    close JUNIPER || warn "Switch $Name Bad exit from SSH: $! $?\n";
+}
+
+
+sub catch_pipe {
+    my $signame = shift;
+    print STDERR "Pipe signal cauthg ($signame) $! $?\n";
+}
+

--- a/switch-configuration/config/scripts/override_switches
+++ b/switch-configuration/config/scripts/override_switches
@@ -58,8 +58,9 @@ foreach(@list)
 }
 
 # Assertions:
-#   output/* contains valid configuratin files for each switch
+#   output/* contains valid configuration files for each switch
 #   Switches are accessible via SSH at their management address in the switchtypes file.
+#	(unless -l in which case accessible via SSH on attached management interface)
 # Phase 1: Push new configuration file to switch.
 # Phase 2: Apply new configuration file using "load override <filename>" and commit it.
 #

--- a/switch-configuration/config/scripts/switch_template.pl
+++ b/switch-configuration/config/scripts/switch_template.pl
@@ -164,10 +164,10 @@ sub get_switchtype
     my $switchtypes = read_config_file("switchtypes");
     foreach(@{$switchtypes})
     {
-      my ($Name, $Num, $MgtVL, $IPv6Addr, $Type, $hierarchy, $noiselevel) = split(/\t+/, $_);
+      my ($Name, $Num, $MgtVL, $IPv6Addr, $Type, $hierarchy, $noiselevel, $model, $mgmtMAC) = split(/\t+/, $_);
       my ($group, $level) = split(/\./, $hierarchy);
       debug(9,"switchtypes->$Name = ($Num, $MgtVL, $IPv6Addr, $Type, $group, $level)\n");
-      $Switchtypes{$Name} = [ $Num, $MgtVL, $IPv6Addr, $Type, $group, $level ];
+      $Switchtypes{$Name} = [ $Num, $MgtVL, $IPv6Addr, $Type, $group, $level, $noiselevel, $model, $mgmtMAC ];
       # Build cache of groups
       debug(5, "Adding $Name to group $group at level $level\n");
       if (!defined($Switchgroups{$group}))
@@ -197,9 +197,28 @@ sub get_switchtype
                             $Switchtypes{$hostname}[3]. ", ".
                             $Switchtypes{$hostname}[4]. ", ".
                             $Switchtypes{$hostname}[5]. ", ".
-                            $Switchtypes{$hostname}[6]. ")\n");
+                            $Switchtypes{$hostname}[6]. ", ".
+                            $Switchtypes{$hostname}[7]. ", ".
+                            $Switchtypes{$hostname}[8]. ", ".
+                            $Switchtypes{$hostname}[9]. ")\n");
   return($hostname, @{$Switchtypes{$hostname}});
 }
+
+sub get_switch_by_mac
+{
+  ## FIXME ## Assertion -- Switchtypes hash has been preloaded
+  my $macaddr = shift(@_);
+  my @switches = ();
+  foreach(keys(%Switchtypes))
+  {
+    ## FIXME ## Stupid stringwise comparison may not accurately find MAC addresses
+    if (lc($macaddr) eq lc($Switchtypes{$_}[9]))
+    {
+      push(@switches, $_);
+    }
+  }
+  return(@switches);
+};
 
 sub build_users_from_auth
 {

--- a/switch-configuration/config/switchtypes
+++ b/switch-configuration/config/switchtypes
@@ -13,57 +13,57 @@
 // .1 = First priority, head-end for hierarchy (e.g. C.1 = NE-IDF Switch)
 // ... Switch chain order from .1 (e.g. C.2 is plugged into C.1 level, C.3 is plugged into C.2 level, etc.)
 // .9 = Stub (No subordinate switches) regardless of next level up switch
-//Name		Num	MgtVL	IPv6				Type		Hierarchy	Noiselevel	Model
-Carmel		1	103	2001:470:f0fb:103::200:1	hiRoom		D.9		Quiet		ex4200-48p
-TTAB-NW-BMT	2	103	2001:470:f0fb:103::200:2	hiIDF		M.2		Loud		ex4200-48p
-MDF-SR		3	103	2001:470:f0fb:103::200:3	hiMDF		M.1		Loud		ex4200-48p
-LaJolla		4	103	2001:470:f0fb:103::200:4	hiRoom		E.9		Normal		ex4200-48p
-Marina		5	103	2001:470:f0fb:103::200:5	hiRoom		D.9		Normal		ex4200-48p
-TTSR-GM-BMT	6	103	2001:470:f0fb:103::200:6	hiIDF		M.2		Loud		ex4200-48p
-LosAngelesAB	7	103	2001:470:f0fb:103::200:7	hiRoom		D.9		Normal		ex4200-48p
-LosAngelesC	8	103	2001:470:f0fb:103::200:8	hiRoom		D.9		Quiet		ex4200-48p
-CenturyAB	9	103	2001:470:f0fb:103::200:9	hiRoom		D.9		Normal		ex4200-48p
-SanLorenzoB	10	103	2001:470:f0fb:103::200:10	hiRoom		D.1		Loud		ex4200-48p
-CenturyCD	11	103	2001:470:f0fb:103::200:11	hiRoom		D.9		Normal		ex4200-48p
-SantaMonicaA	12	103	2001:470:f0fb:103::200:12	hiRoom		D.9		Normal		ex4200-48p
-SpareD		13	103	2001:470:f0fb:103::200:13	hiRoom		E.9		Normal		ex4200-48p
-AVSwitch-CatB	14	103	2001:470:f0fb:103::200:14	hiAV		E.9		Normal		ex4200-48p
-SpareE		15	103	2001:470:f0fb:103::200:15	hiRoom		Z.9		??		ex4200-48p
-SpareF		16	103	2001:470:f0fb:103::200:16	hiRoom		Z.9		??		ex4200-48p
-CatalinaC	17	103	2001:470:f0fb:103::200:17	hiRoom		E.9		Normal		ex4200-48p
-ExpoA1		18	103	2001:470:f0fb:103::200:18	Booth		L.2		Loud		ex4200-48p
-CatalinaD	19	103	2001:470:f0fb:103::200:19	hiRoom		E.9		Normal		ex4200-48p
-NewportA	20	103	2001:470:f0fb:103::200:20	hiRoom		D.9		Quiet		ex4200-48p
-NOC-CatA	21	103	2001:470:f0fb:103::200:21	hiNOC		E.2		Normal		ex4200-48p
-ExpoB1		22	103	2001:470:f0fb:103::200:22	Booth		L.2		Loud		ex4200-48p
-CTF1		23	103	2001:470:f0fb:103::200:23	hiCTF		Z.9		Normal		ex4200-48p
-ExpoC1		24	103	2001:470:f0fb:103::200:24	Booth		L.2		Loud		ex4200-48p
-NewportB	25	103	2001:470:f0fb:103::200:25	hiRoom		D.9		Quiet		ex4200-48p
-CTF2		26	103	2001:470:f0fb:103::200:26	hiCTF		Z.9		Normal		ex4200-48p
-SanLorenzoC	27	103	2001:470:f0fb:103::200:27	hiRoom		D.9		Normal		ex4200-48p
-ExpoA2		28	103	2001:470:f0fb:103::200:28	Booth		L.2		Loud		ex4200-48p
-ExpoB2		29	103	2001:470:f0fb:103::200:29	Booth		L.2		Loud		ex4200-48p
-SanLorenzoD	30	103	2001:470:f0fb:103::200:30	hiRoom		D.9		Normal		ex4200-48p
-NewportC	31	103	2001:470:f0fb:103::200:31	hiRoom		E.9		Quiet		ex4200-48p
-RegDesk		32	103	2001:470:f0fb:103::200:32	hiRegistration	D.9		Normal		ex4200-48p
-ExpoC2		33	103	2001:470:f0fb:103::200:33	Booth		L.2		Normal		ex4200-48p
-ExpoA3		34	103	2001:470:f0fb:103::200:34	Booth		L.2		Loud		ex4200-48p
-ExpoB3		35	103	2001:470:f0fb:103::200:35	Booth		L.2		Loud		ex4200-48p
-ExpoC3		36	103	2001:470:f0fb:103::200:36	Booth		L.2		Normal		ex4200-48p
-SantaMonicaB	37	103	2001:470:f0fb:103::200:37	hiRoom		D.9		Quiet		ex4200-48p
-ExpoA4		38	103	2001:470:f0fb:103::200:38	Booth		L.2		Normal		ex4200-48p
-ExpoB4		39	103	2001:470:f0fb:103::200:39	Booth		L.2		Normal		ex4200-48p
-SantaMonicaC	40	103	2001:470:f0fb:103::200:40	hiRoom		D.9		Quiet		ex4200-48p
-ExpoC4		41	103	2001:470:f0fb:103::200:41	hiRoom		L.2		Normal		ex4200-48p
-ExpoA5		42	103	2001:470:f0fb:103::200:42	hiRoom		L.2		Normal		ex4200-48p
-ExpoB5		43	103	2001:470:f0fb:103::200:43	hiRoom		L.2		Normal		ex4200-48p
-BelAir		44	103	2001:470:f0fb:103::200:44	hiRoom		E.9		Loud		ex4200-48p
-SanLorenzoA	45	103	2001:470:f0fb:103::200:45	hiRoom		D.9		Normal		ex4200-48p
-SanLorenzoE	46	103	2001:470:f0fb:103::200:46	hiRoom		D.9		Loud		ex4200-48p
-SanLorenzoF	47	103	2001:470:f0fb:103::200:47	hiRoom		D.9		Normal		ex4200-48p
-TTLB-LBY	48	103	2001:470:f0fb:103::200:48	hiIDF		M.2		??		ex4200-48p
-TT2E-2FCat	49	103	2001:470:f0fb:103::200:49	hiIDF		M.2		??		ex4200-48p
-TT2D-2FReg	50	103	2001:470:f0fb:103::200:50	hiIDF		M.2		??		ex4200-48p
-SpareA		51	103	2001:470:f0fb:103::200:51	hiRoom		Z.9		??		ex4200-24t
-SpareB		52	103	2001:470:f0fb:103::200:52	hiRoom		Z.9		??		ex4200-24t
-SpareC		53	103	2001:470:f0fb:103::200:53	hiRoom		Z.9		??		ex4200-24t
+//Name		Num	MgtVL	IPv6				Type		Hierarchy	Noiselevel	Model		Mgmt MAC
+Carmel		1	103	2001:470:f0fb:103::200:1	hiRoom		D.9		Quiet		ex4200-48p	02:00:00:00:00:01
+TTAB-NW-BMT	2	103	2001:470:f0fb:103::200:2	hiIDF		M.2		Loud		ex4200-48p	02:00:00:00:00:02
+MDF-SR		3	103	2001:470:f0fb:103::200:3	hiMDF		M.1		Loud		ex4200-48p	02:00:00:00:00:03
+LaJolla		4	103	2001:470:f0fb:103::200:4	hiRoom		E.9		Normal		ex4200-48p	02:00:00:00:00:04
+Marina		5	103	2001:470:f0fb:103::200:5	hiRoom		D.9		Normal		ex4200-48p	02:00:00:00:00:05
+TTSR-GM-BMT	6	103	2001:470:f0fb:103::200:6	hiIDF		M.2		Loud		ex4200-48p	02:00:00:00:00:06
+LosAngelesAB	7	103	2001:470:f0fb:103::200:7	hiRoom		D.9		Normal		ex4200-48p	02:00:00:00:00:07
+LosAngelesC	8	103	2001:470:f0fb:103::200:8	hiRoom		D.9		Quiet		ex4200-48p	02:00:00:00:00:08
+CenturyAB	9	103	2001:470:f0fb:103::200:9	hiRoom		D.9		Normal		ex4200-48p	02:00:00:00:00:09
+SanLorenzoB	10	103	2001:470:f0fb:103::200:10	hiRoom		D.1		Loud		ex4200-48p	02:00:00:00:00:10
+CenturyCD	11	103	2001:470:f0fb:103::200:11	hiRoom		D.9		Normal		ex4200-48p	02:00:00:00:00:11
+SantaMonicaA	12	103	2001:470:f0fb:103::200:12	hiRoom		D.9		Normal		ex4200-48p	02:00:00:00:00:12
+SpareD		13	103	2001:470:f0fb:103::200:13	hiRoom		E.9		Normal		ex4200-48p	02:00:00:00:00:13
+AVSwitch-CatB	14	103	2001:470:f0fb:103::200:14	hiAV		E.9		Normal		ex4200-48p	02:00:00:00:00:14
+SpareE		15	103	2001:470:f0fb:103::200:15	hiRoom		Z.9		??		ex4200-48p	02:00:00:00:00:15
+SpareF		16	103	2001:470:f0fb:103::200:16	hiRoom		Z.9		??		ex4200-48p	02:00:00:00:00:16
+CatalinaC	17	103	2001:470:f0fb:103::200:17	hiRoom		E.9		Normal		ex4200-48p	02:00:00:00:00:17
+ExpoA1		18	103	2001:470:f0fb:103::200:18	Booth		L.2		Loud		ex4200-48p	02:00:00:00:00:18
+CatalinaD	19	103	2001:470:f0fb:103::200:19	hiRoom		E.9		Normal		ex4200-48p	02:00:00:00:00:19
+NewportA	20	103	2001:470:f0fb:103::200:20	hiRoom		D.9		Quiet		ex4200-48p	02:00:00:00:00:20
+NOC-CatA	21	103	2001:470:f0fb:103::200:21	hiNOC		E.2		Normal		ex4200-48p	02:00:00:00:00:21
+ExpoB1		22	103	2001:470:f0fb:103::200:22	Booth		L.2		Loud		ex4200-48p	02:00:00:00:00:22
+CTF1		23	103	2001:470:f0fb:103::200:23	hiCTF		Z.9		Normal		ex4200-48p	02:00:00:00:00:23
+ExpoC1		24	103	2001:470:f0fb:103::200:24	Booth		L.2		Loud		ex4200-48p	02:00:00:00:00:24
+NewportB	25	103	2001:470:f0fb:103::200:25	hiRoom		D.9		Quiet		ex4200-48p	02:00:00:00:00:25
+CTF2		26	103	2001:470:f0fb:103::200:26	hiCTF		Z.9		Normal		ex4200-48p	02:00:00:00:00:26
+SanLorenzoC	27	103	2001:470:f0fb:103::200:27	hiRoom		D.9		Normal		ex4200-48p	02:00:00:00:00:27
+ExpoA2		28	103	2001:470:f0fb:103::200:28	Booth		L.2		Loud		ex4200-48p	02:00:00:00:00:28
+ExpoB2		29	103	2001:470:f0fb:103::200:29	Booth		L.2		Loud		ex4200-48p	02:00:00:00:00:29
+SanLorenzoD	30	103	2001:470:f0fb:103::200:30	hiRoom		D.9		Normal		ex4200-48p	02:00:00:00:00:30
+NewportC	31	103	2001:470:f0fb:103::200:31	hiRoom		E.9		Quiet		ex4200-48p	02:00:00:00:00:31
+RegDesk		32	103	2001:470:f0fb:103::200:32	hiRegistration	D.9		Normal		ex4200-48p	02:00:00:00:00:32
+ExpoC2		33	103	2001:470:f0fb:103::200:33	Booth		L.2		Normal		ex4200-48p	02:00:00:00:00:33
+ExpoA3		34	103	2001:470:f0fb:103::200:34	Booth		L.2		Loud		ex4200-48p	02:00:00:00:00:34
+ExpoB3		35	103	2001:470:f0fb:103::200:35	Booth		L.2		Loud		ex4200-48p	02:00:00:00:00:35
+ExpoC3		36	103	2001:470:f0fb:103::200:36	Booth		L.2		Normal		ex4200-48p	02:00:00:00:00:36
+SantaMonicaB	37	103	2001:470:f0fb:103::200:37	hiRoom		D.9		Quiet		ex4200-48p	02:00:00:00:00:37
+ExpoA4		38	103	2001:470:f0fb:103::200:38	Booth		L.2		Normal		ex4200-48p	02:00:00:00:00:38
+ExpoB4		39	103	2001:470:f0fb:103::200:39	Booth		L.2		Normal		ex4200-48p	02:00:00:00:00:39
+SantaMonicaC	40	103	2001:470:f0fb:103::200:40	hiRoom		D.9		Quiet		ex4200-48p	02:00:00:00:00:40
+ExpoC4		41	103	2001:470:f0fb:103::200:41	hiRoom		L.2		Normal		ex4200-48p	02:00:00:00:00:41
+ExpoA5		42	103	2001:470:f0fb:103::200:42	hiRoom		L.2		Normal		ex4200-48p	02:00:00:00:00:42
+ExpoB5		43	103	2001:470:f0fb:103::200:43	hiRoom		L.2		Normal		ex4200-48p	02:00:00:00:00:43
+BelAir		44	103	2001:470:f0fb:103::200:44	hiRoom		E.9		Loud		ex4200-48p	02:00:00:00:00:44
+SanLorenzoA	45	103	2001:470:f0fb:103::200:45	hiRoom		D.9		Normal		ex4200-48p	02:00:00:00:00:45
+SanLorenzoE	46	103	2001:470:f0fb:103::200:46	hiRoom		D.9		Loud		ex4200-48p	02:00:00:00:00:46
+SanLorenzoF	47	103	2001:470:f0fb:103::200:47	hiRoom		D.9		Normal		ex4200-48p	02:00:00:00:00:47
+TTLB-LBY	48	103	2001:470:f0fb:103::200:48	hiIDF		M.2		??		ex4200-48p	02:00:00:00:00:48
+TT2E-2FCat	49	103	2001:470:f0fb:103::200:49	hiIDF		M.2		??		ex4200-48p	02:00:00:00:00:49
+TT2D-2FReg	50	103	2001:470:f0fb:103::200:50	hiIDF		M.2		??		ex4200-48p	02:00:00:00:00:50
+SpareA		51	103	2001:470:f0fb:103::200:51	hiRoom		Z.9		??		ex4200-24t	02:00:00:00:00:51
+SpareB		52	103	2001:470:f0fb:103::200:52	hiRoom		Z.9		??		ex4200-24t	02:00:00:00:00:52
+SpareC		53	103	2001:470:f0fb:103::200:53	hiRoom		Z.9		??		ex4200-24t	02:00:00:00:00:53


### PR DESCRIPTION
## Description of PR
This PR includes changes necessary to support bulk loading configuration into switches:
bulk_local_load_switches -- New script for quickly loading configs onto switches 
override_switches -- Correct typo in comment and clarify comment.
switch_template -- Add functionality for additional fields in switchtypes, new function get_switch_by_mac
switchtypes -- Add standins for MAC addresses until real addresses can be captured. Intended to facilitate testing.

## Previous Behavior
Functionality did not exist

## New Behavior
bulk_local_load_switches will wait for the management ethernet of a switch to become available and then identify the switch by MAC address in the switch types file and load the appropriate configuration file onto the switch and commit it.

## Tests
Unable to test due to resource constraints (switches in storage in Pasadena), will have to test and debug after arrival in LA Sunday.