### PR TITLE
[READY] - Updates to the core role for ansible during 19x deployment

### DIFF
--- a/ansible/roles/dhcpserver/templates/dhcpd.conf.subnets.j2
+++ b/ansible/roles/dhcpserver/templates/dhcpd.conf.subnets.j2
@@ -7,7 +7,7 @@ subnet {{ vlan["ipv4prefix"] }} netmask {{ vlan["ipv4netmask"]}} {
 {% else %}
     range {{ vlan["ipv4dhcp2a"] }} {{ vlan["ipv4dhcp2b"] }};
 {% endif %}
-    option domain-name-servers {{ vlan["ipv4dns1"] }}, {{ vlan["ipv4dns2"] }}; 
+    option domain-name-servers {{ vlan["ipv4dns1"] + vlan["ipv4dns2"] | join(',')}};
     option routers {{ vlan["ipv4router"]}};
 }
 {% endif %}

--- a/ansible/roles/dhcpserver/templates/dhcpd6.conf.subnets.j2
+++ b/ansible/roles/dhcpserver/templates/dhcpd6.conf.subnets.j2
@@ -7,7 +7,7 @@ subnet6 {{ vlan["ipv6prefix"] }}/{{ vlan["ipv6bitmask"] }} {
 {% else %}
     range6 {{ vlan["ipv6dhcp2a"] }} {{ vlan["ipv6dhcp2b"] }};
 {% endif %}
-    option dhcp6.name-servers {{ vlan["ipv6dns1"] }}, {{ vlan["ipv6dns2"] }}; 
+    option dhcp6.name-servers {{ vlan["ipv6dns1"] + vlan["ipv6dns2"] | join(',')}};
 }
 {% endif %}
 {% endfor %}

--- a/ansible/roles/dnsserver/files/named.conf.options
+++ b/ansible/roles/dnsserver/files/named.conf.options
@@ -1,6 +1,6 @@
 options {
         directory "/var/cache/bind";
-        dnssec-validation auto;
+        dnssec-validation no;
         auth-nxdomain no;    # conform to RFC1035
         listen-on-v6 { any; };
 };

--- a/ansible/roles/dnsserver/templates/named.conf.scale-acls.j2
+++ b/ansible/roles/dnsserver/templates/named.conf.scale-acls.j2
@@ -16,7 +16,7 @@ acl conference {
 };
 
 acl expo {
-{% if hostvars[ansible_hostname].building == "Expo" %}
+{% if hostvars[ansible_hostname].building != "Conference" %}
     localhost;
 {% endif %}
 {% for vlan in vlans %}

--- a/facts/servers/serverlist.csv
+++ b/facts/servers/serverlist.csv
@@ -9,8 +9,7 @@ server7,4c:72:b9:7c:3a:f9,,,
 server8,4c:72:b9:7c:42:21,,,
 server9,4c:72:b9:7c:3e:1d,,,
 server10,4c:72:b9:7c:3f:bc,,,
-core1,58:9c:fc:02:ba:18,2001:470:f325:503::5,10.128.3.5,core
-core2,58:9c:fc:0a:4d:d4,2001:470:f325:103::5,10.0.3.5,core
-monitoring1,58:9c:fc:0a:a8:f3,2001:470:f325:503::6,10.128.3.6,monitoring
-automation1,58:9c:fc:05:4a:f9,2001:470:f325:503::7,10.128.3.7,automation
-pkgcache,02:d7:ea:6f:f5:0b,2001:470:f325:503::19,10.128.3.19,norole
+core1,58:9c:fc:00:38:5f,2001:470:f0fb:103::5,10.0.3.5,core
+monitoring1,58:9c:fc:0a:a8:f3,2001:470:f0fb:103::6,10.0.3.6,monitoring
+automation1,58:9c:fc:05:4a:f9,2001:470:f0fb:103::7,10.0.3.7,automation
+pkgcache,02:d7:ea:6f:f5:0b,2001:470:f0fb:103::19,10.0.3.19,norole


### PR DESCRIPTION
## Description of PR

Updates to the `core` role for ansible during 19x deployment

## Previous Behavior
- Support for 2 dns servers in dhcpd
- named acl conditional led to inconsistent templating
- Bind dnssec set to `auto` (default from bind iirc)

## New Behavior
- Support for 1 or 2 dns server in dhcpd
- named acl conditional led to inconsistent templating
- Bind DNSSEC set to `no` - disabling DNSSEC for the root recursive name servers 
- Updates to the serverlist.csv for `core1` and updates to the ipv6 prefix

## Tests
- ansible-playbook -u ubuntu -i inventory.py core.yml
> `core.yml` is a temp file to only test the single role
