### PR TITLE
[READY] Issue #389 disable password based SSH logins on switches

### DIFF
--- a/switch-configuration/config/miniconfig
+++ b/switch-configuration/config/miniconfig
@@ -50,6 +50,7 @@ system {
     }
     services {
         ssh {
+            no-passwords;
             protocol-version v2;
         }
         netconf {

--- a/switch-configuration/config/scripts/switch_template.pm
+++ b/switch-configuration/config/scripts/switch_template.pm
@@ -1547,6 +1547,7 @@ $USER_AUTHENTICATION
     }
     services {
         ssh {
+            no-passwords;
             protocol-version v2;
         }
         netconf {


### PR DESCRIPTION
## Description of PR
Fixes: #389 

Disable password based SSH logins on switches

## Previous Behavior
Switches allowed password or ssh-key based logins via SSH

## New Behavior
Switches only accept public-key authentication over SSH

## Tests
No testing required, small text change in proto config files.
