### PR TITLE
[READY] - Hypervisor, kea, and ntp configs

### DIFF
--- a/facts/inventory.py
+++ b/facts/inventory.py
@@ -321,15 +321,25 @@ def populatepis(pisfile):
         )
     return pis
 
-def loghostalias(name):
-    """generate aliases for loghost"""
+def serveralias(name):
+    """generate aliases for servers"""
     payload = []
-    if name.lower() == "monitoring1":
-        payload = [
-            "loghost",
-            "monitoring",
-            "zabbix",
-        ]
+    match name.lower():
+        case "monitoring1":
+            payload = [
+                "loghost",
+                "monitoring",
+            ]
+        case "coreexpo":
+            payload = [
+                "coremaster",
+                "ntpexpo",
+            ]
+        case "coreconf":
+            payload = [
+                "coreslave",
+                "ntpconf",
+            ]
     return payload
 
 
@@ -383,7 +393,7 @@ def populateservers(serversfile, vlans):
                 "vlan": vlan,
                 "fqdn": elems[0] + ".scale.lan",
                 "building": building,
-                "aliases": loghostalias(elems[0]),
+                "aliases": serveralias(elems[0]),
             }
         )
     return servers

--- a/facts/inventory.py
+++ b/facts/inventory.py
@@ -450,7 +450,10 @@ def generatekeaconfig(servers, aps, vlans, outputdir):
                     "encapsulate": "",
                 },
             ],
-            "reservation-mode": "global",
+            # All of our reservations are global
+            # https://kea.readthedocs.io/en/kea-2.2.0/arm/dhcp4-srv.html#fine-tuning-dhcpv4-host-reservation
+            "reservations-global": True,
+            "reservations-in-subnet": True,
             "reservations": [],
             # Finally, we list the subnets from which we will be leasing addresses.
             "subnet4": []

--- a/facts/inventory.py
+++ b/facts/inventory.py
@@ -406,7 +406,11 @@ def generatekeaconfig(servers, aps, vlans, outputdir):
             "renew-timer": 1000,
             "rebind-timer": 2000,
             # Next we set up the interfaces to be used by the server.
-            "interfaces-config": {"interfaces": ["*"]},
+            "interfaces-config": {
+                "interfaces": ["*"],
+                "service-sockets-max-retries": 5,
+                "service-sockets-retry-wait-time": 5000
+            },
             # And we specify the type of lease database
             "lease-database": {
                 "type": "memfile",

--- a/facts/inventory.py
+++ b/facts/inventory.py
@@ -427,10 +427,16 @@ def generatekeaconfig(servers, aps, vlans, outputdir):
                 "persist": True,
                 "name": "/var/lib/kea/dhcp4.leases",
             },
-            "option-data": [{
+            "option-data": [
+            {
              "name": "domain-name-servers",
              "data": ','.join([x['ipv4'] for x in servers if x['role'] == 'core'])
-            }],
+            },
+            {
+             "name": "ntp-servers",
+             "data": ','.join([x['ipv4'] for x in servers if x['role'] == 'core'])
+            }
+            ],
             "option-def": [
                 {
                     "name": "radio24-channel",
@@ -498,7 +504,7 @@ def generatekeaconfig(servers, aps, vlans, outputdir):
         }
         for vlan in vlans
         if vlan["ipv4bitmask"]
-        != "0"  # Make sure we dont populate vlans that have no ranges
+        != "0"  # Make sure to skip vlans that have no ranges
     ]
 
     kea_config["Dhcp4"]["subnet4"] = subnets_dict

--- a/flake.lock
+++ b/flake.lock
@@ -47,15 +47,16 @@
         "spectrum": []
       },
       "locked": {
-        "lastModified": 1706214321,
-        "narHash": "sha256-42FZWeJQNYgz0ZkclMzShuvjT9TvJNRN78Iu3SEyD4M=",
-        "owner": "astro",
+        "lastModified": 1707111432,
+        "narHash": "sha256-zkBH/k6YEimyyecSRQsV2VlNGsRdS0hygci+cI3xXRU=",
+        "owner": "sarcasticadmin",
         "repo": "microvm.nix",
-        "rev": "186b8bf6dbacc1ab55fe8ac8d5a2bbf76a1a70e1",
+        "rev": "37a09d245d2aa401da575e344978cf981005fc3a",
         "type": "github"
       },
       "original": {
-        "owner": "astro",
+        "owner": "sarcasticadmin",
+        "ref": "rh/1707108673virtio",
         "repo": "microvm.nix",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -4,7 +4,7 @@
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
     flake-parts = { url = "github:hercules-ci/flake-parts"; inputs.nixpkgs-lib.follows = "nixpkgs"; };
-    microvm = { url = "github:astro/microvm.nix"; inputs.nixpkgs.follows = "nixpkgs"; inputs.spectrum.follows = ""; };
+    microvm = { url = "github:sarcasticadmin/microvm.nix/rh/1707108673virtio"; inputs.nixpkgs.follows = "nixpkgs"; inputs.spectrum.follows = ""; }; # Currently using this fork since the upstream seems to be causing an issue
   };
 
 

--- a/nix/machines/_common/base.nix
+++ b/nix/machines/_common/base.nix
@@ -1,5 +1,13 @@
 { config, pkgs, ... }:
 {
+  # default to stateVersion for current lock
+  system.stateVersion = config.system.nixos.version;
+
+  # remove the annoying experimental warnings
+  nix.extraOptions = ''
+    experimental-features = nix-command flakes
+  '';
+
   environment.systemPackages = with pkgs; [
     bc
     binutils

--- a/nix/machines/_common/time.nix
+++ b/nix/machines/_common/time.nix
@@ -1,0 +1,7 @@
+{
+  # Sets the default timeservers for everything thats using the default: systemd-timesyncd
+  networking.timeServers = [
+    "ntpconf.scale.lan"
+    "ntpexpo.scale.lan"
+  ];
+}

--- a/nix/machines/core/common.nix
+++ b/nix/machines/core/common.nix
@@ -1,9 +1,6 @@
 { config, lib, pkgs, inputs, ... }:
 
 {
-  # If not present then warning and will be set to latest release during build
-  system.stateVersion = "22.11";
-
   boot.kernelParams = [ "console=ttyS0" ];
 
   # disable legacy networking bits as recommended by:

--- a/nix/machines/core/common.nix
+++ b/nix/machines/core/common.nix
@@ -1,4 +1,4 @@
-{ config, lib, pkgs, inputs, ... }:
+{ config, lib, pkgs, inputs, options, ... }:
 
 {
   boot.kernelParams = [ "console=ttyS0" ];
@@ -51,6 +51,8 @@
     };
     ntp = {
       enable = true;
+      # Default to time servers that are not Scales since we have to get time from somewhere
+      servers = options.networking.timeServers.default;
       extraConfig = ''
         # Hosts on the local network(s) are not permitted because of the "restrict default"
         restrict 10.0.0.0/8 kod nomodify notrap nopeer

--- a/nix/machines/core/master.nix
+++ b/nix/machines/core/master.nix
@@ -9,6 +9,8 @@ in
       ./common.nix
     ];
 
+  networking.hostName = "coremaster";
+
   # disable legacy networking bits as recommended by:
   #  https://github.com/NixOS/nixpkgs/issues/10001#issuecomment-905532069
   #  https://github.com/NixOS/nixpkgs/blob/82935bfed15d680aa66d9020d4fe5c4e8dc09123/nixos/tests/systemd-networkd-dhcpserver.nix

--- a/nix/machines/core/master.nix
+++ b/nix/machines/core/master.nix
@@ -24,7 +24,8 @@ in
     enable = true;
     networks = {
       "10-lan" = {
-        name = "enp0*";
+        # to match enp0 or eth0
+        name = "e*0*";
         enable = true;
         address = [ "10.0.3.5/24" "2001:470:f026:103::5/64" ];
         gateway = [ "10.0.3.1" ];

--- a/nix/machines/core/microvm-config.nix
+++ b/nix/machines/core/microvm-config.nix
@@ -1,0 +1,21 @@
+{ config, ... }:
+
+{
+  microvm.qemu.serialConsole = false;
+  microvm.qemu.extraArgs = [
+    "-serial" "pty"
+  ];
+
+  microvm.vcpu = 4;
+  microvm.mem = 8192;
+  microvm.interfaces = [
+    {
+      type = "tap";
+      id = "vm-${config.networking.hostName}";
+      # Will eventually pull this from facts
+      mac =  if config.networking.hostName == "coremaster" then "58:9c:fc:00:38:5f" else "4c:72:b9:7c:41:17";
+    }
+  ];
+
+  microvm.volumes = [ { image = "/persist/microvm/${config.networking.hostName}.img"; mountPoint = "/var"; size = 40000; }];
+}

--- a/nix/machines/core/slave.nix
+++ b/nix/machines/core/slave.nix
@@ -6,9 +6,11 @@
       ./common.nix
     ];
 
+  networking.hostName = "coreslave";
+
   networking = {
     extraHosts = ''
-      10.128.3.5 coreexpo.scale.lan
+      10.128.3.5 coreconf.scale.lan
     '';
   };
 

--- a/nix/machines/flake-module.nix
+++ b/nix/machines/flake-module.nix
@@ -68,6 +68,7 @@ in
         inherit system;
         modules = [
           common
+          ./core/microvm-config.nix
           ./core/master.nix
         ];
         specialArgs = { inherit inputs; };
@@ -76,6 +77,7 @@ in
         inherit system;
         modules = [
           common
+          ./core/microvm-config.nix
           ./core/slave.nix
         ];
         specialArgs = { inherit inputs; };

--- a/nix/machines/flake-module.nix
+++ b/nix/machines/flake-module.nix
@@ -5,7 +5,7 @@ let
   system = "x86_64-linux";
   common = {
     imports = [
-      inputs.self.nixosModules.bhyve-image
+      inputs.microvm.nixosModules.microvm
       ./_common
     ];
   };

--- a/nix/machines/flake-module.nix
+++ b/nix/machines/flake-module.nix
@@ -7,6 +7,7 @@ let
     imports = [
       inputs.microvm.nixosModules.microvm
       ./_common
+      ./_common/time.nix
     ];
   };
 in

--- a/nix/machines/flake-module.nix
+++ b/nix/machines/flake-module.nix
@@ -80,6 +80,16 @@ in
         ];
         specialArgs = { inherit inputs; };
       };
+      hypervisor2 = lib.nixosSystem {
+        inherit system;
+        modules = [
+          ./_common
+          inputs.microvm.nixosModules.host
+          ./hypervisor/hypervisor2.nix
+          ./hypervisor/hardware-configuration.nix
+        ];
+        specialArgs = { inherit inputs; };
+      };
       signs = lib.nixosSystem {
         inherit system;
         modules = [

--- a/nix/machines/hypervisor/hardware-configuration.nix
+++ b/nix/machines/hypervisor/hardware-configuration.nix
@@ -1,0 +1,71 @@
+{ config, lib, pkgs, modulesPath, ... }:
+
+{
+  imports =
+    [
+      (modulesPath + "/installer/scan/not-detected.nix")
+    ];
+
+  # *sas drivers required for Lenovo System x3650 M5 Machine Type: 8871AC1
+  boot.initrd.availableKernelModules = [ "ehci_pci" "ahci" "usbhid" "usb_storage" "sd_mod" "mpt3sas" "megaraid_sas" ];
+  boot.initrd.kernelModules = [ ];
+  boot.kernelModules = [ "kvm-intel" ];
+  boot.extraModulePackages = [ ];
+
+  fileSystems."/" =
+    {
+      device = "zroot/root";
+      fsType = "zfs";
+    };
+  fileSystems."/boot" =
+    {
+      device = "/dev/disk/by-label/BOOT";
+      fsType = "vfat";
+      options = [ "nofail" ];
+    };
+  fileSystems."/boot2" =
+    {
+      device = "/dev/disk/by-label/BOOT2";
+      fsType = "vfat";
+      options = [ "nofail" ];
+    };
+  fileSystems."/nix" =
+    {
+      device = "zroot/nix";
+      fsType = "zfs";
+    };
+
+  fileSystems."/home" =
+    {
+      device = "zroot/home";
+      fsType = "zfs";
+    };
+
+  fileSystems."/persist" =
+    {
+      device = "zroot/persist";
+      fsType = "zfs";
+    };
+
+  # Make sure we have a place to storage persistent volumes
+  system.activationScripts.persist_microvm = lib.stringAfter [ "stdio" ]
+    ''
+      mkdir -m 750 -p /persist/microvm
+      chown microvm:kvm /persist/microvm
+    '';
+
+  swapDevices = [ ];
+
+  nixpkgs.hostPlatform = lib.mkDefault "x86_64-linux";
+  hardware.cpu.intel.updateMicrocode = lib.mkDefault config.hardware.enableRedistributableFirmware;
+
+  boot.loader.grub = {
+    enable = true;
+    efiSupport = true;
+    efiInstallAsRemovable = true;
+    mirroredBoots = [
+      { devices = [ "nodev" ]; path = "/boot"; }
+      { devices = [ "nodev" ]; path = "/boot2"; }
+    ];
+  };
+}

--- a/nix/machines/hypervisor/hypervisor2.nix
+++ b/nix/machines/hypervisor/hypervisor2.nix
@@ -1,4 +1,4 @@
-{ config, pkgs, ... }:
+{ config, pkgs, lib, ... }:
 {
 
 
@@ -48,6 +48,8 @@
       };
     };
   };
+
+  systemd.services.systemd-networkd-wait-online.enable = lib.mkForce false;
 
   environment.systemPackages = with pkgs; [
     tio

--- a/nix/machines/hypervisor/hypervisor2.nix
+++ b/nix/machines/hypervisor/hypervisor2.nix
@@ -1,0 +1,60 @@
+{ config, pkgs, ... }:
+{
+
+
+  # ZFS uniq system ID
+  # to generate: head -c4 /dev/urandom | od -A none -t x4
+  networking.hostId = "6333bc40";
+
+  networking = {
+    # use systemd.networkd
+    useNetworkd = true;
+    useDHCP = false;
+    firewall.enable = true;
+  };
+
+  systemd.network = {
+    enable = true;
+    netdevs.virbr0.netdevConfig = {
+      Kind = "bridge";
+      Name = "virbr0";
+    };
+
+    networks = {
+      "1-virbr0" = {
+        matchConfig.Name = "virbr0";
+        enable = true;
+        #networkConfig.DHCP = "yes";
+        address = [ "10.0.3.20/24" "2001:470:f026:103::20/64" ];
+        gateway = [ "10.0.3.20" ];
+        #[Route]
+        #Gateway=192.168.0.10
+        #Destination=10.0.0.0/8
+        #GatewayOnlink=yes
+      };
+      "20-microvm-eth0" = {
+        matchConfig.Name = "vm-*";
+        networkConfig.Bridge = "virbr0";
+      };
+      "10-lan-eno2" = {
+        matchConfig.Name = "eno2";
+        networkConfig.Bridge = "virbr0";
+      };
+      # Keep this for troubleshooting
+      "10-lan" = {
+        matchConfig.Name = "eno1";
+        enable = true;
+        networkConfig.DHCP = "yes";
+      };
+    };
+  };
+
+  environment.systemPackages = with pkgs; [
+    tio
+  ];
+
+  services.openssh = {
+    enable = true;
+    openFirewall = true;
+  };
+}

--- a/nix/machines/loghost.nix
+++ b/nix/machines/loghost.nix
@@ -1,7 +1,5 @@
 { config, lib, pkgs, ... }:
 {
-  # If not present then warning and will be set to latest release during build
-  system.stateVersion = "22.11";
 
   boot.kernelParams = [ "console=ttyS0" ];
 

--- a/nix/machines/loghost.nix
+++ b/nix/machines/loghost.nix
@@ -3,6 +3,10 @@
 
   boot.kernelParams = [ "console=ttyS0" ];
 
+  networking = {
+    firewall.allowedTCPPorts = [ 514 ];
+  };
+
   # TODO: How to handle sudo esculation
   security.sudo.wheelNeedsPassword = false;
 

--- a/nix/machines/monitor.nix
+++ b/nix/machines/monitor.nix
@@ -8,9 +8,6 @@ in
       ./_common/prometheus.nix
     ];
 
-  # If not present then warning and will be set to latest release during build
-  system.stateVersion = "23.05";
-
   boot.kernelParams = [ "console=ttyS0" "boot.shell_on_fail" ];
 
   networking.firewall.allowedTCPPorts = [ 80 443 ];

--- a/nix/machines/signs.nix
+++ b/nix/machines/signs.nix
@@ -1,8 +1,5 @@
 { config, lib, pkgs, ... }:
 {
-  # If not present then warning and will be set to latest release during build
-  system.stateVersion = "22.11";
-
   boot.kernelParams = [ "console=ttyS0" ];
 
   # TODO: How to handle sudo esculation

--- a/nix/tests/core.nix
+++ b/nix/tests/core.nix
@@ -41,16 +41,19 @@
     };
 
   };
-  testScript =
+  testScript = { nodes, ... }:
     let
       coreServerIp = "10.0.3.5";
       clientDefaultRoute = "10.0.3.1";
+      # TODO: do this for all zones
+      scaleZone = "${nodes.coremaster.services.bind.zones."scale.lan.".file}";
     in
     ''
       start_all()
       coremaster.wait_for_unit("systemd-networkd-wait-online.service")
       coremaster.wait_for_unit("ntpd.service")
       coremaster.succeed("kea-dhcp4 -t /etc/kea/dhcp4-server.conf")
+      coremaster.succeed("named-checkzone scale.lan ${scaleZone}")
       client1.wait_for_unit("systemd-networkd-wait-online.service")
       client1.wait_until_succeeds("ping -c 5 ${coreServerIp}")
       client1.wait_until_succeeds("ip route show | grep default | grep -w ${clientDefaultRoute}")

--- a/nix/tests/core.nix
+++ b/nix/tests/core.nix
@@ -4,7 +4,8 @@
   name = "core";
 
   nodes = {
-    coreServer = { lib, ... }: {
+    # node must match hostname for testScript to find it below
+    coremaster = { lib, ... }: {
       _module.args = { inherit inputs; };
       imports = [ ../machines/core/master.nix ];
 
@@ -47,9 +48,9 @@
     in
     ''
       start_all()
-      coreServer.wait_for_unit("systemd-networkd-wait-online.service")
-      coreServer.wait_for_unit("ntpd.service")
-      coreServer.succeed("kea-dhcp4 -t /etc/kea/dhcp4-server.conf")
+      coremaster.wait_for_unit("systemd-networkd-wait-online.service")
+      coremaster.wait_for_unit("ntpd.service")
+      coremaster.succeed("kea-dhcp4 -t /etc/kea/dhcp4-server.conf")
       client1.wait_for_unit("systemd-networkd-wait-online.service")
       client1.wait_until_succeeds("ping -c 5 ${coreServerIp}")
       client1.wait_until_succeeds("ip route show | grep default | grep -w ${clientDefaultRoute}")


### PR DESCRIPTION
## Description of PR

Relates to: #660 #593

Baseline configuration for hypervisor using: https://github.com/astro/microvm.nix

There will be more follow ups but as you can see theres already a lot here so Id like to get this reviewed where things currently sit.

## Previous Behavior
- Bhyve config and hosts
- no time being included in dhcp info 
- servers were using external ntp for getting time

## New Behavior
- microvm project as the hypervisor config (qemu)
- kea ntp configs for dhcpv4
- kea binding workaround after having issue with systemd service startup: https://gitlab.isc.org/isc-projects/kea/-/issues/2776
- New runNixOSTest for verifying that bind zone for `scale.lan` is valid
- update kea reservation config due to deprecated option: https://kea.readthedocs.io/en/kea-2.2.0/arm/dhcp4-srv.html#fine-tuning-dhcpv4-host-reservation
- simple alias support for servers in `inventory.py`
- servers utilize our own ntp servers
- `hardware-configuration.nix` for hypervisors leverages labels thanks for the work in: https://github.com/socallinuxexpo/scale-network/pull/668 but we can use this same configuration for both machines
- leveraging a fork of microvm for the time being due to a recursion problem that Im getting with the current upstream commits
  - The includes a fix that was upstreamed: https://github.com/astro/microvm.nix/pull/199

## Tests

Passes:
```
$ nix flake check
```

Specifically, this test with the new `scale.lan` validation for the zone:
```
$ nix build -L .#checks.x86_64-linux.core
```

Testing on the new lenovo hardware works (currently only testing on hypervisor2):
```
# nixos-rebuild switch --flake github:socallinuxexpo/scale-network/rh/issue-660-2#hypervisor2 --refresh
```
