### PR TITLE
[Ready] Added last-minut request for Expo Hal VM Vending Machine (against my better judgment)

### DIFF
--- a/facts/datasource.py
+++ b/facts/datasource.py
@@ -147,8 +147,8 @@ def test_datafile(delimiter, meta):
     with open(meta["file"], encoding='utf-8') as fha:
         lines = fha.readlines()
     for linenum, line in enumerate(lines):
-        # skip comments
-        if line[0] == '/' and line[1] == '/':
+        # skip comments or empty lines
+        if (line[0] == '/' and line[1] == '/') or (line.startswith('\n')):
             continue
         elems = re.split(delimiter, line)
         # check for expected number of columns

--- a/facts/datasource.py
+++ b/facts/datasource.py
@@ -157,11 +157,11 @@ def test_datafile(delimiter, meta):
             count = str(meta["count"])[:-1]
             if len(elems) < int(count):
                 return False, "insufficient col count: " + str(len(elems)) + \
-                  " wanted " + str(meta["count"]) + " at line " + str(linenum) \
+                  " wanted " + str(meta["count"]) + " at line " + str(linenum+1) \
                   + " of " + meta["file"]
         elif len(elems) != meta["count"]:
             return False, "invalid col count: " + str(len(elems)) + " wanted " + \
-                str(meta["count"]) + " at line " + str(linenum) + " of " + meta["file"]
+                str(meta["count"]) + " at line " + str(linenum+1) + " of " + meta["file"]
         # skip validators for header row
         if meta["header"] and linenum == 0:
             continue
@@ -169,5 +169,5 @@ def test_datafile(delimiter, meta):
         for i, val in enumerate(elems):
             if not meta["cols"][i](val.rstrip('\n')):
                 return False, "invalid field " + val + " failed " + meta["cols"][i].__name__ + \
-                " at line " + str(linenum) + " of " + meta["file"]
+                " at line " + str(linenum+1) + " of " + meta["file"]
     return True, ""

--- a/facts/datasource.py
+++ b/facts/datasource.py
@@ -44,6 +44,14 @@ def isvalidip(addr):
         return False
     return True
 
+def isvalidsubnet(subnet):
+    '''test for valid v4 or v6 subnet'''
+    try:
+        ipaddress.ip_network(subnet, strict=True)
+    except ValueError:
+        return False
+    return True
+
 
 def isvalidiporempty(val):
     '''test for valid ip or empty'''

--- a/facts/test_datasources.py
+++ b/facts/test_datasources.py
@@ -2,6 +2,7 @@
 '''
 CSV data source tests
 '''
+import os
 import datasource as ds
 
 
@@ -96,3 +97,25 @@ def test_switchtypes_tsv():
     }
     result, err = ds.test_tsvfile(meta)
     assert result, err
+
+
+def test_vlansd_tsv():
+    """test vlans.d/"""
+
+    vlansddir = "../switch-configuration/config/vlans.d/"
+    for filename in os.listdir(vlansddir):
+        meta = {
+            "file": vlansddir + filename,
+            "header": False,
+            "count": "6+",
+            "cols": [
+                ds.isuntested,
+                ds.isuntested,
+                ds.isuntested,
+                ds.isvalidsubnet,
+                ds.isvalidsubnet,
+                ds.isuntested,
+            ],
+        }
+        result, err = ds.test_tsvfile(meta)
+        assert result, err

--- a/switch-configuration/config/scripts/switch_template.pm
+++ b/switch-configuration/config/scripts/switch_template.pm
@@ -813,22 +813,7 @@ sub VV_get_prefix6
     warn("Error: cannot support more than 9999 IPv6 VLANs (>16 bit variable BCD field) for VVRNG\n");
     return -1;
   }
-  $netbase = $quartets[3];
-  if ($quartets[3] !~ /^\d+$/)
-  {
-    # Have to extract BCD compatible portion to netbase and treat rest as fixed.
-    my @digits = split(//, $quartets[3]);
-    while ($digits[0] !~ /^\d$/ && $#digits)
-    {
-      $digitpfx .= shift @digits; # Save hex prefix for later use
-    }
-    $netbase = join("", @digits);
-    if ($netbase !~ /^\d+$/)
-    {
-      warn("Error: Supplied ipv6 not BCD compatible for VVRNG\n");
-      return -1;
-    }
-  }
+  $netbase = $VV_LOW;
   my $netmax;
   if ($n_bits % 4)
   {

--- a/switch-configuration/config/types/Catwalk
+++ b/switch-configuration/config/types/Catwalk
@@ -88,7 +88,7 @@ TRUNK	ge-0/0/28	exSCALE-SLOW,exSCALE-FAST,exSpeaker,exInfra, \
 			exSigns,HAM_BRIDGE 	-	// 
 TRUNK	ge-0/0/29	exSCALE-SLOW,exSCALE-FAST,exSpeaker,exInfra, \
 			exAVLAN,vendor_backbone \
-			exSigns,HAM_BRIDGE 	-	// 
+			exSigns,exVmVendor,HAM_BRIDGE 	-	// 
 TRUNK	ge-0/0/30	exSCALE-SLOW,exSCALE-FAST,exInfra	POE	// AP for Game Night
 TRUNK	ge-0/0/31	exSCALE-SLOW,exSCALE-FAST,exInfra	POE	// AP for Game Night
 TRUNK	ge-0/0/32	exSCALE-SLOW,exSCALE-FAST,exInfra	POE	// AP for Game Night

--- a/switch-configuration/config/vlans.d/Expo
+++ b/switch-configuration/config/vlans.d/Expo
@@ -12,7 +12,8 @@ VLAN	exSigns				107	2001:470:f026:107::/64	0.0.0.0/0	Signs network (Expo Center)
 VLAN	exRegistration  	110	2001:470:f026:110::/64	10.0.10.0/24	Registration Network (Expo Center) IPv6 Only
 // Akamai cache is deprecated
 //VLAN	exAkamai			111	2001:470:f026:111::/64	0.0.0.0/0	Special public Akamai Cache Cluster network (has IPv4 from convention center)
-//112 through 199 not used
+VLAN exVmVendor             112 2001:470:f026:112::/64  10.0.144.0/20     Special network for VM Vending Machine
+//113 through 199 not used
 //200 through 499 Vendors
 //200-498 are dynamically generated from Booth information file as Vendor VLANs.
 //The difference is that these VLAN interfaces will also be built with firewall filters to prevent access to other

--- a/switch-configuration/config/vlans.d/Expo
+++ b/switch-configuration/config/vlans.d/Expo
@@ -12,7 +12,7 @@ VLAN	exSigns				107	2001:470:f026:107::/64	0.0.0.0/0	Signs network (Expo Center)
 VLAN	exRegistration  	110	2001:470:f026:110::/64	10.0.10.0/24	Registration Network (Expo Center) IPv6 Only
 // Akamai cache is deprecated
 //VLAN	exAkamai			111	2001:470:f026:111::/64	0.0.0.0/0	Special public Akamai Cache Cluster network (has IPv4 from convention center)
-VLAN exVmVendor             112 2001:470:f026:112::/64  10.0.144.0/20     Special network for VM Vending Machine
+VLAN	exVmVendor		112	2001:470:f026:112::/64	10.0.144.0/20	Special network for VM Vending Machine
 //113 through 199 not used
 //200 through 499 Vendors
 //200-498 are dynamically generated from Booth information file as Vendor VLANs.

--- a/switch-configuration/config/vlans.d/Expo
+++ b/switch-configuration/config/vlans.d/Expo
@@ -18,6 +18,7 @@ VLAN	exVmVendor		112	2001:470:f026:112::/64	10.0.144.0/20	Special network for VM
 //200-498 are dynamically generated from Booth information file as Vendor VLANs.
 //The difference is that these VLAN interfaces will also be built with firewall filters to prevent access to other
 //VLANs (vendor_vlan <-> internet only)
-VVRNG	vendor_vlan_		200-498	2001:470:f026:200::/54	10.2.0.0/15	Dynamically allocated and named booth VLANs
+VVRNG	vendor_vlan_		200-498	2001:470:f026::/48	10.2.0.0/15	Dynamically allocated and named booth VLANs
 //499 is reserved for the Vendor backbone VLAN between the Expo switches and the routers.
 VLAN	vendor_backbone		499	2001:470:f026:499::/64	10.1.0.0/24	Vendor Backbone
+

--- a/switch-configuration/config/vlans.d/Expo
+++ b/switch-configuration/config/vlans.d/Expo
@@ -1,6 +1,6 @@
 // Expo Center -- VLANS 100-499
-VLAN	exSCALE-SLOW		100	2001:470:f026:100::/64	10.0.128.0/21	2.4G Wireless Network in Expo Center
-VLAN	exSCALE-FAST		101	2001:470:f026:101::/64	10.0.136.0/21	5G Wireless Network in Expo Center
+VLAN	exSCALE-SLOW			100	2001:470:f026:100::/64	10.0.128.0/21	2.4G Wireless Network in Expo Center
+VLAN	exSCALE-FAST			101	2001:470:f026:101::/64	10.0.136.0/21	5G Wireless Network in Expo Center
 VLAN	exSpeaker			102	2001:470:f026:102::/64	10.0.2.0/24	Speaker Network
 VLAN	exInfra				103	2001:470:f026:103::/64	10.0.3.0/24	SCALE Network Infrastructure and Servers (Expo Center)
 VLAN	exMDF				104	2001:470:f026:104::/64	10.0.4.0/24	Link to MDF Router
@@ -9,16 +9,16 @@ VLAN	exAVLAN				105	2001:470:f026:105::/64	10.0.5.0/24	Audio Visual Network (DHC
 VLAN	exSigns				107	2001:470:f026:107::/64	0.0.0.0/0	Signs network (Expo Center) IPv6 Only
 //VLAN	exStaff				108	2001:470:f026:108::/64	10.0.8.0/24	Staff Wireless Network
 //109 not used
-VLAN	exRegistration  	110	2001:470:f026:110::/64	10.0.10.0/24	Registration Network (Expo Center) IPv6 Only
+VLAN	exRegistration			110	2001:470:f026:110::/64	10.0.10.0/24	Registration Network (Expo Center) IPv6 Only
 // Akamai cache is deprecated
 //VLAN	exAkamai			111	2001:470:f026:111::/64	0.0.0.0/0	Special public Akamai Cache Cluster network (has IPv4 from convention center)
-VLAN	exVmVendor		112	2001:470:f026:112::/64	10.0.144.0/20	Special network for VM Vending Machine
+VLAN	exVmVendor			112	2001:470:f026:112::/64	10.0.144.0/20	Special network for VM Vending Machine
 //113 through 199 not used
 //200 through 499 Vendors
 //200-498 are dynamically generated from Booth information file as Vendor VLANs.
 //The difference is that these VLAN interfaces will also be built with firewall filters to prevent access to other
 //VLANs (vendor_vlan <-> internet only)
-VVRNG	vendor_vlan_		200-498	2001:470:f026::/48	10.2.0.0/15	Dynamically allocated and named booth VLANs
+VVRNG	vendor_vlan_			200-498	2001:470:f026::/48	10.2.0.0/15	Dynamically allocated and named booth VLANs
 //499 is reserved for the Vendor backbone VLAN between the Expo switches and the routers.
-VLAN	vendor_backbone		499	2001:470:f026:499::/64	10.1.0.0/24	Vendor Backbone
+VLAN	vendor_backbone			499	2001:470:f026:499::/64	10.1.0.0/24	Vendor Backbone
 

--- a/switch-configuration/config/vlans.d/Hilton
+++ b/switch-configuration/config/vlans.d/Hilton
@@ -15,6 +15,6 @@ VLAN	hiInstall		111	2001:470:f026:111::/64	10.0.11.0/24	Install Fests and Worksh
 //200-498 are dynamically generated from Booth information file as Vendor VLANs.
 //The difference is that these VLAN interfaces will also be built with firewall filters to prevent access to other
 //VLANs (vendor_vlan <-> internet only)
-VVRNG	vendor_vlan_		200-498	2001:470:f026:200::/54	10.2.0.0/15	Dynamically allocated and named booth VLANs
+VVRNG	vendor_vlan_		200-498	2001:470:f026::/48	10.2.0.0/15	Dynamically allocated and named booth VLANs
 //499 is reserved for the Vendor backbone VLAN between the Expo switches and the routers.
 VLAN	vendor_backbone		499	2001:470:f026:499::/64	10.1.0.0/24	Vendor Backbone


### PR DESCRIPTION

## Description of PR
Add configuration to support VM Vending Machine in Expo Hall

## Previous Behavior
We didn't have to worry about DefCon bringing complexity to our network.

## New Behavior
Should (hopefully) support last minute request for a vending machine to support short term VMs for people to use for mischief.

## Tests
There's no way to test this in advance, we just have to cope with whatever happens as it comes up.
