### PR TITLE
[READY] - new sign image for dst spring forward

### DIFF
--- a/nix/machines/signs.nix
+++ b/nix/machines/signs.nix
@@ -18,7 +18,7 @@
   virtualisation.oci-containers = {
     containers.scale-signs = {
       environmentFiles = [ /run/secrets/scale-sign-secrets.env ];
-      image = "sarcasticadmin/scale-signs:87d7eb0";
+      image = "sarcasticadmin/scale-signs:a74021a";
       ports = [ "80:80" ];
       extraOptions = [
         "--network=host"


### PR DESCRIPTION
## Description of PR

bumping the sign container on the nix vm

## Tests

- signs display the right talks at the right time
