### PR TITLE
[WAIT] - Adding nix ci to github actions

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -1,0 +1,22 @@
+---
+name: nixTests
+
+on:
+  pull_request:
+    paths:
+      - '**.nix'
+  push:   # This is only run when PRs are merged into master
+    branches:
+      - master
+  workflow_dispatch:
+
+jobs:
+  nixFmt:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install Nix
+        uses: cachix/install-nix-action@v18
+      # Check formatting via treefmt
+      - name: check formatting
+        run: nix develop --command treefmt --fail-on-change --no-cache && git --no-pager diff

--- a/shell.nix
+++ b/shell.nix
@@ -1,15 +1,15 @@
 # Leverage the nix flake devShell to get pinned nixpkgs
-{ pkgs ? import <nixpkgs> {} }:
+{ pkgs ? import <nixpkgs> { } }:
 
 with pkgs;
 
 let
   scale_python = python38.withPackages
-      (pythonPackages: with pythonPackages; [ pytest pylint ]);
+    (pythonPackages: with pythonPackages; [ pytest pylint ]);
 
   # Trying to keep these pkg sets separate for later
   global = [ bash curl git jq kermit nixpkgs-fmt treefmt screen glibcLocales ] ++ [ scale_python ];
-  ansible_sub = [ansible_2_12 ansible-lint];
+  ansible_sub = [ ansible_2_12 ansible-lint ];
   openwrt_sub = [ expect gomplate magic-wormhole tftp-hpa nettools unixtools.ping iperf3 ncurses ncurses.dev pkg-config gcc stdenv ];
   network_sub = [ perl534 ];
 in

--- a/shell.nix
+++ b/shell.nix
@@ -8,7 +8,7 @@ let
       (pythonPackages: with pythonPackages; [ pytest pylint ]);
 
   # Trying to keep these pkg sets separate for later
-  global = [ bash curl git jq kermit screen glibcLocales ] ++ [ scale_python ];
+  global = [ bash curl git jq kermit nixpkgs-fmt treefmt screen glibcLocales ] ++ [ scale_python ];
   ansible_sub = [ansible_2_12 ansible-lint];
   openwrt_sub = [ expect gomplate magic-wormhole tftp-hpa nettools unixtools.ping iperf3 ncurses ncurses.dev pkg-config gcc stdenv ];
   network_sub = [ perl534 ];

--- a/treefmt.toml
+++ b/treefmt.toml
@@ -1,0 +1,3 @@
+[formatter.nix]
+command = "nixpkgs-fmt"
+includes = ["*.nix"]


### PR DESCRIPTION
## Description of PR

Depends on: https://github.com/socallinuxexpo/scale-network/pull/509
Fixes: #510 

Adding initial nix ci for `nixpkgs-fmt`

## Previous Behavior
- No formatting present for `.nix` files

## New Behavior
- Formatting and checks for `*.nix`

## Tests
- Running the checks locally while inside a `devShell`

```
$ nix develop --command treefmt --fail-on-change --no-cache && git --no-pager diff
[INFO]: #nix: 8 files processed in 12.79ms

traversed 290 files
matched 8 files to formatters
left with 8 files after cache
of whom 0 files were re-formatted
all of this in 23ms
```
