### PR TITLE
[READY] - UEFI disk formatting and sudo settings

### DIFF
--- a/nix/machines/_common/users.nix
+++ b/nix/machines/_common/users.nix
@@ -5,6 +5,7 @@
   security.sudo = {
     extraConfig = ''
       Defaults rootpw
+      Defaults lecture="never"
     '';
   };
 

--- a/nix/machines/_common/users.nix
+++ b/nix/machines/_common/users.nix
@@ -1,6 +1,13 @@
 { config, lib, pkgs, ... }:
 
 {
+
+  security.sudo = {
+    extraConfig = ''
+      Defaults rootpw
+    '';
+  };
+
   users.mutableUsers = false;
   users.extraUsers.root.hashedPassword = "$6$3Hm/K5fbR3UEMK6H$3aaegtdwvejGk9Bk0ttN5bNJn4z2Yt6LWXD3nGI7.44Pbm7A1TpKuxG9XQLwsj7M9NEk8eB5Exg0qVRV//6br/";
 

--- a/nix/machines/bootstrap/bootstrap.sh
+++ b/nix/machines/bootstrap/bootstrap.sh
@@ -25,8 +25,14 @@ zfs create -o mountpoint=legacy zroot/nix  # For /nix
 zfs create -o mountpoint=legacy zroot/persist  # For /persist
 
 # Create ESP partiions
-mkfs.vfat /dev/${DISK0}1
-mkfs.vfat /dev/${DISK1}1
+# FAT32 suggested as the most compat and portable
+mkfs.fat -F32 /dev/${DISK0}1
+mkfs.fat -F32 /dev/${DISK1}1
+
+# Give use labels so we dont have to lookup
+# uuids or something annoying for our configs
+mlabel -i /dev/${DISK0}1 ::"BOOT"
+mlabel -i /dev/${DISK1}1 ::"BOOT2"
 
 # Mount new ZFS pool
 mount -t zfs zroot/root /mnt
@@ -39,7 +45,7 @@ mount -t zfs zroot/nix /mnt/nix
 mount -t zfs zroot/home /mnt/home
 
 # Mount both of the ESP's
-mount /dev/${DISK0}1 /mnt/boot
-mount /dev/${DISK1}1 /mnt/boot2
+mount /dev/disk/by-label/BOOT /mnt/boot
+mount /dev/disk/by-label/BOOT2 /mnt/boot2
 
 echo "nixos-install --flake github:socallinuxexpo/scale-network/<branch>#<machine>"


### PR DESCRIPTION
## Description of PR

Follow up from #658 and comment: https://github.com/socallinuxexpo/scale-network/pull/658#discussion_r1466948661

FAT32 will be used to provide the UEFI partitions from now on and will include labels.

## Previous Behavior
- vfat UEFI partitions for hypervisors
- sudo was asking for a users non existant user password

## New Behavior
- FAT32 formatted partitions for hypervisors
- sudo will ask for root's password, without any lecturing

## Tests
- sudo changes checked out when applied again this branch on the hypervisor
- Will have to wait until the next time we use the bootstrap script to verify the formattings good
