### PR TITLE
[READY] - init pr-standardize-comment for trigger workflow

### DIFF
--- a/.github/workflows/trigger.yml
+++ b/.github/workflows/trigger.yml
@@ -15,12 +15,15 @@ jobs:
       && github.event.issue.pull_request
       && github.actor == 'sarcasticadmin'
     steps:
+    - name: Standardize PR comment
+      id: pr-standardize-comment
+      uses: nebulaworks/action-standardize-pr-comment@v1.0
     - name: 'Collect event data'
       id: job
       run: |
         set -eux
-        SUBCOMM=$(cut -d ' ' -f 2 <<< "${{ github.event.comment.body }}")
-        SUBARGS="$(cut -d ' ' -f 3- <<< "${{ github.event.comment.body }}")"
+        SUBCOMM=$(cut -d ' ' -f 2 <<< "${{ steps.pr-standardize-comment.outputs.comment }}")
+        SUBARGS="$(cut -d ' ' -f 3- <<< "${{ steps.pr-standardize-comment.outputs.comment }}")"
         # Have to do this to get git commit ref for comments in PRs
         # "github.event.pull_request.head" will not work since this
         # is not a PR event


### PR DESCRIPTION
## Description of PR

Fixes: #511

Depends on: #606 

Leverage the opensource workflow: https://github.com/Nebulaworks/action-standardize-pr-comment

Allows us to be able to test the workflows while in the PR vs having to merge and then test (fail on continuous delivery).

## Previous Behavior
- Could only test the trigger GHA workflow on `master`

## New Behavior
- Can test the `trigger` GHA workflow from PR

## Tests
- I believe this will need to be merged in `master` prior to being able to test this for the first time
