### PR TITLE
[READY] - Validate datafiles without docker

### DIFF
--- a/.github/workflows/validate-datafiles.yml
+++ b/.github/workflows/validate-datafiles.yml
@@ -1,13 +1,8 @@
 ---
-name: ansible-test
+name: validate-datafiles
 
 on:
   pull_request:
-    paths:
-      - '.github/**'
-      - 'facts/**'
-      - 'tests/**'
-      - 'switch-configuration/config/**'
   push:   # This is only run when PRs are merged into master
     branches:
       - master
@@ -17,16 +12,8 @@ jobs:
   validate_datafiles:
     name: validate_datafiles
     runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: facts/
-    container:
-      image: kylerisse/ansible-tester@sha256:f6a9507ec1d7a2dd0570cd88cb19746840c4f97e7618f53158616b9e1f5a3618
     steps:
-      - name: checkout
-        id: checkout
-        uses: actions/checkout@v2
-      - name: lint_python_files
-        run: pylint *.py
-      - name: datafile_unittest
-        run: pytest -vv
+      - uses: actions/checkout@v3
+      - uses: DeterminateSystems/nix-installer-action@main
+      - uses: DeterminateSystems/magic-nix-cache-action@main
+      - run: nix build -L .#checks.pytest-facts

--- a/facts/datasource.py
+++ b/facts/datasource.py
@@ -135,9 +135,8 @@ def test_datafile(delimiter, meta):
                 corresponding column index.
     }
     '''
-    fha = open(meta["file"])
-    lines = fha.readlines()
-    fha.close()
+    with open(meta["file"], encoding='utf-8') as fha:
+        lines = fha.readlines()
     for linenum, line in enumerate(lines):
         # skip comments
         if line[0] == '/' and line[1] == '/':

--- a/flake.nix
+++ b/flake.nix
@@ -64,7 +64,7 @@
               common
               ./nix/machines/core/master.nix
             ];
-            specialArgs = {inherit self;};
+            specialArgs = { inherit self; };
           };
           coreSlave = nixpkgs.lib.nixosSystem {
             inherit system pkgs;
@@ -92,6 +92,23 @@
           {
             default = import ./shell.nix { inherit pkgs; };
           });
+
+      checks =
+        let
+          pkgs = nixpkgsFor.x86_64-linux;
+        in
+        {
+          # python tests for the data found in facts
+          # disabling persistence and cache for py utils to avoid warnings
+          # since caching is taken care of by nix
+          pytest-facts = pkgs.runCommand "pytest-facts" { } ''
+            cp -r ${pkgs.lib.cleanSource self}/* .
+            cd facts
+            ${pkgs.python3Packages.pylint}/bin/pylint --persistent n *.py
+            ${pkgs.python3Packages.pytest}/bin/pytest -vv -p no:cacheprovider
+            touch $out
+          '';
+        };
     };
 
   # Bold green prompt for `nix develop`


### PR DESCRIPTION
## Description of PR
- init pytest check via flakes
- datasources.py: leverage with for opening up data files
- updating action for datafiles

## Previous Behavior
- Docker was used to run pytest and pylint on datafiles

## New Behavior
- move pytest and pylint to nix check

## Tests
- https://github.com/socallinuxexpo/scale-network/actions/runs/6338478727
