### PR TITLE
[READY] - nixos-rebuild switch works and kea default route set

### DIFF
--- a/facts/inventory.py
+++ b/facts/inventory.py
@@ -12,7 +12,6 @@ import re
 import sys
 import jinja2
 
-
 def getfilelines(filename, header=False, directory="./", building=None):
     """returns the contents of a file as lines
     omits the top line for git beautification if the header boolean is set to true
@@ -466,6 +465,7 @@ def generatekeaconfig(servers, aps, vlans, outputdir):
             "id": int(vlan["ipv4prefix"].replace('.', '')),
             "user-context": { "vlan": vlan["name"] },
             "pools": [{"pool": vlan["ipv4dhcpStart"] + " - " + vlan["ipv4dhcpEnd"]}],
+            "option-data": [{ "name": "routers", "data": str(vlan["ipv4router"]) }],
         }
         for vlan in vlans
         if vlan["ipv4bitmask"]

--- a/flake.nix
+++ b/flake.nix
@@ -26,9 +26,10 @@
         inherit (nixpkgsFor.${system}) scaleTests scaleInventory;
       });
 
-      nixosConfigurations = forAllSystems (system:
+      nixosConfigurations =
         let
           # All scale common modules
+          system = "x86_64-linux";
           common =
             ({ modulesPath, ... }: {
               imports = [
@@ -71,7 +72,7 @@
               ./nix/machines/core/slave.nix
             ];
           };
-        });
+        };
 
       # Like nix-shell
       # Good example: https://github.com/tcdi/pgx/blob/master/flake.nix

--- a/nix/machines/core/slave.nix
+++ b/nix/machines/core/slave.nix
@@ -36,18 +36,18 @@
           "scale.lan." = {
             master = false;
             masters = [ "2001:470:f026:103::5" ];
-            file = "/var/named/sec-scale.lan";
+            file = "/var/run/named/sec-scale.lan";
           };
           "10.in-addr.arpa." = {
             master = false;
             masters = [ "2001:470:f026:103::5" ];
-            file = "/var/named/sec-10.rev";
+            file = "/var/run/named/sec-10.rev";
           };
           # 2001:470:f026::
           "6.2.0.f.0.7.4.0.1.0.0.2.ip6.arpa." = {
             master = false;
             masters = [ "2001:470:f026:103::5" ];
-            file = "/var/named/sec-2001.470.f026-48.rev";
+            file = "/var/run/named/sec-2001.470.f026-48.rev";
           };
         };
     };

--- a/nix/machines/core/slave.nix
+++ b/nix/machines/core/slave.nix
@@ -44,7 +44,7 @@
             file = "/var/named/sec-10.rev";
           };
           # 2001:470:f026::
-          "6.2.0.f.0.7.4.0.1.0.0.2.ip6.arpa.." = {
+          "6.2.0.f.0.7.4.0.1.0.0.2.ip6.arpa." = {
             master = false;
             masters = [ "2001:470:f026:103::5" ];
             file = "/var/named/sec-2001.470.f026-48.rev";

--- a/nix/machines/core/slave.nix
+++ b/nix/machines/core/slave.nix
@@ -22,6 +22,15 @@
         enable = true;
         address = [ "10.128.3.5/24" "2001:470:f026:503::5/64" ];
         gateway = [ "10.128.3.1" ];
+        # TODO: Causes double entry of [Network] in .network file
+        # Need to look into unifying into one block
+        extraConfig = ''
+          [Network]
+          IPv6Token=static:::5
+          LLDP=true
+          EmitLLDP=true;
+          IPv6PrivacyExtensions=false
+        '';
       };
     };
   };

--- a/nix/machines/loghost.nix
+++ b/nix/machines/loghost.nix
@@ -10,6 +10,8 @@
 
   environment.systemPackages = with pkgs; [
     rsyslog
+    vim
+    git
   ];
 
   # Easy test of the service using logger

--- a/nix/tests/core.nix
+++ b/nix/tests/core.nix
@@ -36,17 +36,20 @@
     };
 
   };
-  testScript = ''
+  testScript = let
+    coreServerIp = "10.0.3.5";
+    clientDefaultRoute = "10.0.3.1";
+  in ''
     start_all()
     coreServer.wait_for_unit("systemd-networkd-wait-online.service")
     coreServer.succeed("kea-dhcp4 -t /etc/kea/dhcp4-server.conf")
     client1.wait_for_unit("systemd-networkd-wait-online.service")
-    client1.wait_until_succeeds("ping -c 5 10.0.3.5")
-    client1.wait_until_succeeds("ip route show | grep default | grep -w 10.0.3.1")
+    client1.wait_until_succeeds("ping -c 5 ${coreServerIp}")
+    client1.wait_until_succeeds("ip route show | grep default | grep -w ${clientDefaultRoute}")
     # Have to wrap drill since retcode isnt necessarily 1 on query failure
     client1.wait_until_succeeds("test ! -z \"$(drill -Q -z scale.lan SOA)\"")
     client1.wait_until_succeeds("test ! -z \"$(drill -Q -z coreexpo.scale.lan A)\"")
     client1.wait_until_succeeds("test ! -z \"$(drill -Q -z coreexpo.scale.lan AAAA)\"")
-    client1.wait_until_succeeds("test ! -z \"$(drill -Q -z -x 10.0.3.5)\"")
+    client1.wait_until_succeeds("test ! -z \"$(drill -Q -z -x ${coreServerIp})\"")
   '';
 }

--- a/nix/tests/core.nix
+++ b/nix/tests/core.nix
@@ -42,6 +42,7 @@
     coreServer.succeed("kea-dhcp4 -t /etc/kea/dhcp4-server.conf")
     client1.wait_for_unit("systemd-networkd-wait-online.service")
     client1.wait_until_succeeds("ping -c 5 10.0.3.5")
+    client1.wait_until_succeeds("ip route show | grep default | grep -w 10.0.3.1")
     # Have to wrap drill since retcode isnt necessarily 1 on query failure
     client1.wait_until_succeeds("test ! -z \"$(drill -Q -z scale.lan SOA)\"")
     client1.wait_until_succeeds("test ! -z \"$(drill -Q -z coreexpo.scale.lan A)\"")


### PR DESCRIPTION
## Description of PR
- no set in nixosConfiguration for flake
- loghost necessary pkgs
- add in missing ipv4 gateway in kea.config
- new test for route
- parameterize the core tests
- disable ipv6 privacy configs for core* roles
- move slave zone file store to `/var/run/named`

## Tests

- Rebuild switch working on `coreexpo`:

```
nixos-rebuild switch --flake github:socallinuxexpo/scale-network/393c224d8ebb5ed44f05bba8e28fe1912bd6f0e0#coreMaster
```

- Verified zone transfers are working from `coreexpo`
