### PR TITLE
[READY] - Bump alpine container for golden tests

### DIFF
--- a/.github/workflows/openwrt-golden.yml
+++ b/.github/workflows/openwrt-golden.yml
@@ -19,8 +19,8 @@ jobs:
     name: gomplate_tests
     runs-on: ubuntu-latest
     container:
-      # gomplate v3.2.0-alpine
-      image: hairyhenderson/gomplate@sha256:7614155c5c6ce3fa8ac892e2e77643615bd8724d2b9c9817037540f324af2342
+      # gomplate v3.11.3-alpine
+      image: hairyhenderson/gomplate@sha256:7a8e23a4900cb11b92b1e19122b7e20c606fb21d3fc569c44c3d9e7fc9cab1ee
     steps:
       - name: checkout
         id: checkout


### PR DESCRIPTION
## Description of PR

Blocks: #611 

For gomplate testing lets bump this container to match whats in the nix shell: v3.11.3

## Previous Behavior
- Gomplate was using an older version which caused it to break recently: https://github.com/socallinuxexpo/scale-network/actions/runs/5791484774/job/15696369527?pr=611

## New Behavior
- Leverage a newer version of the container thats compatible with the latest version of actions/checkout@v2

## Tests
- https://github.com/socallinuxexpo/scale-network/actions/runs/5791587798
