### PR TITLE
Snake case (blech) and test on commits within switch-configuration/co…

### DIFF
--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -8,6 +8,7 @@ on:
       - 'ansible/**'
       - 'facts/**'
       - 'tests/**'
+      - 'switch-configuration/config/**'
   push:   # This is only run when PRs are merged into master
     branches:
       - master

--- a/facts/datasource.py
+++ b/facts/datasource.py
@@ -89,7 +89,7 @@ def isvalidhierarchy(val):
         return True
     return False
 
-def isvalidPOE(val):
+def isvalid_p_o_e(val):
     '''test for valid POE flag'''
     pattern = r"^(POE)|(-)$"
     result = re.match(pattern, val)


### PR DESCRIPTION
## Description of PR
Guido must die.
isvalid_p_o_e is hideous. isvalidPOE would make much more sense and be much more readable.
Unfortunately, Guido is a snake.

## Previous Behavior
Thinks broke because Guido
Also, tests weren't run against some PRs that needed them.

## New Behavior
Conformed to Guido's tyranny. Also added tests run conditions.

## Tests
If we tested, things might actually work.
