### PR TITLE
[REVIEW] - init flake.nix and loghost machine build

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,26 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1669542132,
+        "narHash": "sha256-DRlg++NJAwPh8io3ExBJdNW7Djs3plVI5jgYQ+iXAZQ=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "a115bb9bd56831941be3776c8a94005867f316a7",
+        "type": "github"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "ref": "nixos-unstable",
+        "type": "indirect"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -14,6 +14,26 @@
       nixpkgsFor = forAllSystems (system: import nixpkgs { inherit system; overlays = [ ]; });
     in
     {
+      nixosConfigurations = forAllSystems (system:
+        let
+          # All scale common modules
+          common =
+            ({ modulesPath, ... }: {
+              imports = [
+                "${toString modulesPath}/virtualisation/qemu-vm.nix"
+              ];
+            });
+        in
+        {
+          loghost = nixpkgs.lib.nixosSystem {
+            inherit system;
+            modules = [
+              common
+              ./nix/machines/loghost.nix
+            ];
+          };
+        });
+
       # Like nix-shell
       # Good example: https://github.com/tcdi/pgx/blob/master/flake.nix
       devShells = forAllSystems

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,32 @@
+{
+  inputs = {
+    nixpkgs.url = "nixpkgs/nixos-unstable";
+  };
+  outputs = { self, nixpkgs, ... }:
+    let
+      # System types to support.
+      supportedSystems = [ "x86_64-linux" ];
+
+      # Helper function to generate an attrset '{ x86_64-linux = f "x86_64-linux"; ... }'.
+      forAllSystems = f: nixpkgs.lib.genAttrs supportedSystems (system: f system);
+
+      # Nixpkgs instantiated for supported system types.
+      nixpkgsFor = forAllSystems (system: import nixpkgs { inherit system; overlays = [ ]; });
+    in
+    {
+      # Like nix-shell
+      # Good example: https://github.com/tcdi/pgx/blob/master/flake.nix
+      devShells = forAllSystems
+        (system:
+          let
+            pkgs = nixpkgsFor.${system};
+          in
+          {
+            default = import ./shell.nix { inherit pkgs; };
+          });
+    };
+
+  # Bold green prompt for `nix develop`
+  # Had to add extra escape chars to each special char
+  nixConfig.bash-prompt = "\\[\\033[01;32m\\][nix-flakes \\W] \$\\[\\033[00m\\] ";
+}

--- a/flake.nix
+++ b/flake.nix
@@ -11,9 +11,19 @@
       forAllSystems = f: nixpkgs.lib.genAttrs supportedSystems (system: f system);
 
       # Nixpkgs instantiated for supported system types.
-      nixpkgsFor = forAllSystems (system: import nixpkgs { inherit system; overlays = [ ]; });
+      nixpkgsFor = forAllSystems (system: import nixpkgs { inherit system; overlays = [ self.overlays.default ]; });
     in
     {
+      overlays.default = (final: prev:
+        with final.pkgs;
+        rec {
+          scaleTests = import ./nix/tests/allTests.nix { inherit nixosTest; };
+        });
+
+      packages = forAllSystems (system: {
+        inherit (nixpkgsFor.${system}) scaleTests;
+      });
+
       nixosConfigurations = forAllSystems (system:
         let
           # All scale common modules

--- a/nix/README.md
+++ b/nix/README.md
@@ -1,0 +1,10 @@
+# Nix and NixOS configuration
+
+## Local VMs
+
+To build and run the `loghost` machine via nix on NixOS:
+
+```
+nix build ".#nixosConfigurations.x86_64-linux.loghost.config.system.build.vm"
+./result/bin/run-nixos-vm
+```

--- a/nix/machines/loghost.nix
+++ b/nix/machines/loghost.nix
@@ -1,0 +1,50 @@
+{ config, lib, pkgs, ... }:
+{
+  # If not present then warning and will be set to latest release during build
+  system.stateVersion = "22.11";
+
+  fileSystems."/" = {
+    device = "/dev/disk/by-label/nixos";
+    fsType = "ext4";
+    autoResize = true;
+  };
+  boot.growPartition = true;
+  boot.kernelParams = [ "console=ttyS0" ];
+  boot.loader.grub.device = "/dev/vda";
+  boot.loader.timeout = 0;
+
+  # TODO: How to handle to the root password
+  users.extraUsers.root.password = "";
+
+  # TODO: Consume users from facts/keys instead of this
+  users.users = {
+    rherna = {
+      isNormalUser = true;
+      uid = 2005;
+      extraGroups = [ "wheel" ];
+      openssh.authorizedKeys.keys = [ "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIMEiESod7DOT2cmT2QEYjBIrzYqTDnJLld1em3doDROq" ];
+    };
+  };
+
+  # TODO: How to handle sudo esculation
+  security.sudo.wheelNeedsPassword = false;
+
+  environment.systemPackages = with pkgs; [
+    rsyslog
+  ];
+
+  # Easy test of the service using logger
+  # logger -n 127.0.0.1 -P 514 --tcp "simple test"
+  # cat /var/log/rsyslog/<hostname>/root.log
+  services.rsyslogd = {
+    enable = true;
+    defaultConfig = ''
+      module(load="imtcp")
+      input(type="imtcp" port="514")
+
+      $template RemoteLogs,"/var/log/rsyslog/%HOSTNAME%/%PROGRAMNAME%.log"
+      *.* ?RemoteLogs
+      & ~
+    '';
+  };
+}

--- a/nix/tests/allTests.nix
+++ b/nix/tests/allTests.nix
@@ -1,0 +1,4 @@
+{ nixosTest }:
+rec {
+  loghost = nixosTest (import ./loghost.nix);
+}

--- a/nix/tests/loghost.nix
+++ b/nix/tests/loghost.nix
@@ -1,0 +1,14 @@
+{
+  name = "loghost";
+  nodes.machine1 = { ... }: { imports = [ ../machines/loghost.nix ]; } // {
+    virtualisation.graphics = false;
+  };
+
+  testScript = ''
+    start_all()
+    machine1.succeed("sleep 2")
+    machine1.succeed("systemctl is-active syslog")
+    machine1.succeed("logger -n 127.0.0.1 -P 514 --tcp 'troy'")
+    machine1.succeed("cat /var/log/**/**/root.log | grep troy")
+  '';
+}

--- a/shell.nix
+++ b/shell.nix
@@ -1,4 +1,4 @@
-# TODO: Pin this to a specific version of nixpkgs
+# Leverage the nix flake devShell to get pinned nixpkgs
 { pkgs ? import <nixpkgs> {} }:
 
 with pkgs;
@@ -9,9 +9,9 @@ let
 
   # Trying to keep these pkg sets separate for later
   global = [ bash curl git jq kermit  screen glibcLocales ] ++ [ scale_python ];
-  ansible_sub = [ansible_2_11 ansible-lint];
+  ansible_sub = [ansible_2_12 ansible-lint];
   openwrt_sub = [ expect gomplate magic-wormhole tftp-hpa nettools unixtools.ping];
-  network_sub = [ perl532 ];
+  network_sub = [ perl534 ];
 in
 mkShell {
   buildInputs = [ global ] ++ [ ansible_sub ] ++ [ openwrt_sub ] ++ [ network_sub ];


### PR DESCRIPTION
## Description of PR

Fixes: #508

Adding initial flake.nix and consuming the `shell.nix` from `devShells.default` which we added back in #395 . Additionally adding a new NixOS VM for a dedicated `loghost` server along with tests to validate it works inside qemu. Still need to try out the VM in bhyve but this is a good checkpoint from me to get feedback.

## Previous Behavior
- Loghost was setup on `server3`

## New Behavior
- flake.nix and flake.lock add for consistent reference to `nixpkgs`
- Reference shell.nix from `devShells.default`
- `loghost` is its own dedicated machine

## Tests

Test the `devShell.default`:
```
 $ nix develop
 ```
Test the vm machine via the nixos test framework. These tests actually spin up a vm and run the test suite in `nix/tests/loghost.nix`:

```
~$ nix build ".#packages.x86_64-linux.scaleTests.loghost"
```

Also able to build the qemu vm:

```
~$ nix build ".#nixosConfigurations.x86_64-linux.loghost.config.system.build.vm"
~$ $ ls -lah result/bin/run-nixos-vm 
lrwxrwxrwx 1 root root 56 Jan  1  1970 result/bin/run-nixos-vm -> /nix/store/7vq1mgm186gkfyqlp3w136s4q2kxx1c7-run-nixos-vm
```
> This vm then can be run directly on my nixos system

