### PR TITLE
[READY] - supporting bind master and slave with nvme devices 

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -56,11 +56,18 @@
               ./nix/machines/massflash.nix
             ];
           };
-          core = nixpkgs.lib.nixosSystem {
+          coreMaster = nixpkgs.lib.nixosSystem {
             inherit system pkgs;
             modules = [
               common
-              ./nix/machines/core
+              ./nix/machines/core/master.nix
+            ];
+          };
+          coreSlave = nixpkgs.lib.nixosSystem {
+            inherit system pkgs;
+            modules = [
+              common
+              ./nix/machines/core/slave.nix
             ];
           };
         });

--- a/flake.nix
+++ b/flake.nix
@@ -33,6 +33,7 @@
             ({ modulesPath, ... }: {
               imports = [
                 ./nix/modules/bhyve-image.nix
+                ./nix/machines/_common/users.nix
               ];
             });
           pkgs = nixpkgsFor.${system};

--- a/nix/machines/_common/users.nix
+++ b/nix/machines/_common/users.nix
@@ -1,0 +1,16 @@
+{ config, lib, pkgs, ... }:
+
+{
+  users.mutableUsers = false;
+  users.extraUsers.root.hashedPassword = "$6$3Hm/K5fbR3UEMK6H$3aaegtdwvejGk9Bk0ttN5bNJn4z2Yt6LWXD3nGI7.44Pbm7A1TpKuxG9XQLwsj7M9NEk8eB5Exg0qVRV//6br/";
+
+  users.users = {
+    rherna = {
+      isNormalUser = true;
+      uid = 2005;
+      extraGroups = [ "wheel" ];
+      openssh.authorizedKeys.keys = [ "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIMEiESod7DOT2cmT2QEYjBIrzYqTDnJLld1em3doDROq" ];
+    };
+  };
+
+}

--- a/nix/machines/core/common.nix
+++ b/nix/machines/core/common.nix
@@ -1,0 +1,62 @@
+{ config, lib, pkgs, ... }:
+
+{
+  # If not present then warning and will be set to latest release during build
+  system.stateVersion = "22.11";
+
+  boot.kernelParams = [ "console=ttyS0" ];
+
+  users.extraUsers.root.password = "";
+
+  users.users = {
+    rherna = {
+      isNormalUser = true;
+      uid = 2005;
+      extraGroups = [ "wheel" ];
+      openssh.authorizedKeys.keys = [ "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIMEiESod7DOT2cmT2QEYjBIrzYqTDnJLld1em3doDROq" ];
+    };
+  };
+
+  # disable legacy networking bits as recommended by:
+  #  https://github.com/NixOS/nixpkgs/issues/10001#issuecomment-905532069
+  #  https://github.com/NixOS/nixpkgs/blob/82935bfed15d680aa66d9020d4fe5c4e8dc09123/nixos/tests/systemd-networkd-dhcpserver.nix
+  networking = {
+    useDHCP = false;
+    useNetworkd = true;
+    firewall.allowedTCPPorts = [ 53 67 68 ];
+    firewall.allowedUDPPorts = [ 53 67 68 ];
+  };
+
+  security.sudo.wheelNeedsPassword = false;
+
+  environment.systemPackages = with pkgs; [
+    ldns
+    bind
+    kea
+    scaleInventory
+  ];
+
+  environment.etc."bind/named.conf".source = config.services.bind.configFile;
+
+  systemd.services.bind =
+    let
+      # Get original config
+      cfg = config.services.bind;
+    in
+    {
+      serviceConfig.ExecStart = lib.mkForce "${cfg.package.out}/sbin/named -u named ${lib.strings.optionalString cfg.ipv4Only "-4"} -c /etc/bind/named.conf -f";
+    };
+
+  services = {
+    resolved.enable = false;
+    openssh = {
+      enable = true;
+    };
+    kea = {
+      dhcp4 = {
+        enable = true;
+        configFile = "${pkgs.scaleInventory}/config/kea.json";
+      };
+    };
+  };
+}

--- a/nix/machines/core/common.nix
+++ b/nix/machines/core/common.nix
@@ -6,17 +6,6 @@
 
   boot.kernelParams = [ "console=ttyS0" ];
 
-  users.extraUsers.root.password = "";
-
-  users.users = {
-    rherna = {
-      isNormalUser = true;
-      uid = 2005;
-      extraGroups = [ "wheel" ];
-      openssh.authorizedKeys.keys = [ "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIMEiESod7DOT2cmT2QEYjBIrzYqTDnJLld1em3doDROq" ];
-    };
-  };
-
   # disable legacy networking bits as recommended by:
   #  https://github.com/NixOS/nixpkgs/issues/10001#issuecomment-905532069
   #  https://github.com/NixOS/nixpkgs/blob/82935bfed15d680aa66d9020d4fe5c4e8dc09123/nixos/tests/systemd-networkd-dhcpserver.nix

--- a/nix/machines/core/master.nix
+++ b/nix/machines/core/master.nix
@@ -18,14 +18,15 @@
     };
   };
 
+  imports =
+    [
+      ./common.nix
+    ];
+
   # disable legacy networking bits as recommended by:
   #  https://github.com/NixOS/nixpkgs/issues/10001#issuecomment-905532069
   #  https://github.com/NixOS/nixpkgs/blob/82935bfed15d680aa66d9020d4fe5c4e8dc09123/nixos/tests/systemd-networkd-dhcpserver.nix
   networking = {
-    useDHCP = false;
-    useNetworkd = true;
-    firewall.allowedTCPPorts = [ 53 67 68 ];
-    firewall.allowedUDPPorts = [ 53 67 68 ];
     extraHosts = ''
       10.0.3.5 coreexpo.scale.lan
     '';
@@ -45,45 +46,16 @@
     };
   };
 
-  security.sudo.wheelNeedsPassword = false;
-
-  environment.systemPackages = with pkgs; [
-    ldns
-    bind
-    kea
-    scaleInventory
-  ];
-
-  environment.etc."bind/named.conf".source = config.services.bind.configFile;
-
-  systemd.services.bind =
-    let
-      # Get original config
-      cfg = config.services.bind;
-    in
-    {
-      serviceConfig.ExecStart = lib.mkForce "${cfg.package.out}/sbin/named -u named ${lib.strings.optionalString cfg.ipv4Only "-4"} -c /etc/bind/named.conf -f";
-    };
-
   services = {
-    resolved.enable = false;
-    openssh = {
-      enable = true;
-    };
-    kea = {
-      dhcp4 = {
-        enable = true;
-        configFile = "${pkgs.scaleInventory}/config/kea.json";
-      };
-    };
     bind = {
       enable = true;
-      cacheNetworks = [ "127.0.0.0/8" "10.0.0.0/8" "::1/128" ];
+      cacheNetworks = [ "::1/128" "127.0.0.0/8" "2001:470:f0fb::/48" "10.0.0.0/8" ];
       forwarders = [ "8.8.8.8" "8.8.4.4" ];
       zones =
         {
           "scale.lan." = {
             master = true;
+            slaves = [ "2001:470:f026:503::5" ];
             file = pkgs.writeText "named.scale.lan" (lib.strings.concatStrings [
               ''
                 $ORIGIN scale.lan.
@@ -103,6 +75,7 @@
           };
           "10.in-addr.arpa." = {
             master = true;
+            slaves = [ "2001:470:f026:503::5" ];
             file = pkgs.writeText "named-10.rev" (lib.strings.concatStrings [
               ''
                 $ORIGIN 10.in-addr.arpa.
@@ -123,6 +96,7 @@
           # 2001:470:f026::
           "6.2.0.f.0.7.4.0.1.0.0.2.ip6.arpa." = {
             master = true;
+            slaves = [ "2001:470:f026:503::5" ];
             file = pkgs.writeText "named-2001.470.f026-48.rev" (lib.strings.concatStrings [
               ''
                 $ORIGIN 6.2.0.f.0.7.4.0.1.0.0.2.ip6.arpa.

--- a/nix/machines/core/master.nix
+++ b/nix/machines/core/master.nix
@@ -1,22 +1,6 @@
 { config, lib, pkgs, ... }:
 
 {
-  # If not present then warning and will be set to latest release during build
-  system.stateVersion = "22.11";
-
-  boot.kernelParams = [ "console=ttyS0" ];
-
-  users.mutableUsers = false;
-  users.extraUsers.root.hashedPassword = "$6$3Hm/K5fbR3UEMK6H$3aaegtdwvejGk9Bk0ttN5bNJn4z2Yt6LWXD3nGI7.44Pbm7A1TpKuxG9XQLwsj7M9NEk8eB5Exg0qVRV//6br/";
-
-  users.users = {
-    rherna = {
-      isNormalUser = true;
-      uid = 2005;
-      extraGroups = [ "wheel" ];
-      openssh.authorizedKeys.keys = [ "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIMEiESod7DOT2cmT2QEYjBIrzYqTDnJLld1em3doDROq" ];
-    };
-  };
 
   imports =
     [

--- a/nix/machines/core/slave.nix
+++ b/nix/machines/core/slave.nix
@@ -1,0 +1,55 @@
+{ config, lib, pkgs, ... }:
+
+{
+  imports =
+    [
+      ./common.nix
+    ];
+
+  networking = {
+    extraHosts = ''
+      10.128.3.5 coreexpo.scale.lan
+    '';
+  };
+
+  # Make sure that the makes of these files are actually lexicographically before 99-default.link provides by systemd defaults since first match wins
+  # Ref: https://github.com/systemd/systemd/issues/9227#issuecomment-395500679
+  systemd.network = {
+    enable = true;
+    networks = {
+      "10-lan" = {
+        name = "enp0*";
+        enable = true;
+        address = [ "10.128.3.5/24" "2001:470:f026:503::5/64" ];
+        gateway = [ "10.128.3.1" ];
+      };
+    };
+  };
+
+  services = {
+    bind = {
+      enable = true;
+      cacheNetworks = [ "::1/128" "127.0.0.0/8" "2001:470:f026::/48" "10.0.0.0/8" ];
+      forwarders = [ "8.8.8.8" "8.8.4.4" ];
+      zones =
+        {
+          "scale.lan." = {
+            master = false;
+            masters = [ "2001:470:f026:103::5" ];
+            file = "/var/named/sec-scale.lan";
+          };
+          "10.in-addr.arpa." = {
+            master = false;
+            masters = [ "2001:470:f026:103::5" ];
+            file = "/var/named/sec-10.rev";
+          };
+          # 2001:470:f026::
+          "6.2.0.f.0.7.4.0.1.0.0.2.ip6.arpa.." = {
+            master = false;
+            masters = [ "2001:470:f026:103::5" ];
+            file = "/var/named/sec-2001.470.f026-48.rev";
+          };
+        };
+    };
+  };
+}

--- a/nix/machines/loghost.nix
+++ b/nix/machines/loghost.nix
@@ -5,19 +5,6 @@
 
   boot.kernelParams = [ "console=ttyS0" ];
 
-  # TODO: How to handle to the root password
-  users.extraUsers.root.password = "";
-
-  # TODO: Consume users from facts/keys instead of this
-  users.users = {
-    rherna = {
-      isNormalUser = true;
-      uid = 2005;
-      extraGroups = [ "wheel" ];
-      openssh.authorizedKeys.keys = [ "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIMEiESod7DOT2cmT2QEYjBIrzYqTDnJLld1em3doDROq" ];
-    };
-  };
-
   # TODO: How to handle sudo esculation
   security.sudo.wheelNeedsPassword = false;
 

--- a/nix/modules/bhyve-image.nix
+++ b/nix/modules/bhyve-image.nix
@@ -46,7 +46,7 @@ in
     };
 
     boot.growPartition = true;
-
+    boot.initrd.availableKernelModules = [ "nvme" ];
     boot.loader.grub = {
       device = "/dev/sda";
     };

--- a/nix/tests/core.nix
+++ b/nix/tests/core.nix
@@ -2,7 +2,7 @@
   name = "core";
   nodes = {
     coreServer = { lib, ... }: {
-      imports = [ ../machines/core ];
+      imports = [ ../machines/core/master.nix ];
     } // {
       virtualisation.vlans = [ 1 ];
       virtualisation.graphics = false;


### PR DESCRIPTION
## Description of PR

Support bind slave for coreconf vm

## Previous Behavior
- Originally vms were only bootable via ahci device type
- no slaves for bind were supported

## New Behavior
- split master & slave configs for core machine
- adding common to core
- support nvme devices for booting
- common config cleanup

## Tests

Will test completely when hosts are deployed

Tests passing locally

```
$ nix build ".#packages.x86_64-linux.scaleTests.core"
```
