### PR TITLE
[READY] - Updates to core server and kea config

### DIFF
--- a/facts/inventory.py
+++ b/facts/inventory.py
@@ -556,11 +556,13 @@ def main():
         for ap in aps
     ]
 
-    # TODO: support generating id for each subnet block
-    # called out in: https://kea.readthedocs.io/en/latest/arm/dhcp4-srv.html#ipv4-subnet-identifier
     subnets_dict = [
         {
             "subnet": vlan["ipv4prefix"] + "/" + str(vlan["ipv4bitmask"]),
+            # generating uniq id (prefix with dots) for each subnet block to ensure autoids dont effect reordering
+            # called out in: https://kea.readthedocs.io/en/latest/arm/dhcp4-srv.html#ipv4-subnet-identifier
+            # subnet ids must be greater than zero and less than 4294967295
+            "id": int(vlan["ipv4prefix"].replace('.', '')),
             "user-context": { "vlan": vlan["name"] },
             "pools": [{"pool": vlan["ipv4dhcpStart"] + " - " + vlan["ipv4dhcpEnd"]}],
         }

--- a/facts/inventory.py
+++ b/facts/inventory.py
@@ -561,6 +561,7 @@ def main():
     subnets_dict = [
         {
             "subnet": vlan["ipv4prefix"] + "/" + str(vlan["ipv4bitmask"]),
+            "user-context": { "vlan": vlan["name"] },
             "pools": [{"pool": vlan["ipv4dhcpStart"] + " - " + vlan["ipv4dhcpEnd"]}],
         }
         for vlan in vlans

--- a/nix/machines/core/default.nix
+++ b/nix/machines/core/default.nix
@@ -19,22 +19,24 @@ in
     };
   };
 
-  networking.usePredictableInterfaceNames = false;
+  # disable legacy networking bits as recommended by:
+  #  https://github.com/NixOS/nixpkgs/issues/10001#issuecomment-905532069
+  #  https://github.com/NixOS/nixpkgs/blob/82935bfed15d680aa66d9020d4fe5c4e8dc09123/nixos/tests/systemd-networkd-dhcpserver.nix
+  networking = {
+    useDHCP = false;
+    useNetworkd = true;
+  };
+
   # Make sure that the makes of these files are actually lexicographically before 99-default.link provides by systemd defaults since first match wins
   # Ref: https://github.com/systemd/systemd/issues/9227#issuecomment-395500679
   systemd.network = {
     enable = true;
-    links = {
-      "10-lan" = {
-        matchConfig = { OriginalName = "*"; };
-        linkConfig = { MACAddress = "58:9c:fc:00:38:5f"; MACAddressPolicy = "none"; };
-      };
-    };
     networks = {
       "10-lan" = {
+        name = "enp0*";
+        enable = true;
         address = [ "10.0.3.5/24" "2001:470:f0fb:103::5/64" ];
         gateway = [ "10.0.3.1" ];
-        matchConfig = { Name = "eth0"; };
       };
     };
   };

--- a/nix/tests/core.nix
+++ b/nix/tests/core.nix
@@ -33,7 +33,7 @@
   testScript = ''
     start_all()
     # Kea needs a sec to startup so well sleep
-    coreServer.succeed("sleep 10")
+    coreServer.wait_for_unit("systemd-networkd-wait-online.service")
     coreServer.succeed("kea-dhcp4 -t /etc/kea/dhcp4-server.conf")
     client1.wait_for_unit("systemd-networkd-wait-online.service")
     client1.wait_until_succeeds("ping -c 5 10.0.3.5")

--- a/nix/tests/core.nix
+++ b/nix/tests/core.nix
@@ -1,14 +1,41 @@
 {
   name = "core";
-  nodes.machine1 = { ... }: { imports = [ ../machines/core ]; } // {
-    virtualisation.graphics = false;
+  nodes = {
+    coreServer = { lib, ... }: {
+      imports = [ ../machines/core ];
+    } // {
+      virtualisation.vlans = [ 1 ];
+      virtualisation.graphics = false;
+      systemd.network = {
+        networks = lib.mkForce {
+          "01-eth1" = {
+            name = "eth1";
+            enable = true;
+            address = [ "10.0.3.5/24" ];
+            gateway = [ "10.0.3.1" ];
+          };
+        };
+      };
+    };
+
+    client1 = { config, pkgs, ... }: {
+      virtualisation.vlans = [ 1 ];
+      systemd.services.systemd-networkd.environment.SYSTEMD_LOG_LEVEL = "debug";
+      networking = {
+        useNetworkd = true;
+        useDHCP = false;
+        firewall.enable = false;
+        interfaces.eth1.useDHCP = true;
+      };
+    };
   };
 
   testScript = ''
     start_all()
     # Kea needs a sec to startup so well sleep
-    machine1.succeed("sleep 10")
-    machine1.succeed("kea-dhcp4 -t /etc/kea/dhcp4-server.conf")
-    machine1.succeed("systemctl is-active kea-dhcp4-server")
+    coreServer.succeed("sleep 10")
+    coreServer.succeed("kea-dhcp4 -t /etc/kea/dhcp4-server.conf")
+    client1.wait_for_unit("systemd-networkd-wait-online.service")
+    client1.wait_until_succeeds("ping -c 5 10.0.3.5")
   '';
 }


### PR DESCRIPTION
## Description of PR

Updates to kea configuration on core server.

## Previous Behavior
- Had issues with mac address setting via systemd

## New Behavior
- simplify the systemd-networkd config (going to override the mac at the bhyve level instead)
- Adding actual client/server dhcpd test for core
- define user-context per subnet for vlan name
- init subnet ids for kea
- core test wait for network on coreserver to common online

## Tests

Client/server test for dhcp passes. Current test scenario is: Kea server starts with currrent configuration and is tested via builtin `-t` flag. Kea client comes up and tries to get a lease then pings the server:

```
nix build ".#packages.x86_64-linux.scaleTests.core"
```

Confirmed dhcp options are being passed as expected with APs configurations as well.
