### PR TITLE
[READY] - gha: removing set-output due to deprecation

### DIFF
--- a/.github/workflows/trigger.yml
+++ b/.github/workflows/trigger.yml
@@ -35,9 +35,9 @@ jobs:
           --header 'Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}' \
           --header 'Content-Type: application/json' | jq -r '.head.ref' \
         )
-        echo ::set-output name=subcomm::$SUBCOMM
-        echo ::set-output name=subargs::$SUBARGS
-        echo ::set-output name=ref::$REF
+        echo "subcomm=$SUBCOMM" >> $GITHUB_OUTPUT
+        echo "subargs=$SUBARGS" >> $GITHUB_OUTPUT
+        echo "ref=$REF" >> $GITHUB_OUTPUT
       continue-on-error: true
     outputs:
       subcomm: ${{ steps.job.outputs.subcomm }}
@@ -65,7 +65,7 @@ jobs:
           --form "variables[OPENWRT_INTEG]=YES" \
           --form variables[WORMHOLE_CODE]=$WORMHOLE_CODE \
           https://gitlab.com/api/v4/projects/17362342/trigger/pipeline | jq -r .web_url)
-        echo ::set-output name=pipeline::$PIPELINE
+        echo "pipeline=$PIPELINE" >> $GITHUB_OUTPUT
     - name: Create status PR Comment
       if: ${{ success() }}
       uses: peter-evans/create-or-update-comment@ca08ebd5dc95aa0cd97021e9708fcd6b87138c9b  # SHA ref: v3.0.1
@@ -83,4 +83,3 @@ jobs:
           [FAIL] - Error triggering gitlab flash pipeline
     outputs:
       pipeline: ${{ steps.flash.outputs.pipeline }}
-

--- a/tests/serverspec/spec/shared/openwrt/init.rb
+++ b/tests/serverspec/spec/shared/openwrt/init.rb
@@ -4,11 +4,11 @@ require 'serverspec' # If you want to use serverspec matchers, you will need thi
 RSpec.shared_examples "openwrt" do
 
   DEFAULT_BINS=["apinger", "awk", "bash", "logrotate",
-                "rsyslogd",  "zabbix_agentd", "tcpdump"]
+                "rsyslogd", "tcpdump"]
 
   REMOVED_BINS=["snmpd", "dropbear"]
 
-  DEFAULT_SERVICES=["apinger", "crond", "rsyslogd", "zabbix", "lldpd"]
+  DEFAULT_SERVICES=["apinger", "crond", "rsyslogd", "lldpd"]
 
   DEFAULT_BINS.each do |bin|
     describe command("which #{bin} 2> /dev/null") do

--- a/tests/serverspec/spec/shared/openwrt/init.rb
+++ b/tests/serverspec/spec/shared/openwrt/init.rb
@@ -4,8 +4,7 @@ require 'serverspec' # If you want to use serverspec matchers, you will need thi
 RSpec.shared_examples "openwrt" do
 
   DEFAULT_BINS=["apinger", "awk", "bash", "logrotate",
-                "python3", "rsyslogd", "zabbix_agentd",
-                "tcpdump"]
+                "rsyslogd",  "zabbix_agentd", "tcpdump"]
 
   REMOVED_BINS=["snmpd", "dropbear"]
 


### PR DESCRIPTION
## Description of PR

Fixes: https://github.com/socallinuxexpo/scale-network/issues/610

Relates to: #611 (python3 removal)

More deprecations from gha, specifically `set-output`: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

## Previous Behavior
- trigger workflow uses `set-output`
- Checking for python3, and zabbix in serverspec tests

## New Behavior
- trigger workflow uses `$GITHUB_OUTPUT`
- removed serverspec tests that were checking for binaries/services that are no longer present

## Tests
- [x] Working Case - Trigger Test: https://github.com/socallinuxexpo/scale-network/pull/629#discussion_r1385966499
  - result: https://gitlab.com/socallinuxexpo/scale-network/-/jobs/5484332703 
- [x] Fail Case - Trigger Test: https://github.com/socallinuxexpo/scale-network/pull/629#discussion_r1385926925
  - result: https://gitlab.com/socallinuxexpo/scale-network/-/pipelines/1064632364
  - Confirmation that variables are propagating with gha output updates:
```
{"ref":"rh/1696716150gha","variables":{"OPENWRT_INTEG":"YES","WORMHOLE_CODE":"tony-1-hello"},"id":"17362342"}
```
