### PR TITLE
[WIP] adds dynamic zone serial generation for bind master

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -64,6 +64,7 @@
               common
               ./nix/machines/core/master.nix
             ];
+            specialArgs = {inherit self;};
           };
           coreSlave = nixpkgs.lib.nixosSystem {
             inherit system pkgs;

--- a/nix/machines/core/master.nix
+++ b/nix/machines/core/master.nix
@@ -1,6 +1,6 @@
 { config, lib, pkgs, ... }:
 let
-  zoneSerial = "2023030901";
+  zoneSerial = toString self.lastModified;
 in
 {
 


### PR DESCRIPTION
## Description of PR
Dynamically generate the bind zone serial number based on git commit timestamp

## Previous Behavior
- statically set zone serial, caching errors

## New Behavior
- ever incrementing zone serial based on timestamp

## Tests
Tested on @MatthewCroughan 's nix demo machine
