### PR TITLE
[READY] - update workflows runs-on to 22.04

### DIFF
--- a/.github/workflows/openwrt-build.yml
+++ b/.github/workflows/openwrt-build.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   build:
     name: Building openwrt img
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         target: ["ar71xx", "ipq806x"]

--- a/.github/workflows/trigger.yml
+++ b/.github/workflows/trigger.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   verify:
     name: Verify Commenter
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     # Currently limiting this to robs user til stable
     if: >
       startsWith(github.event.comment.body, '/tux')
@@ -39,7 +39,7 @@ jobs:
       ref: ${{ steps.job.outputs.ref }}
   flash:
     name: Flash netgear hardware
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     needs: verify
     if: >
       needs.verify.outputs.subcomm == 'openwrt'


### PR DESCRIPTION
## Description of PR

Fixes: #605

Some of the GHA workflows were using a deprecated version of ubuntu and
it was causing failures. Example:
https://github.com/socallinuxexpo/scale-network/actions/runs/4648537091

## Previous Behavior
- Some workflows were running on 18.04 which was deprecated

## New Behavior
- Bumped workflows to use 22.04

## Tests

- Able to trigger a workflow via this branch and it built successfully: https://github.com/socallinuxexpo/scale-network/actions/runs/4706054646
