### PR TITLE
[WIP] - Add Wi-Fi 6 BSS Coloring to udhcpc.user

### DIFF
--- a/openwrt/files/etc/udhcpc.user
+++ b/openwrt/files/etc/udhcpc.user
@@ -12,7 +12,7 @@ case "$1" in
         bss_color = `echo $ip | cut -d'.' -f4 | expr \( $i % 62 \) + 1`
         uci_bss_color = `uci -q show wireless.radio1.he_bss_color`
 
-        if [ $bss_color != $uci_bss_color ] || [ $? == 0 ]; then
+        if [ $bss_color != $uci_bss_color ] || [ $? == 1 ]; then
             uci set 'wireless.radio1.he_bss_color'=$bss_color
             uci commit
             wifi reload

--- a/openwrt/files/etc/udhcpc.user
+++ b/openwrt/files/etc/udhcpc.user
@@ -5,6 +5,20 @@ case "$1" in
   "renew"|"bound")
     # dump params to tmp so its easier to troubleshoot
     set > /tmp/dhcp.params
+
+    board = `cat /etc/board.json | jq '.model.id' -r | cut -d',' -f2`
+
+    if [ $1 == "bound" ] && [ $board == "e8450-ubi" ] ; then
+        bss_color = `echo $ip | cut -d'.' -f4 | expr \( $i % 62 \) + 1`
+        uci_bss_color = `uci -q show wireless.radio1.he_bss_color`
+
+        if [ $bss_color != $uci_bss_color ] || [ $? == 0 ]; then
+            uci set 'wireless.radio1.he_bss_color'=$bss_color
+            uci commit
+            wifi reload
+        fi
+    fi
+
     radio0=`uci show 'wireless.radio0.channel'|cut -f 2 -d "'"`
     radio1=`uci show 'wireless.radio1.channel'|cut -f 2 -d "'"`
     if [ ! -z "$opt224" ] || [ ! -z "$opt225" ]; then


### PR DESCRIPTION
## Description of PR

Fixes: https://github.com/socallinuxexpo/scale-network/issues/652

Add Wi-Fi 6 BSS Coloring to udhcpc.user

## Previous Behavior
No Wi-Fi 6 BSS Coloring existed.

## New Behavior
Use the last octet of the IPv4 management address, in a modulo 62+1, to produce the BSS color number.

## Tests
Rob to test on the Linksys E8450 and compatible models.
