### PR TITLE
[READY] - enable ntpd on core machines

### DIFF
--- a/nix/machines/core/common.nix
+++ b/nix/machines/core/common.nix
@@ -13,7 +13,7 @@
     useDHCP = false;
     useNetworkd = true;
     firewall.allowedTCPPorts = [ 53 67 68 ];
-    firewall.allowedUDPPorts = [ 53 67 68 ];
+    firewall.allowedUDPPorts = [ 53 67 68 123 ];
   };
 
   security.sudo.wheelNeedsPassword = false;
@@ -51,6 +51,14 @@
         enable = true;
         configFile = "${inputs.self.packages.${pkgs.system}.scaleInventory}/config/kea.json";
       };
+    };
+    ntp = {
+      enable = true;
+      extraConfig = ''
+        # Hosts on the local network(s) are not permitted because of the "restrict default"
+        restrict 10.0.0.0/8 kod nomodify notrap nopeer
+        restrict 2001:470:f026::/48 kod nomodify notrap nopeer
+      '';
     };
   };
 }

--- a/nix/pkgs/scaleInventory.nix
+++ b/nix/pkgs/scaleInventory.nix
@@ -7,7 +7,6 @@
 let
   local_manifests = copyPathsToStore [
     ../../switch-configuration
-    ../../ansible
     ../../facts
   ];
 in

--- a/nix/tests/core.nix
+++ b/nix/tests/core.nix
@@ -48,6 +48,7 @@
     ''
       start_all()
       coreServer.wait_for_unit("systemd-networkd-wait-online.service")
+      coreServer.wait_for_unit("ntpd.service")
       coreServer.succeed("kea-dhcp4 -t /etc/kea/dhcp4-server.conf")
       client1.wait_for_unit("systemd-networkd-wait-online.service")
       client1.wait_until_succeeds("ping -c 5 ${coreServerIp}")


### PR DESCRIPTION
## Description of PR

Related to: #592

Getting ntpd enabled and running on the core machines

## Previous Behavior
- ntpd was not running on the core machines
- left old ansible reference after #663 in scaleInventory pkg

## New Behavior
- ntpd running on core and restricted to scale ipv4 and ipv6 ranges
- cleaned up old ansible ref  in scaleInventory pkg

## Tests
- Running vm locally confirms that is working as expected:

```
nix build .#nixosConfigurations.coreMaster.config.system.build.vm
```

- Running the vmtest for core works as expect:

```
$ nix build -L .#checks.x86_64-linux.core
```
