### PR TITLE
[REVIEW] - init bhyve image support for nixos images

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -31,7 +31,7 @@
           common =
             ({ modulesPath, ... }: {
               imports = [
-                "${toString modulesPath}/virtualisation/qemu-vm.nix"
+                ./nix/modules/bhyve-image.nix
               ];
             });
           pkgs = nixpkgsFor.${system};

--- a/flake.nix
+++ b/flake.nix
@@ -17,7 +17,7 @@
       overlays.default = (final: prev:
         with final.pkgs;
         rec {
-          scaleTests = import ./nix/tests/allTests.nix { inherit nixosTest; };
+          scaleTests = callPackage ./nix/tests/allTests.nix { };
           massflash = callPackage ./nix/pkgs/massflash.nix { };
         });
 

--- a/nix/machines/loghost.nix
+++ b/nix/machines/loghost.nix
@@ -3,15 +3,7 @@
   # If not present then warning and will be set to latest release during build
   system.stateVersion = "22.11";
 
-  fileSystems."/" = {
-    device = "/dev/disk/by-label/nixos";
-    fsType = "ext4";
-    autoResize = true;
-  };
-  boot.growPartition = true;
   boot.kernelParams = [ "console=ttyS0" ];
-  boot.loader.grub.device = "/dev/vda";
-  boot.loader.timeout = 0;
 
   # TODO: How to handle to the root password
   users.extraUsers.root.password = "";

--- a/nix/modules/bhyve-image.nix
+++ b/nix/modules/bhyve-image.nix
@@ -1,0 +1,54 @@
+{ config, pkgs, lib, ... }:
+
+# Minimal configuration for building NixOS bhyve images
+# Inspiration based on hyperv-image.nix: https://github.com/NixOS/nixpkgs/blob/dd3ce3ebcc5de070edb64038fc9135c92f44a670/nixos/modules/virtualisation/hyperv-image.nix
+
+with lib;
+
+let
+  cfg = config.bhyve;
+in
+{
+  options = {
+    bhyve = {
+      baseImageSize = mkOption {
+        type = with types; either (enum [ "auto" ]) int;
+        default = "auto";
+        example = 2048;
+        description = lib.mdDoc ''
+          The size of the bhyve base image in MiB.
+        '';
+      };
+      vmDerivationName = mkOption {
+        type = types.str;
+        default = "nixos-bhyve-${config.system.nixos.label}-${pkgs.stdenv.hostPlatform.system}";
+        description = lib.mdDoc ''
+          The name of the derivation for the bhyve appliance.
+        '';
+      };
+    };
+  };
+
+  config = {
+    system.build.bhyveImage = import "${pkgs.path}/nixos/lib/make-disk-image.nix" {
+      inherit config lib pkgs;
+      name = cfg.vmDerivationName;
+      format = "raw";
+      diskSize = cfg.baseImageSize;
+      # TODO: Check out uefi
+      partitionTableType = "legacy";
+    };
+
+    fileSystems."/" = {
+      device = "/dev/disk/by-label/nixos";
+      autoResize = true;
+      fsType = "ext4";
+    };
+
+    boot.growPartition = true;
+
+    boot.loader.grub = {
+      device = "/dev/sda";
+    };
+  };
+}

--- a/utilities/bhyve/templates/loghost.conf
+++ b/utilities/bhyve/templates/loghost.conf
@@ -1,0 +1,9 @@
+loader="grub"
+cpu=2
+memory=2048M
+network0_type="virtio-net"
+network0_switch="public"
+disk0_type="ahci-hd"
+disk0_name="disk0"
+disk0_dev="zvol"
+disk0_size="100G"


### PR DESCRIPTION
## Description of PR

Adding necessary bits to support running on bhyve for the images produced via nix.

## Previous Behavior

- loghost was only being specific to a qemu image format

## New Behavior

- update tests to use `callPackage`
- adding bhyve config for loghost - Proposing to put this in `utilties/bhyve` instead of `ansible/roles/bhyve`
- bhyve image nix function
- loghost support bhyve image gen

## Tests

Able to build and run a nixos vm on bhyve:

```
$ nix build ".#nixosConfigurations.x86_64-linux.loghost.config.system.build.bhyveImage"
```
> Produces a bootable, compatible image when applied with the vm config

Building qemu images still works as well:

```
$ nix build ".#nixosConfigurations.x86_64-linux.loghost.config.system.build.vm"
```
