### PR TITLE
[READY] - kea dhcpv6 config and service

### DIFF
--- a/facts/inventory.py
+++ b/facts/inventory.py
@@ -168,7 +168,7 @@ def ip6toptr(ip_address):
 def dhcp6ranges(prefix, bitmask):
     """generates start and end IPv6 addresses for DHCP ranges"""
     if bitmask == 0:
-        return ["", "", "", ""]
+        return ["", ""]
     prefsplit = re.split(r"\:\:", prefix)[0]
     return [
         prefsplit + ":d8c::1",

--- a/facts/inventory.py
+++ b/facts/inventory.py
@@ -587,6 +587,16 @@ def generatekeaconfig(servers, aps, vlans, outputdir):
                 subnet["valid-lifetime"] = 300
                 subnet["min-valid-lifetime"] = 300
                 subnet["max-valid-lifetime"] = 300
+
+            # TODO: This should probably be broken into its own config and dynamically included since each core
+            # server will only be local per building. For now we are defaulting to exInfra
+            if vlan["name"] in ["exInfra"]:
+                # This is only required for the subnets that will allocate dhcpv6 addresses without a relay
+                # in our case this is only ever the cf* vlan since thats where the VMs nic will be bridge to
+                # TODO: we should figure out a better way of dynamically allocating this config of the
+                # interface so is not hardcoded
+                # https://kea.readthedocs.io/en/kea-2.2.0/arm/dhcp6-srv.html#ipv6-subnet-selection
+                subnet["interface"] = "eth0"
             subnets6_dict.append(subnet)
 
     keav6_config["Dhcp6"]["subnet6"] = subnets6_dict

--- a/facts/inventory.py
+++ b/facts/inventory.py
@@ -544,7 +544,7 @@ def generatekeaconfig(servers, aps, vlans, outputdir):
     kea_config["Dhcp4"]["subnet4"] = subnets_dict
     kea_config["Dhcp4"]["reservations"] = reservations_dict
 
-    with open(f'{outputdir}/kea.json', 'w') as f:
+    with open(f'{outputdir}/dhcp4-server.conf', 'w') as f:
         f.write(json.dumps(kea_config, indent=2))
 
     subnets6_dict = [

--- a/facts/inventory.py
+++ b/facts/inventory.py
@@ -73,7 +73,7 @@ def genvlans(line, building):
     elems = re.split(r"\t+", line)
     rangeb, rangee = elems[2].split("-")
     for i in range(int(rangeb), int(rangee) + 1):
-        ipv6prefix = elems[3].split("/")[0].split(rangeb + "::")[0] + str(i) + "::"
+        ipv6prefix = elems[3].split("/")[0][:-1] + str(i) + "::"
         ipv6dhcp = dhcp6ranges(ipv6prefix, 64)
         ocs = elems[4].split(".")
         ocs[1] = str(int(ocs[1]) + math.floor((i - int(rangeb)) / 256))
@@ -166,13 +166,13 @@ def ip6toptr(ip_address):
 
 
 def dhcp6ranges(prefix, bitmask):
-    """generates start and end IPv6 addresses for 2x DHCP ranges"""
+    """generates start and end IPv6 addresses for DHCP ranges"""
     if bitmask == 0:
         return ["", "", "", ""]
     prefsplit = re.split(r"\:\:", prefix)[0]
     return [
-        prefsplit + ":1::1",
-        prefsplit + ":2::400",
+        prefsplit + ":d8c::1",
+        prefsplit + ":d8c::800", # 2048 addresses
     ]
 
 
@@ -401,7 +401,7 @@ def populateservers(serversfile, vlans):
 def populatedhcpnameservers(servers, vlans):
     coreservers = [x for x in servers if x['role'] == 'core']
     for i, _ in enumerate(vlans):
-        vlans[i]["ipv6dns1"] = coreservers[0]['ipv4']
+        vlans[i]["ipv6dns1"] = coreservers[0]['ipv6']
         vlans[i]["ipv4dns1"] = coreservers[0]['ipv4']
         if len(coreservers) > 1:
             vlans[i]["ipv6dns2"] = coreservers[1]['ipv6']
@@ -475,6 +475,40 @@ def generatekeaconfig(servers, aps, vlans, outputdir):
             "subnet4": []
             # DHCPv4 configuration ends with the next line
         }
+      }
+    keav6_config = {
+        "Dhcp6": {
+            # First we set up global values
+            "valid-lifetime": 4000,
+            "renew-timer": 1000,
+            "rebind-timer": 2000,
+            # Next we set up the interfaces to be used by the server.
+            "interfaces-config": {
+                "interfaces": ["*"],
+                "service-sockets-max-retries": 5,
+                "service-sockets-retry-wait-time": 5000
+            },
+            # And we specify the type of lease database
+            "lease-database": {
+                "type": "memfile",
+                "persist": True,
+                "name": "/var/lib/kea/dhcp6.leases",
+            },
+            "option-data": [
+            {
+             # This option is different from dhcpv4
+             # ref: https://kb.isc.org/docs/kea-configuration-for-small-office-or-home-use
+             "name": "dns-servers",
+             "data": ','.join([x['ipv6'] for x in servers if x['role'] == 'core'])
+            },
+            ],
+            "option-def": [],
+            "reservations-global": True,
+            "reservations-in-subnet": False,
+            "reservations": [],
+            # Finally, we list the subnets from which we will be leasing addresses.
+            "subnet6": []
+        }
     }
 
     reservations_dict = [
@@ -509,8 +543,31 @@ def generatekeaconfig(servers, aps, vlans, outputdir):
 
     kea_config["Dhcp4"]["subnet4"] = subnets_dict
     kea_config["Dhcp4"]["reservations"] = reservations_dict
+
     with open(f'{outputdir}/kea.json', 'w') as f:
         f.write(json.dumps(kea_config, indent=2))
+
+    subnets6_dict = [
+        {
+            "subnet": vlan["ipv6prefix"] + "/" + str(vlan["ipv6bitmask"]),
+            # generating uniq id (prefix with dots) for each subnet block to ensure autoids dont effect reordering
+            # called out in: https://kea.readthedocs.io/en/latest/arm/dhcp4-srv.html#ipv4-subnet-identifier
+            # subnet ids must be greater than zero and less than 4294967295
+            #
+            # for ipv6 well take the last 8 hex digits to make sure the id is small enough but uniq
+            "id": int(vlan["ipv6prefix"].replace(':', '')[-8:], 16),
+            "user-context": { "vlan": vlan["name"] },
+            "pools": [{"pool": vlan["ipv6dhcpStart"] + " - " + vlan["ipv6dhcpEnd"]}],
+        }
+        for vlan in vlans
+        if vlan["ipv6bitmask"]
+        != "0"  # Make sure to skip vlans that have no ranges
+    ]
+
+    keav6_config["Dhcp6"]["subnet6"] = subnets6_dict
+
+    with open(f'{outputdir}/dhcp6-server.conf', 'w') as f:
+        f.write(json.dumps(keav6_config, indent=2))
 
 
 def generatepromconfig(servers, aps, vlans, outputdir):

--- a/facts/inventory.py
+++ b/facts/inventory.py
@@ -420,9 +420,10 @@ def generatekeaconfig(servers, aps, vlans, outputdir):
         # DHCPv4 configuration starts on the next line
         "Dhcp4": {
             # First we set up global values
-            "valid-lifetime": 4000,
-            "renew-timer": 1000,
-            "rebind-timer": 2000,
+            # Set lifetime of lease to always be the same
+            "valid-lifetime": 1440,
+            "min-valid-lifetime": 1440,
+            "max-valid-lifetime": 1440,
             # Next we set up the interfaces to be used by the server.
             "interfaces-config": {
                 "interfaces": ["*"],
@@ -487,9 +488,9 @@ def generatekeaconfig(servers, aps, vlans, outputdir):
     keav6_config = {
         "Dhcp6": {
             # First we set up global values
-            "valid-lifetime": 4000,
-            "renew-timer": 1000,
-            "rebind-timer": 2000,
+            "valid-lifetime": 1440,
+            "min-valid-lifetime": 1440,
+            "max-valid-lifetime": 1440,
             # Next we set up the interfaces to be used by the server.
             "interfaces-config": {
                 "interfaces": ["*"],

--- a/facts/inventory.py
+++ b/facts/inventory.py
@@ -170,6 +170,14 @@ def dhcp6ranges(prefix, bitmask):
     if bitmask == 0:
         return ["", ""]
     prefsplit = re.split(r"\:\:", prefix)[0]
+    # TODO: Infer this going forward
+    # Conditional for the exVmVendor vlan, matching the ipv4 /20
+    if prefix == "2001:470:f026:112::":
+        return [
+            prefsplit + ":d8c::1",
+            prefsplit + ":d8c::1000", # 4096 addresses
+        ]
+
     return [
         prefsplit + ":d8c::1",
         prefsplit + ":d8c::800", # 2048 addresses

--- a/facts/test_inventory.py
+++ b/facts/test_inventory.py
@@ -61,7 +61,7 @@ def test_getfilelinesbldg():
             "//200-498 are dynamically generated from Booth information file as Vendor VLANs.\n",
             "//The difference is that these VLAN interfaces will also be built with firewall filters to prevent access to other\n",
             "//VLANs (vendor_vlan <-> internet only)\n",
-            "VVRNG\tvendor_vlan_\t\t200-201\t2001:470:f325:200::/54\t10.2.0.0/15\tDynamically allocated and named booth VLANs\n",
+            "VVRNG\tvendor_vlan_\t\t200-201\t2001:470:f325::/48\t10.2.0.0/15\tDynamically allocated and named booth VLANs\n",
             "//499 is reserved for the Vendor backbone VLAN between the Expo switches and the routers.\n",
         ]]
     ]
@@ -75,14 +75,14 @@ def test_dhcp6ranges():
     '''test cases for the dhcp6ranges() function'''
     cases = [
         [["2001:470:f325:504::", 64], [
-            "2001:470:f325:504:1::1",
-            "2001:470:f325:504:2::400",
+            "2001:470:f325:504:d8c::1",
+            "2001:470:f325:504:d8c::800",
         ]],
         [["2001:470:f325:111::", 64], [
-            "2001:470:f325:111:1::1",
-            "2001:470:f325:111:2::400"
+            "2001:470:f325:111:d8c::1",
+            "2001:470:f325:111:d8c::800"
         ]],
-        [["::", 0], ["", "", "", ""]]
+        [["::", 0], ["", ""]]
     ]
     for case, ranges in cases:
         prefix, bitmask = case
@@ -122,8 +122,8 @@ def test_makevlan():
             "ipv4bitmask": "24",
             "building": "Conference",
             "description": "Capture the Flag",
-            "ipv6dhcpStart": "2001:470:f325:504:1::1",
-            "ipv6dhcpEnd": "2001:470:f325:504:2::400",
+            "ipv6dhcpStart": "2001:470:f325:504:d8c::1",
+            "ipv6dhcpEnd": "2001:470:f325:504:d8c::800",
             "ipv4dhcpStart": "10.128.4.80",
             "ipv4dhcpEnd": "10.128.4.254",
             "ipv4router": "10.128.4.1",
@@ -160,7 +160,7 @@ def test_bitmasktonetmask():
 def test_genvlans():
     '''test cases for the genvlans() function'''
     cases = [
-        ["VVRNG\ttest_vlan_\t\t200-201\t2001:470:f325:200::/54\t10.2.0.0/15\tdynamic vlan", [
+        ["VVRNG\ttest_vlan_\t\t200-201\t2001:470:f325::/48\t10.2.0.0/15\tdynamic vlan", [
             {
                 "name": "test_vlan_200",
                 "id": 200,
@@ -170,8 +170,8 @@ def test_genvlans():
                 "ipv4bitmask": 24,
                 "building": "Expo",
                 "description": "Dyanmic vlan 200",
-                "ipv6dhcpStart": "2001:470:f325:200:1::1",
-                "ipv6dhcpEnd": "2001:470:f325:200:2::400",
+                "ipv6dhcpStart": "2001:470:f325:200:d8c::1",
+                "ipv6dhcpEnd": "2001:470:f325:200:d8c::800",
                 "ipv4dhcpStart": "10.2.0.80",
                 "ipv4dhcpEnd": "10.2.0.254",
                 "ipv4router": "10.2.0.1",
@@ -190,8 +190,8 @@ def test_genvlans():
                 "ipv4bitmask": 24,
                 "building": "Expo",
                 "description": "Dyanmic vlan 201",
-                "ipv6dhcpStart": "2001:470:f325:201:1::1",
-                "ipv6dhcpEnd": "2001:470:f325:201:2::400",
+                "ipv6dhcpStart": "2001:470:f325:201:d8c::1",
+                "ipv6dhcpEnd": "2001:470:f325:201:d8c::800",
                 "ipv4dhcpStart": "10.2.1.80",
                 "ipv4dhcpEnd": "10.2.1.254",
                 "ipv4router": "10.2.1.1",
@@ -270,8 +270,8 @@ def test_populatevlans():
                 "ipv4bitmask": "21",
                 "building": "Expo",
                 "description": "2.4G Wireless Network in Expo Center",
-                "ipv6dhcpStart": "2001:470:f325:100:1::1",
-                "ipv6dhcpEnd": "2001:470:f325:100:2::400",
+                "ipv6dhcpStart": "2001:470:f325:100:d8c::1",
+                "ipv6dhcpEnd": "2001:470:f325:100:d8c::800",
                 "ipv4dhcpStart": "10.0.128.80",
                 "ipv4dhcpEnd": "10.0.135.254",
                 "ipv4router": "10.0.128.1",
@@ -290,8 +290,8 @@ def test_populatevlans():
                 "ipv4bitmask": 24,
                 "building": "Expo",
                 "description": "Dyanmic vlan 200",
-                "ipv6dhcpStart": "2001:470:f325:200:1::1",
-                "ipv6dhcpEnd": "2001:470:f325:200:2::400",
+                "ipv6dhcpStart": "2001:470:f325:200:d8c::1",
+                "ipv6dhcpEnd": "2001:470:f325:200:d8c::800",
                 "ipv4dhcpStart": "10.2.0.80",
                 "ipv4dhcpEnd": "10.2.0.254",
                 "ipv4router": "10.2.0.1",
@@ -310,8 +310,8 @@ def test_populatevlans():
                 "ipv4bitmask": 24,
                 "building": "Expo",
                 "description": "Dyanmic vlan 201",
-                "ipv6dhcpStart": "2001:470:f325:201:1::1",
-                "ipv6dhcpEnd": "2001:470:f325:201:2::400",
+                "ipv6dhcpStart": "2001:470:f325:201:d8c::1",
+                "ipv6dhcpEnd": "2001:470:f325:201:d8c::800",
                 "ipv4dhcpStart": "10.2.1.80",
                 "ipv4dhcpEnd": "10.2.1.254",
                 "ipv4router": "10.2.1.1",
@@ -330,8 +330,8 @@ def test_populatevlans():
                 "ipv4bitmask": "21",
                 "building": "Conference",
                 "description": "2.4G Wireless Network in Conference Center",
-                "ipv6dhcpStart": "2001:470:f325:500:1::1",
-                "ipv6dhcpEnd": "2001:470:f325:500:2::400",
+                "ipv6dhcpStart": "2001:470:f325:500:d8c::1",
+                "ipv6dhcpEnd": "2001:470:f325:500:d8c::800",
                 "ipv4dhcpStart": "10.128.128.80",
                 "ipv4dhcpEnd": "10.128.135.254",
                 "ipv4router": "10.128.128.1",
@@ -350,8 +350,8 @@ def test_populatevlans():
                 "ipv4bitmask": "0",
                 "building": "Conference",
                 "description": "Signs network (Conference Center) IPv6 Only",
-                "ipv6dhcpStart": "2001:470:f325:507:1::1",
-                "ipv6dhcpEnd": "2001:470:f325:507:2::400",
+                "ipv6dhcpStart": "2001:470:f325:507:d8c::1",
+                "ipv6dhcpEnd": "2001:470:f325:507:d8c::800",
                 "ipv4dhcpStart": "",
                 "ipv4dhcpEnd": "",
                 "ipv4router": "",

--- a/facts/testdata/dir.d/Expo
+++ b/facts/testdata/dir.d/Expo
@@ -6,5 +6,5 @@ VLAN	exSCALE-SLOW		100	2001:470:f325:100::/64	10.0.128.0/21	2.4G Wireless Networ
 //200-498 are dynamically generated from Booth information file as Vendor VLANs.
 //The difference is that these VLAN interfaces will also be built with firewall filters to prevent access to other
 //VLANs (vendor_vlan <-> internet only)
-VVRNG	vendor_vlan_		200-201	2001:470:f325:200::/54	10.2.0.0/15	Dynamically allocated and named booth VLANs
+VVRNG	vendor_vlan_		200-201	2001:470:f325::/48	10.2.0.0/15	Dynamically allocated and named booth VLANs
 //499 is reserved for the Vendor backbone VLAN between the Expo switches and the routers.

--- a/nix/machines/_common/base.nix
+++ b/nix/machines/_common/base.nix
@@ -42,4 +42,8 @@
 
   # Purge nano from being the default
   environment.variables = { EDITOR = "vim"; };
+
+  # Force noXlibs per recommendation in microVMs
+  # ref: https://github.com/astro/microvm.nix/issues/167
+  environment.noXlibs = false;
 }

--- a/nix/machines/core/common.nix
+++ b/nix/machines/core/common.nix
@@ -46,7 +46,7 @@
     kea = {
       dhcp4 = {
         enable = true;
-        configFile = "${inputs.self.packages.${pkgs.system}.scaleInventory}/config/kea.json";
+        configFile = "${inputs.self.packages.${pkgs.system}.scaleInventory}/config/dhcp4-server.conf";
       };
       dhcp6 = {
         enable = true;

--- a/nix/machines/core/common.nix
+++ b/nix/machines/core/common.nix
@@ -48,6 +48,10 @@
         enable = true;
         configFile = "${inputs.self.packages.${pkgs.system}.scaleInventory}/config/kea.json";
       };
+      dhcp6 = {
+        enable = true;
+        configFile = "${inputs.self.packages.${pkgs.system}.scaleInventory}/config/dhcp6-server.conf";
+      };
     };
     ntp = {
       enable = true;

--- a/nix/machines/core/common.nix
+++ b/nix/machines/core/common.nix
@@ -10,7 +10,7 @@
     useDHCP = false;
     useNetworkd = true;
     firewall.allowedTCPPorts = [ 53 67 68 ];
-    firewall.allowedUDPPorts = [ 53 67 68 123 ];
+    firewall.allowedUDPPorts = [ 53 67 68 123 547 ];
   };
 
   security.sudo.wheelNeedsPassword = false;

--- a/nix/tests/core.nix
+++ b/nix/tests/core.nix
@@ -1,9 +1,77 @@
-{ inputs, ... }:
+{ inputs, pkgs, ... }:
+let
+  chomp = "103";
+  prefix = "2001:470:f026:${chomp}";
+  routerAddr = {
+    ipv6 = "${prefix}::1";
+    ipv4 = "10.0.3.1";
+  };
+  coremasterAddr = {
+    ipv6 = "${prefix}::5";
+    ipv4 = "10.0.3.5";
+  };
 
+  dhcp6TestConfig = pkgs.runCommand "replace"
+    {
+      buildInputs = [ pkgs.gnused ];
+    }
+    ''
+      mkdir $out
+      sed 's/eth0/eth1/g' ${inputs.self.packages.${pkgs.system}.scaleInventory}/config/dhcp6-server.conf > $out/dhcp6-server.conf
+    '';
+in
 {
   name = "core";
 
   nodes = {
+    # temporary router since we do not have the junipers for ipv6 router advertisement
+    router = { ... }: {
+      virtualisation.vlans = [ 1 ];
+      virtualisation.graphics = false;
+      systemd.services.systemd-networkd.environment.SYSTEMD_LOG_LEVEL = "debug";
+      # since this is a router we need to set enable ipv6 forwarding or radvd will complain
+      boot.kernel.sysctl."net.ipv6.conf.all.forwarding" = true;
+      networking = {
+        useDHCP = false;
+        useNetworkd = true;
+      };
+      systemd.network = {
+        enable = true;
+        networks = {
+          "01-eth1" = {
+            name = "eth1";
+            enable = true;
+            networkConfig = {
+              DHCP = "no";
+              IPv6AcceptRA = false;
+              IPv6PrivacyExtensions = false;
+            };
+            address = [ "${routerAddr.ipv6}/64" "${routerAddr.ipv4}/24" ];
+            ipv6AcceptRAConfig = {
+              UseAutonomousPrefix = true;
+              #DHCPv6Client = "always";
+              #UseDNS = true;
+            };
+          };
+        };
+      };
+      services.radvd.enable = true;
+      services.radvd.config =
+        ''
+          interface eth1 {
+            AdvSendAdvert on;
+            # M Flag
+            AdvManagedFlag on;
+            # O Flag
+            AdvOtherConfigFlag on;
+            # ULA prefix (RFC 4193).
+            prefix ${prefix}::/64 {
+              AdvOnLink on;
+            };
+          };
+        '';
+    };
+
     # node must match hostname for testScript to find it below
     coremaster = { lib, ... }: {
       _module.args = { inherit inputs; };
@@ -12,13 +80,15 @@
       virtualisation.vlans = [ 1 ];
       virtualisation.graphics = false;
       systemd.services.systemd-networkd.environment.SYSTEMD_LOG_LEVEL = "debug";
+      # substitute this dhcpv6 config since we need to respond on eth1 for these tests
+      services.kea.dhcp6.configFile = lib.mkForce "${dhcp6TestConfig}/dhcp6-server.conf";
       systemd.network = {
         networks = lib.mkForce {
           "01-eth1" = {
             name = "eth1";
             enable = true;
-            address = [ "10.0.3.5/24" ];
-            gateway = [ "10.0.3.1" ];
+            address = [ "${coremasterAddr.ipv6}/64" "${coremasterAddr.ipv4}/24" ];
+            gateway = [ "${routerAddr.ipv4}" ];
           };
         };
       };
@@ -31,7 +101,25 @@
         useNetworkd = true;
         useDHCP = false;
         firewall.enable = false;
-        interfaces.eth1.useDHCP = true;
+      };
+      systemd.network = {
+        enable = true;
+        networks = {
+          "01-eth1" = {
+            name = "eth1";
+            enable = true;
+            networkConfig = {
+              DHCP = "yes";
+              IPv6AcceptRA = true;
+              IPv6PrivacyExtensions = false;
+            };
+            ipv6AcceptRAConfig = {
+              UseAutonomousPrefix = false;
+              #DHCPv6Client = "always";
+              #UseDNS = true;
+            };
+          };
+        };
       };
       environment = {
         systemPackages = with pkgs; [
@@ -39,28 +127,33 @@
         ];
       };
     };
-
   };
+
+
   testScript = { nodes, ... }:
     let
-      coreServerIp = "10.0.3.5";
-      clientDefaultRoute = "10.0.3.1";
       # TODO: do this for all zones
       scaleZone = "${nodes.coremaster.services.bind.zones."scale.lan.".file}";
     in
     ''
       start_all()
+      router.wait_for_unit("systemd-networkd-wait-online.service")
+      router.wait_for_unit("radvd.service")
       coremaster.wait_for_unit("systemd-networkd-wait-online.service")
       coremaster.wait_for_unit("ntpd.service")
       coremaster.succeed("kea-dhcp4 -t /etc/kea/dhcp4-server.conf")
+      coremaster.succeed("kea-dhcp6 -t /etc/kea/dhcp6-server.conf")
       coremaster.succeed("named-checkzone scale.lan ${scaleZone}")
       client1.wait_for_unit("systemd-networkd-wait-online.service")
-      client1.wait_until_succeeds("ping -c 5 ${coreServerIp}")
-      client1.wait_until_succeeds("ip route show | grep default | grep -w ${clientDefaultRoute}")
+      client1.wait_until_succeeds("ping -c 5 ${coremasterAddr.ipv4}")
+      #client1.wait_until_succeeds("ping -c 5 -6 ${coremasterAddr.ipv6}")
+      client1.wait_until_succeeds("ip route show | grep default | grep -w ${routerAddr.ipv4}")
+      # ensure that we got the correct prefix and suffix on dhcpv6
+      #client1.wait_until_succeeds("ip addr show dev eth1 | grep inet6 | grep ${chomp}:d8c")
       # Have to wrap drill since retcode isnt necessarily 1 on query failure
       client1.wait_until_succeeds("test ! -z \"$(drill -Q -z scale.lan SOA)\"")
       client1.wait_until_succeeds("test ! -z \"$(drill -Q -z coreexpo.scale.lan A)\"")
       client1.wait_until_succeeds("test ! -z \"$(drill -Q -z coreexpo.scale.lan AAAA)\"")
-      client1.wait_until_succeeds("test ! -z \"$(drill -Q -z -x ${coreServerIp})\"")
+      client1.wait_until_succeeds("test ! -z \"$(drill -Q -z -x ${coremasterAddr.ipv4})\"")
     '';
 }

--- a/nix/tests/flake-module.nix
+++ b/nix/tests/flake-module.nix
@@ -1,8 +1,8 @@
-{ withSystem, inputs, ... }:
+{ withSystem, inputs, pkgs, ... }:
 
 {
   flake.checks.x86_64-linux = withSystem "x86_64-linux" ({ pkgs, ... }: {
-    core = pkgs.testers.runNixOSTest (import ./core.nix { inherit inputs; });
+    core = pkgs.testers.runNixOSTest (import ./core.nix { inherit inputs pkgs; });
     loghost = pkgs.testers.runNixOSTest ./loghost.nix;
   });
 


### PR DESCRIPTION
## Description of PR

Fixes: #596
Depends on: #670 (Will have to rebase after)

Kea DHCPv6 using all of the existing vlans from switch configurations

A lot of this was made very easy by previous work (thanks @kylerisse ): https://github.com/socallinuxexpo/scale-network/pull/252 ,inventory.py ipv6 support, and the retired isc-dhcpv6. This was all very useful as reference for this implementation.

## Previous Behavior
- kea didnt have dhcpv6
- lease time was set to 4000 sec for dhcpv4

## New Behavior
- kea dhcpv6 configuration ([dhcp6-server.conf.txt](https://github.com/socallinuxexpo/scale-network/files/14326060/dhcp6-server.conf.txt) (ignore the .txt apartly github doesnt let you upload a .conf :laughing:)
- kea dhcpv6 service enabled on `core`
- dhcpv6 specific runNixOSTest for core test
- kea dhcpv4/v6 lease time for mgmt vlan is now 5 min
- kea dhcpv4/v6 lease time for all other subnets is 24min
- updates to python facts tests for new dhcpv6 configurations

## Tests
- Core sanity check in runNixOSTests runs well:

```
$ build -L .#checks.x86_64-linux.core
```
