### PR TITLE
[READY]  - fixing apinger and massflash updates

### DIFF
--- a/ansible/roles/dnsserver/templates/named.conf.scale-acls.j2
+++ b/ansible/roles/dnsserver/templates/named.conf.scale-acls.j2
@@ -2,7 +2,7 @@
 // FIX: this makes assumes for the building and ip mapping
 
 acl conference {
-    10.128.0.0/16;
+    10.128.0.0/9;
     2001:470:f0fb:500::/56;
     2001:470:f0fb:600::/55;
     2001:470:f0fb:800::/56;
@@ -10,7 +10,7 @@ acl conference {
 
 acl expo {
     localhost;
-    10.0.0.0/16;
+    10.0.0.0/9;
     2001:470:f0fb:0::/54;
     2001:470:f0fb:400::/56;
 };

--- a/openwrt/Makefile
+++ b/openwrt/Makefile
@@ -119,6 +119,7 @@ endif
 	# TODO: should do this automatically for .sh file types
 	chmod 750 $(TMPL_OUT_DIR)/root/bin/config-version.sh
 	chmod 750 $(TMPL_OUT_DIR)/root/bin/wifi-details.sh
+	chmod 750 $(TMPL_OUT_DIR)/root/bin/apinger-pop.sh
 	chmod 755 $(TMPL_OUT_DIR)/root
 	chmod 700 $(TMPL_OUT_DIR)/root/.ssh
 	chmod 640 $(TMPL_OUT_DIR)/root/.ssh/authorized_keys

--- a/openwrt/docs/MASSFLASH.md
+++ b/openwrt/docs/MASSFLASH.md
@@ -19,6 +19,7 @@ Place the following files in `openwrt/scripts/massflash`:
 <INTERFACE> = enp5s0.503
 <LIBRUNSCRIPT> = /nix/store/5qr44w8fm0vf5whsa683444wv4q0bwns-kea-2.0.2/lib/kea/hooks/libdhcp_run_script.so
 <MASSFLASH> = /home/user/scale-network/scripts/massflash/massflash
+SHAHERE = 7fdf577afb4bf2bd3134520eef929fb3b02090c6
 ```
 
 Outside of the necessary files:
@@ -57,3 +58,12 @@ env: QUERY4_TYPE, LEASE4_ADDRESS, LEASE4_HWADDR
 ```
 
 - Hardcoded paths. These will get cleaned up in followups to the repo. Right now they will be left in for as references.
+
+## Running oneoff
+
+One off to run the `massflash`:
+```
+export QUERY4_TYPE=DHCPREQUEST
+export LEASE4_ADDRESS=<IP>
+expect massflash lease4_renew
+```

--- a/openwrt/files/etc/rc.local
+++ b/openwrt/files/etc/rc.local
@@ -4,4 +4,11 @@
 # TODO make this a true service
 /root/bin/wifi-details.sh >/dev/null 2>/dev/null </dev/null &
 
+# apinger initial template population
+# this needs to remain in the case where DHCP isnt working initially
+# there is also a race condition with the wifi interfaces coming online
+# and requires a 30 sec grace period before checking via apinger. If not
+# the result is wifi is up but the wifi tool detects it as down
+(sleep 30 && /root/bin/apinger-pop.sh "8.8.8.8") &> /dev/null &
+
 exit 0

--- a/openwrt/files/etc/udhcpc.user
+++ b/openwrt/files/etc/udhcpc.user
@@ -18,12 +18,7 @@ case "$1" in
 
     # apinger template population
     if [ ! -z "$router" ]; then
-      sed "s/<DEFAULTGATEWAY>/$router/g" /etc/apinger.tmpl > /tmp/apinger.conf
-      # Only restart apinger if compare has diff
-      if ! cmp /tmp/apinger.conf /etc/apinger.conf; then
-        # Cant use "service" since thats a shell function
-        cp /tmp/apinger.conf /etc/apinger.conf && /etc/init.d/apinger restart
-      fi
+      /root/bin/apinger-pop.sh "$router"
     fi
 
     if [ ! -z "$hostname" ]; then

--- a/openwrt/files/etc/udhcpc.user
+++ b/openwrt/files/etc/udhcpc.user
@@ -24,7 +24,13 @@ case "$1" in
     if [ ! -z "$hostname" ]; then
       uci set 'system.@system[0].hostname'="$hostname"
       uci commit
-      if [ `echo "$HOSTNAME" | tr '[A-Z]' '[a-z]'` != `echo "$hostname" | tr '[A-Z]' '[a-z]'` ]; then reboot; fi
+      if [ `echo "$HOSTNAME" | tr '[A-Z]' '[a-z]'` != `echo "$hostname" | tr '[A-Z]' '[a-z]'` ]; then
+        # reload/restart whatever needs the hostname updated
+        /etc/init.d/system reload
+        service zabbix_agentd restart
+        service rsyslog restart
+        service lldpd restart
+      fi
     fi
     if [ ! -z "$opt226" ]; then
       /root/bin/config-version.sh -c $(printf %d "0x$opt226")

--- a/openwrt/files/root/bin/apinger-pop.sh
+++ b/openwrt/files/root/bin/apinger-pop.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+
+if [ -z ${1} ]; then
+  echo "[ERROR] require arg for setting the gateway"
+  exit 1
+fi
+
+sed "s/<DEFAULTGATEWAY>/${1}/g" /etc/apinger.tmpl > /tmp/apinger.conf
+# Only restart apinger if compare has diff
+if ! cmp /tmp/apinger.conf /etc/apinger.conf; then
+  # Cant use "service" since thats a shell function
+  sleep 5
+  cp /tmp/apinger.conf /etc/apinger.conf && /etc/init.d/apinger restart
+fi

--- a/openwrt/scripts/massflash/massflash
+++ b/openwrt/scripts/massflash/massflash
@@ -37,7 +37,7 @@ set host $env(LEASE4_ADDRESS)
 set port "22"
 
 # Read in passwords from password file
-set fp [open "$scripts_dir/passwords.txt" r]
+set fp [open "$script_dir/passwords.txt" r]
 set passwords {}
 while { [gets $fp data] >= 0 } {
   lappend passwords $data
@@ -71,6 +71,7 @@ for {set i 0} {$i < 5} {incr i} {
       "*:~#*" {
           # TODO parse board/cpu info
           # Also might be looking in /tmp/board.json
+          # cat /etc/board.json | jq -r .model.id | cut -d',' -f2
           send { cat /tmp/cpuinfo | grep -E "machine" | cut -d " " -f3 }
           send \r
           # Reduce counter to get the right pass in the list

--- a/openwrt/scripts/massflash/massflash
+++ b/openwrt/scripts/massflash/massflash
@@ -136,7 +136,7 @@ puts "scp good!"
 # Warning: Be careful about the escaping when spawning an ssh connection and executing commands
 set pid [spawn ssh -i $script_dir/id_priv -p $port -t\
   -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no \
-  $sshuser@$host "grep 7fdf577afb4bf2bd3134520eef929fb3b02090c6 /etc/scale-release; if \[ $? == 0 \]; then init 0; else sysupgrade -n -v /tmp/flash.bin; fi" ]
+  $sshuser@$host "grep SHAHERE /etc/scale-release; if \[ $? == 0 \]; then init 0; else sysupgrade -n -v /tmp/flash.bin; fi" ]
 expect {
     "*password: " {
         send $goodpass\r

--- a/tests/unit/openwrt/golden/ar71xx/etc/rc.local
+++ b/tests/unit/openwrt/golden/ar71xx/etc/rc.local
@@ -4,4 +4,11 @@
 # TODO make this a true service
 /root/bin/wifi-details.sh >/dev/null 2>/dev/null </dev/null &
 
+# apinger initial template population
+# this needs to remain in the case where DHCP isnt working initially
+# there is also a race condition with the wifi interfaces coming online
+# and requires a 30 sec grace period before checking via apinger. If not
+# the result is wifi is up but the wifi tool detects it as down
+(sleep 30 && /root/bin/apinger-pop.sh "8.8.8.8") &> /dev/null &
+
 exit 0

--- a/tests/unit/openwrt/golden/ar71xx/etc/udhcpc.user
+++ b/tests/unit/openwrt/golden/ar71xx/etc/udhcpc.user
@@ -18,18 +18,19 @@ case "$1" in
 
     # apinger template population
     if [ ! -z "$router" ]; then
-      sed "s/<DEFAULTGATEWAY>/$router/g" /etc/apinger.tmpl > /tmp/apinger.conf
-      # Only restart apinger if compare has diff
-      if ! cmp /tmp/apinger.conf /etc/apinger.conf; then
-        # Cant use "service" since thats a shell function
-        cp /tmp/apinger.conf /etc/apinger.conf && /etc/init.d/apinger restart
-      fi
+      /root/bin/apinger-pop.sh "$router"
     fi
 
     if [ ! -z "$hostname" ]; then
       uci set 'system.@system[0].hostname'="$hostname"
       uci commit
-      if [ `echo "$HOSTNAME" | tr '[A-Z]' '[a-z]'` != `echo "$hostname" | tr '[A-Z]' '[a-z]'` ]; then reboot; fi
+      if [ `echo "$HOSTNAME" | tr '[A-Z]' '[a-z]'` != `echo "$hostname" | tr '[A-Z]' '[a-z]'` ]; then
+        # reload/restart whatever needs the hostname updated
+        /etc/init.d/system reload
+        service zabbix_agentd restart
+        service rsyslog restart
+        service lldpd restart
+      fi
     fi
     if [ ! -z "$opt226" ]; then
       /root/bin/config-version.sh -c $(printf %d "0x$opt226")

--- a/tests/unit/openwrt/golden/ar71xx/root/bin/apinger-pop.sh
+++ b/tests/unit/openwrt/golden/ar71xx/root/bin/apinger-pop.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+
+if [ -z ${1} ]; then
+  echo "[ERROR] require arg for setting the gateway"
+  exit 1
+fi
+
+sed "s/<DEFAULTGATEWAY>/${1}/g" /etc/apinger.tmpl > /tmp/apinger.conf
+# Only restart apinger if compare has diff
+if ! cmp /tmp/apinger.conf /etc/apinger.conf; then
+  # Cant use "service" since thats a shell function
+  sleep 5
+  cp /tmp/apinger.conf /etc/apinger.conf && /etc/init.d/apinger restart
+fi

--- a/tests/unit/openwrt/golden/ipq806x/etc/rc.local
+++ b/tests/unit/openwrt/golden/ipq806x/etc/rc.local
@@ -4,4 +4,11 @@
 # TODO make this a true service
 /root/bin/wifi-details.sh >/dev/null 2>/dev/null </dev/null &
 
+# apinger initial template population
+# this needs to remain in the case where DHCP isnt working initially
+# there is also a race condition with the wifi interfaces coming online
+# and requires a 30 sec grace period before checking via apinger. If not
+# the result is wifi is up but the wifi tool detects it as down
+(sleep 30 && /root/bin/apinger-pop.sh "8.8.8.8") &> /dev/null &
+
 exit 0

--- a/tests/unit/openwrt/golden/ipq806x/etc/udhcpc.user
+++ b/tests/unit/openwrt/golden/ipq806x/etc/udhcpc.user
@@ -18,18 +18,19 @@ case "$1" in
 
     # apinger template population
     if [ ! -z "$router" ]; then
-      sed "s/<DEFAULTGATEWAY>/$router/g" /etc/apinger.tmpl > /tmp/apinger.conf
-      # Only restart apinger if compare has diff
-      if ! cmp /tmp/apinger.conf /etc/apinger.conf; then
-        # Cant use "service" since thats a shell function
-        cp /tmp/apinger.conf /etc/apinger.conf && /etc/init.d/apinger restart
-      fi
+      /root/bin/apinger-pop.sh "$router"
     fi
 
     if [ ! -z "$hostname" ]; then
       uci set 'system.@system[0].hostname'="$hostname"
       uci commit
-      if [ `echo "$HOSTNAME" | tr '[A-Z]' '[a-z]'` != `echo "$hostname" | tr '[A-Z]' '[a-z]'` ]; then reboot; fi
+      if [ `echo "$HOSTNAME" | tr '[A-Z]' '[a-z]'` != `echo "$hostname" | tr '[A-Z]' '[a-z]'` ]; then
+        # reload/restart whatever needs the hostname updated
+        /etc/init.d/system reload
+        service zabbix_agentd restart
+        service rsyslog restart
+        service lldpd restart
+      fi
     fi
     if [ ! -z "$opt226" ]; then
       /root/bin/config-version.sh -c $(printf %d "0x$opt226")

--- a/tests/unit/openwrt/golden/ipq806x/root/bin/apinger-pop.sh
+++ b/tests/unit/openwrt/golden/ipq806x/root/bin/apinger-pop.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+
+if [ -z ${1} ]; then
+  echo "[ERROR] require arg for setting the gateway"
+  exit 1
+fi
+
+sed "s/<DEFAULTGATEWAY>/${1}/g" /etc/apinger.tmpl > /tmp/apinger.conf
+# Only restart apinger if compare has diff
+if ! cmp /tmp/apinger.conf /etc/apinger.conf; then
+  # Cant use "service" since thats a shell function
+  sleep 5
+  cp /tmp/apinger.conf /etc/apinger.conf && /etc/init.d/apinger restart
+fi


### PR DESCRIPTION
## Description of PR

apinger updates, dhcpclient reload/restart services, and massflash being used to update the APs

## Previous Behavior
- `apinger` template wasnt working when no network was present
- `dhcpclient` reboots when hostname changes
- AP will yoyo if it has amnesia of its hostname

## New Behavior
- Fixing `apinger` on boot when no network present at first
- `dhcpclient` reloads services and system when hostname changes
- AP has stable uptime stable
- `massflash` doesnt have a hardcode sha

## Tests
- [x] - Loaded it on `flash1` correctly
- [x] - Test cases: flash -> bring up without network results in down the radios
- [x] - Test cases: unplug network and replug with radios going down then up as expected 
- [x] - serverspec tests pass
- [x] - load on `noc1` and AP has been running successfully since
