### PR TITLE
Added -i flag to override_switches to allow ignoring failed switches

### DIFF
--- a/switch-configuration/config/scripts/override_switches
+++ b/switch-configuration/config/scripts/override_switches
@@ -15,10 +15,12 @@ require "./scripts/switch_template.pl";
 use FileHandle;
 use IPC::Open2;
 use Getopt::Std;
+our $opt_i;
 our $opt_l;
 our $opt_n;
-getopts('ln');
+getopts('iln');
 
+# -i -- ignore failed switches, print a summary of failures at the end.
 # -l -- configure locally attached switch via management interface rather than remote.
 # -n -- Don't actually apply the configuration, just show the compare and then roll back.
 
@@ -95,6 +97,16 @@ sub catch_pipe {
     print STDERR "Pipe signal cauthg ($signame) $! $?\n";
 }
 
+if ($opt_i && $opt_l) {
+    warn("Warning: -i and -l not compatible, -l supercedes.");
+}
+
+if ($opt_i)
+{
+    print STDERR "Errors will be recorded and ignored. (-i chosen).\n";
+}
+
+my %errors=();
 foreach my $switch (@list)
 {
     my ($Name, $Num, $MgtVL, $IPv6Addr, $Type);
@@ -106,7 +118,14 @@ foreach my $switch (@list)
     # Phase 1: Copy configuration to device
     if (!-f "output/$Name.conf")
     {
-        die("Error: Couldn't read configuration file for $Name");
+        if ($opt_i)
+        {
+            push @{$errors{$Name}}, "Error: Couldn't read configuration file for $Name";
+        }
+        else
+        {
+            die("Error: Couldn't read configuration file for $Name");
+        }
     }
     ##FIXME## Using system is an attrocious hack -- do something better
     print STDERR "Sending configuration file to $Name ($IPv6Addr)\n";
@@ -117,8 +136,18 @@ foreach my $switch (@list)
     }
     else
     {
-        die("Failed to copy configuration to device $Name at $IPv6Addr ($? : $!)\n") if 
-            system("scp \"output/$Name.conf\" \[$IPv6Addr\]".":/tmp/new_config.conf");
+        if (system("scp \"output/$Name.conf\" \[$IPv6Addr\]".":/tmp/new_config.conf"))
+        {
+            if ($opt_i)
+            {
+                push @{$errors{$Name}},
+                    "Failed to copy configuration to device $Name at $IPv6Addr ($? : $!)\n";
+            }
+            else
+            {
+                die("Failed to copy configuration to device $Name at $IPv6Addr ($? : $!)\n");
+            }
+        }
     }
     
     print STDERR "Activating...\n";
@@ -133,4 +162,14 @@ foreach my $switch (@list)
     print JUNIPER $SWITCH_COMMANDS;
     print STDERR "Finished sending commands to switch...\n";
     close JUNIPER || warn "Switch $Name Bad exit from SSH: $! $?\n";
+}
+
+foreach (sort keys(%errors))
+{
+  print STDERR "Failures on switch $_:\n";
+  foreach my $error (@{$errors{$_}})
+  {
+    print STDERR "\t$error\n";
+  }
+  print "\n";
 }


### PR DESCRIPTION
## Description of PR
Added -I option to override_switches to allow script to proceed, ignoring failed switches.

## Previous Behavior
First failed switch aborted script

## New Behavior
If -I option is used, switch failures will not abort the script and are reported at the end of the run.

## Tests
Ran it against a mostly non-existent network. Errors were reported at the end as expected.
