### PR TITLE
[READY] - referencing new standardize pr comment for event url

### DIFF
--- a/.github/workflows/trigger.yml
+++ b/.github/workflows/trigger.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
     - name: Standardize PR comment
       id: pr-standardize-comment
-      uses: nebulaworks/action-standardize-pr-comment@v1.0
+      uses: sarcasticadmin/action-standardize-pr-comment@bc2d905e9d53bcdd31dc224e91a44362bd25ae8d
     - name: 'Collect event data'
       # Currently limiting this to robs user til stable
       if: >


### PR DESCRIPTION
## Description of PR

Fixes annoying failing comments in any issue.

## Previous Behavior
- Issue comment triggers a GHA that fails

## New Behavior
- Issue comments are skipped correctly correct in GHA (but still run due to how actions)

## Tests
- PR comment still working: https://github.com/socallinuxexpo/scale-network/actions/runs/6299070552/job/17099125555
- Cannot test the issue comments until this is merged into `master`
