### PR TITLE
[READY] add additional cname records for monitoring1

### DIFF
--- a/facts/inventory.py
+++ b/facts/inventory.py
@@ -321,6 +321,17 @@ def populatepis(pisfile):
         )
     return pis
 
+def loghostalias(name):
+    """generate aliases for loghost"""
+    payload = []
+    if name.lower() == "monitoring1":
+        payload = [
+            "loghost",
+            "monitoring",
+            "zabbix",
+        ]
+    return payload
+
 
 def roomalias(name):
     """generats room name based alias names for switches"""
@@ -372,6 +383,7 @@ def populateservers(serversfile, vlans):
                 "vlan": vlan,
                 "fqdn": elems[0] + ".scale.lan",
                 "building": building,
+                "aliases": loghostalias(elems[0]),
             }
         )
     return servers


### PR DESCRIPTION
## Description of PR
fixes #570 

## Previous Behavior

- no cnames for loghost, monitoring, and zabbix

## New Behavior

- cnames for loghost, monitoring, and zabbix

## Tests
locally ran inventory script, here's output
```
$ cat /tmp/inventory_test/db.scale.lan.records | grep monitoring1
monitoring1  IN  AAAA    2001:470:f026:103::6
monitoring1  IN  A    10.0.3.6
loghost IN    CNAME   monitoring1.scale.lan.
monitoring IN    CNAME   monitoring1.scale.lan.
zabbix IN    CNAME   monitoring1.scale.lan.
```
