### PR TITLE
[READY] - Update artifact upload GHA to v3.1.1

### DIFF
--- a/.github/workflows/openwrt-build.yml
+++ b/.github/workflows/openwrt-build.yml
@@ -30,7 +30,7 @@ jobs:
           cd openwrt
           TARGET=${{ matrix.target }} make templates build-img package 2>&1 | tee ${{ matrix.target }}-build.log
       - name: 'Upload openwrt build artifact tarball'
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3.1.1
         with:
           name:  ${{ matrix.target }}-openwrt-build-artifacts
           # Cant use relative pathing .. or . for artifacts action
@@ -39,7 +39,7 @@ jobs:
             openwrt/build/artifacts/*.tar.gz
           retention-days: 30
       - name: 'Upload openwrt build log'
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3.1.1
         with:
           name:  ${{ matrix.target }}-openwrt-buildlog
           path: |


### PR DESCRIPTION
## Description of PR

Fixes: #515 

## Previous Behavior
- actions/upload-artifact was set to v2

## New Behavior
- actions/upload-artifact set to v3.1.1

## Tests
- Manually triggered the openwrt-build action: https://github.com/socallinuxexpo/scale-network/actions/runs/3795442315 Even though its the "old" build it still confirms what we need: The artifacts are still captured properly after the build
