### PR TITLE
[READY] add better datastore test clarity

### DIFF
--- a/facts/datasource.py
+++ b/facts/datasource.py
@@ -149,15 +149,17 @@ def test_datafile(delimiter, meta):
             count = str(meta["count"])[:-1]
             if len(elems) < int(count):
                 return False, "insufficient col count: " + str(len(elems)) + \
-                   " wanted " + str(meta["count"]) + "at line " + str(linenum)
+                  " wanted " + str(meta["count"]) + " at line " + str(linenum) \
+                  + " of " + meta["file"]
         elif len(elems) != meta["count"]:
             return False, "invalid col count: " + str(len(elems)) + " wanted " + \
-                str(meta["count"]) + " at line " + str(linenum)
+                str(meta["count"]) + " at line " + str(linenum) + " of " + meta["file"]
         # skip validators for header row
         if meta["header"] and linenum == 0:
             continue
         # run the validators for each column
         for i, val in enumerate(elems):
             if not meta["cols"][i](val.rstrip('\n')):
-                return False, "invalid field " + val + " at line " + str(linenum)
+                return False, "invalid field " + val + " failed " + meta["cols"][i].__name__ + \
+                " at line " + str(linenum) + " of " + meta["file"]
     return True, ""


### PR DESCRIPTION
Fixes #480 

## Description of PR
Updates data validation to be more verbose.

## Previous Behavior
- field based test failures did not display the file name or specific validation failure
- column based test failures did not display the file name

## New Behavior
- filed based test failures now display the file name and function name
- column based test failures now display the file name

## Tests
Locally:
1. Fix for issue 480, this is the new output of a field based validation with file name and function name added:
```
> pytest -vv -p no:cacheprovider
================================================================================= test session starts =================================================================================
platform darwin -- Python 3.11.3, pytest-7.1.3, pluggy-1.0.0 -- /nix/store/mcfk7g2qscks090ww00kzlxzqdk0z02x-python3-3.11.3/bin/python3.11
rootdir: /Users/kyle.risse/go/src/github.com/kylerisse/scale-network/facts
collected 5 items

test_datasources.py::test_aplist_csv FAILED                                                                                                                                     [ 20%]
test_datasources.py::test_pilist_csv PASSED                                                                                                                                     [ 40%]
test_datasources.py::test_routerlist_csv PASSED                                                                                                                                 [ 60%]
test_datasources.py::test_serverlist_csv PASSED                                                                                                                                 [ 80%]
test_datasources.py::test_switchtypes_tsv PASSED                                                                                                                                [100%]

====================================================================================== FAILURES =======================================================================================
___________________________________________________________________________________ test_aplist_csv ___________________________________________________________________________________

    def test_aplist_csv():
        '''test aplist.csv'''
        meta = {
            "file": "./aps/aplist.csv",
            "header": True,
            "count": 10,
            "cols": [
                ds.isvalidhostname,
                ds.isuntested,
                ds.isvalidmac,
                ds.isvalidip,
                ds.isvalidwifi24chan,
                ds.isvalidwifi5chan,
                ds.isint,
                ds.isintorempty,
                ds.isintorempty,
                ds.isintorempty
            ]
        }
        result, err = ds.test_csvfile(meta)
>       assert result, err
E       AssertionError: invalid field 173 failed isvalidwifi5chan at line 1 of ./aps/aplist.csv
E       assert False

test_datasources.py:28: AssertionError
=============================================================================== short test summary info ===============================================================================
FAILED test_datasources.py::test_aplist_csv - AssertionError: invalid field 173 failed isvalidwifi5chan at line 1 of ./aps/aplist.csv
============================================================================= 1 failed, 4 passed in 0.02s =============================================================================
```

Untested: Running test via flake, I'm on Darwin 🤦‍♂️ 