### PR TITLE
[READY] Od pre21x 05

### DIFF
--- a/nix/dev/flake-module.nix
+++ b/nix/dev/flake-module.nix
@@ -31,7 +31,7 @@
         stdenv
         inputs.self.packages.${pkgs.system}.serverspec
       ];
-      network_sub = [ pkgs.perl ];
+      network_sub = with pkgs; [ perl ghostscript ];
     in
     {
       devShells.default = pkgs.mkShell {

--- a/switch-configuration/Makefile
+++ b/switch-configuration/Makefile
@@ -32,7 +32,7 @@ build-switch-configs: .build-switch-configs
 
 # Make the switch-maps-bundle which is a collection of all the switch port maps
 # this is a for printing for the cable team
-switch-maps-bundle: config/switch-maps/bundle.ps config/switch-maps/refs.ps config/switch-maps/stickers.ps
+switch-maps-bundle: config/switch-maps/bundle.ps config/switch-maps/refs.ps config/switch-maps/stickers.ps config/switch-maps/stickers.pdf
 
 config/switch-maps/bundle.ps: .build-switch-configs .build-switch-configs
 	cd config && \
@@ -45,6 +45,10 @@ config/switch-maps/refs.ps: .build-switch-configs .build-switch-configs
 config/switch-maps/stickers.ps: .build-switch-configs .build-switch-configs
 	cd config && \
 		perl scripts/generate_ps_stickers.pl > switch-maps/stickers.ps
+
+config/switch-maps/stickers.pdf: config/switch-maps/stickers.ps
+	cd config && \
+		gs -sDEVICE=pdfwrite -sOutputFile=switch-maps/stickers.pdf <switch-maps/stickers.ps > /dev/null
 
 clean:
 	rm -f .build-switch-configs .lint .secrets

--- a/switch-configuration/Makefile
+++ b/switch-configuration/Makefile
@@ -7,7 +7,7 @@ ifndef PERL
   $(error "perl is not available please install it")
 endif
 
-all: switch-maps-bundle
+all: switch-maps-outputs
 
 lint:	.lint
 
@@ -32,15 +32,21 @@ build-switch-configs: .build-switch-configs
 
 # Make the switch-maps-bundle which is a collection of all the switch port maps
 # this is a for printing for the cable team
-switch-maps-bundle: config/switch-maps/bundle.ps config/switch-maps/refs.ps config/switch-maps/stickers.ps config/switch-maps/stickers.pdf
+switch-maps-outputs: config/switch-maps/refs.ps config/switch-maps/refs.pdf config/switch-maps/stickers.ps config/switch-maps/stickers.pdf
 
-config/switch-maps/bundle.ps: .build-switch-configs .build-switch-configs
-	cd config && \
-		perl scripts/generate_ps_maps.pl > switch-maps/bundle.ps
+# Bundle is technically obsolete at this point and doesn't work properly any more
+#config/switch-maps/bundle.ps: .build-switch-configs .build-switch-configs
+#	cd config && \
+#		perl scripts/generate_ps_maps.pl > switch-maps/bundle.ps
 
 config/switch-maps/refs.ps: .build-switch-configs .build-switch-configs
 	cd config && \
 		perl scripts/generate_ps_refs.pl > switch-maps/refs.ps
+
+
+config/switch-maps/refs.pdf: config/switch-maps/refs.ps
+	cd config && \
+		gs -sDEVICE=pdfwrite -sOutputFile=switch-maps/refs.pdf <switch-maps/refs.ps > /dev/null
 
 config/switch-maps/stickers.ps: .build-switch-configs .build-switch-configs
 	cd config && \

--- a/switch-configuration/README.md
+++ b/switch-configuration/README.md
@@ -135,9 +135,9 @@ Configuration elements include:
 RSRVD	<number_of_ports>
 VLAN	<vlan_name> <number_of_ports>
 VVLAN	<number_of_ports>
-TRUNK	<port> <vlan_name>[,<vlan_name>...]
+TRUNK	<port> <vlan_name>[,<vlan_name>...] <trunktype>
 JUNOS	<junos_version>
-FIBER   <port> <vlan_name>[,<vlan_name>...]
+FIBER   <port> <vlan_name>[,<vlan_name>...] <trunktype>
 ```
 
 ## config/routers/{backups,to_push}/<name>

--- a/switch-configuration/config/scripts/generate_ps_maps.pl
+++ b/switch-configuration/config/scripts/generate_ps_maps.pl
@@ -4,6 +4,8 @@
 # them 5 to a page.
 #
 # Currently output is to STDOUT. Might convert to sending to a file later.
+#
+# Obsolete and needs proper page sizing changes to display properly -- Precursor to stickers
 
 my $PS_Preamble = <<EOF;
 %!PS-Adobe

--- a/switch-configuration/config/scripts/generate_ps_refs.pl
+++ b/switch-configuration/config/scripts/generate_ps_refs.pl
@@ -34,6 +34,8 @@ my $map_pos = 0;		# Current position on page (0-3)
 
 my @maps = <switch-maps/*.eps>;
 
+@maps=reverse(@maps);
+
 show_preamble();
 
 foreach(@maps)

--- a/switch-configuration/config/scripts/generate_ps_refs.pl
+++ b/switch-configuration/config/scripts/generate_ps_refs.pl
@@ -1,9 +1,11 @@
 #!/usr/bin/env perl
 #
 # Collect EPS files in switch-maps directory and generate a single PS file that will print
-# them 5 to a page.
+# them 9 to a page.
 #
 # Currently output is to STDOUT. Might convert to sending to a file later.
+#
+# Intended for handheld reference, prints on US/Letter size paper
 
 my $PS_Preamble = <<EOF;
 %!PS-Adobe

--- a/switch-configuration/config/scripts/generate_ps_stickers.pl
+++ b/switch-configuration/config/scripts/generate_ps_stickers.pl
@@ -69,7 +69,7 @@ my $map_pos = 0;		# Current position on page (0-3)
 
 show_preamble();
 
-foreach(sort(@maps))
+foreach(reverse(sort(@maps)))
 {
   setorigin($map_pos) if ($map_number);	# Don't move the origin for the first map.
   embed($_);

--- a/switch-configuration/config/scripts/switch_template.pm
+++ b/switch-configuration/config/scripts/switch_template.pm
@@ -57,6 +57,28 @@ our @EXPORT = qw(
 );
 
 
+my %colormap = (
+	"AP" => {
+		'red'	=> 0,
+		'green'	=> 0.5,
+		'blue'  => 0.5,
+		},
+	"Uplink" => {
+		'red'	=> 0,
+		'green'	=> 0.5,
+		'blue'	=> 0,
+		},
+	"Downlink" => {
+		'red'	=> 0.5,
+		'green'	=> 0.5,
+		'blue'	=> 0,
+		},
+	"Unknown" => {
+		'red'	=> 0,
+		'green'	=> 0,
+		'blue'	=> 0,
+		},
+);
 sub BEGIN
 {
   return;
@@ -591,6 +613,13 @@ EOF
       ##FIXME## Build interface ranges
       my $iface = shift(@tokens);
       my $vlans = shift(@tokens);
+      my $poe = shift(@tokens);
+      my $trunktype = shift(@tokens);
+      if ($trunktype ne "AP" && $trunktype ne "Uplink" && $trunktype ne "Downlink")
+      {
+	      warn("TRUNK $_ invalid trunktype: $trunktype -- setting to Unknown\n");
+	      $trunktype="Unknown";
+      }
       debug(9, "\t$cmd\t$iface ($vlans)\n");
       $vlans =~ s/\s*,\s*/ /g;
       my $portnum = $iface;
@@ -623,9 +652,9 @@ EOF
       if ($cmd eq "TRUNK")
       {
         # Handle non-fiber trunk port
-        debug(9, "$cmd output standard box for port $portnum ($iface)\n");
+        debug(9, "$cmd output standard box for port $portnum ($iface) ($trunktype) -- (".${colormap{$trunktype}}{'red'}.",".${colormap{$trunktype}}{'green'}.",".${colormap{$trunktype}}{'blue'}.")\n");
         $portmap_PS .= <<EOF;
-(TRUNK) 1 0.75 0.75 $portnum DrawPort
+($trunktype) $colormap{$trunktype}{'red'} $colormap{$trunktype}{'green'} $colormap{$trunktype}{'blue'} $portnum DrawPort
 EOF
       }
 

--- a/switch-configuration/config/scripts/switch_template.pm
+++ b/switch-configuration/config/scripts/switch_template.pm
@@ -60,21 +60,26 @@ our @EXPORT = qw(
 my %colormap = (
 	"AP" => {
 		'red'	=> 0,
-		'green'	=> 0.5,
-		'blue'  => 0.5,
+		'green'	=> 0.75,
+		'blue'  => 0.75,
 		},
 	"Uplink" => {
 		'red'	=> 0,
-		'green'	=> 0.5,
+		'green'	=> 0.75,
 		'blue'	=> 0,
 		},
 	"Downlink" => {
-		'red'	=> 0.5,
-		'green'	=> 0.5,
+		'red'	=> 0.75,
+		'green'	=> 0.75,
 		'blue'	=> 0,
 		},
+	"MassFlash" => {
+		'red'	=> 0.75,
+		'green'	=> 0,
+		'blue'	=> 0.75,
+		},
 	"Unknown" => {
-		'red'	=> 0,
+		'red'	=> 1,
 		'green'	=> 0,
 		'blue'	=> 0,
 		},
@@ -615,9 +620,10 @@ EOF
       my $vlans = shift(@tokens);
       my $poe = shift(@tokens);
       my $trunktype = shift(@tokens);
-      if ($trunktype ne "AP" && $trunktype ne "Uplink" && $trunktype ne "Downlink")
+      $trunktype =~ s/^\s*(\S+)\s*/$1/;
+      if (!exists($colormap{$trunktype}))
       {
-	      warn("TRUNK $_ invalid trunktype: $trunktype -- setting to Unknown\n");
+	      warn("TRUNK $_ invalid trunktype: \"$trunktype\" -- setting to Unknown\n");
 	      $trunktype="Unknown";
       }
       debug(9, "\t$cmd\t$iface ($vlans)\n");

--- a/switch-configuration/config/types/Booth
+++ b/switch-configuration/config/types/Booth
@@ -1,19 +1,19 @@
 // Expo Booth Area switch Template
 TRUNK	ge-0/0/0	exSCALE-SLOW,exSCALE-FAST,exSpeaker,exInfra,exAVLAN, \
-				exSigns,vendor_backbone			-	// Uplink
+				exSigns,vendor_backbone			-	Uplink
 TRUNK	ge-0/0/1	exSCALE-SLOW,exSCALE-FAST,exSpeaker,exInfra,exAVLAN, \
-				exSigns,vendor_backbone			-	// Downlink
+				exSigns,vendor_backbone			-	Downlink
 RSRVD	6
-TRUNK	ge-0/0/8	exInfra,exSCALE-SLOW,exSCALE-FAST		POE	// AP
-TRUNK	ge-0/0/9	exInfra,exSCALE-SLOW,exSCALE-FAST		POE	// AP
-TRUNK	ge-0/0/10	exInfra,exSCALE-SLOW,exSCALE-FAST		POE	// AP
-TRUNK	ge-0/0/11	exInfra,exSCALE-SLOW,exSCALE-FAST		POE	// AP
-TRUNK	ge-0/0/12	exInfra,exSCALE-SLOW,exSCALE-FAST		POE	// AP
-TRUNK	ge-0/0/13	exInfra,exSCALE-SLOW,exSCALE-FAST		POE	// AP
-TRUNK	ge-0/0/14	exInfra,exSCALE-SLOW,exSCALE-FAST		POE	// AP
-TRUNK	ge-0/0/15	exInfra,exSCALE-SLOW,exSCALE-FAST		POE	// AP
-TRUNK	ge-0/0/16	exInfra,exSCALE-SLOW,exSCALE-FAST		POE	// AP
-TRUNK	ge-0/0/17	exInfra,exSCALE-SLOW,exSCALE-FAST		POE	// AP
+TRUNK	ge-0/0/8	exInfra,exSCALE-SLOW,exSCALE-FAST		POE	AP
+TRUNK	ge-0/0/9	exInfra,exSCALE-SLOW,exSCALE-FAST		POE	AP
+TRUNK	ge-0/0/10	exInfra,exSCALE-SLOW,exSCALE-FAST		POE	AP
+TRUNK	ge-0/0/11	exInfra,exSCALE-SLOW,exSCALE-FAST		POE	AP
+TRUNK	ge-0/0/12	exInfra,exSCALE-SLOW,exSCALE-FAST		POE	AP
+TRUNK	ge-0/0/13	exInfra,exSCALE-SLOW,exSCALE-FAST		POE	AP
+TRUNK	ge-0/0/14	exInfra,exSCALE-SLOW,exSCALE-FAST		POE	AP
+TRUNK	ge-0/0/15	exInfra,exSCALE-SLOW,exSCALE-FAST		POE	AP
+TRUNK	ge-0/0/16	exInfra,exSCALE-SLOW,exSCALE-FAST		POE	AP
+TRUNK	ge-0/0/17	exInfra,exSCALE-SLOW,exSCALE-FAST		POE	AP
 RSRVD	6
 VVLAN	16			// Dynamically assigned Vendor VLAN ports
 RSRVD	8

--- a/switch-configuration/config/types/Booth
+++ b/switch-configuration/config/types/Booth
@@ -1,8 +1,8 @@
 // Expo Booth Area switch Template
 TRUNK	ge-0/0/0	exSCALE-SLOW,exSCALE-FAST,exSpeaker,exInfra,exAVLAN, \
-				exSigns,vendor_backbone			-
+				exSigns,vendor_backbone			-	// Uplink
 TRUNK	ge-0/0/1	exSCALE-SLOW,exSCALE-FAST,exSpeaker,exInfra,exAVLAN, \
-				exSigns,vendor_backbone			-
+				exSigns,vendor_backbone			-	// Downlink
 RSRVD	6
 TRUNK	ge-0/0/8	exInfra,exSCALE-SLOW,exSCALE-FAST		POE	// AP
 TRUNK	ge-0/0/9	exInfra,exSCALE-SLOW,exSCALE-FAST		POE	// AP

--- a/switch-configuration/config/types/Catwalk
+++ b/switch-configuration/config/types/Catwalk
@@ -1,94 +1,94 @@
 // Expo Center Catwalk Switch Configuration
 TRUNK	ge-0/0/0	exSCALE-SLOW,exSCALE-FAST,exSpeaker,exInfra, \
 			exAVLAN,vendor_backbone \
-			exSigns,HAM_BRIDGE 	-	// Link to EX Router
+			exSigns,HAM_BRIDGE 	-	// Uplink
 TRUNK	ge-0/0/1	exSCALE-SLOW,exSCALE-FAST,exSpeaker,exInfra, \
 			exAVLAN,vendor_backbone \
-			exSigns,HAM_BRIDGE 	-	// Downlink to BallroomF
+			exSigns,HAM_BRIDGE 	-	// Downlink
 TRUNK	ge-0/0/2	exSCALE-SLOW,exSCALE-FAST,exSpeaker,exInfra, \
 			exAVLAN,vendor_backbone \
-			exSigns,HAM_BRIDGE 	-	// Downlink to BallroomG
+			exSigns,HAM_BRIDGE 	-	// Downlink
 TRUNK	ge-0/0/3	exSCALE-SLOW,exSCALE-FAST,exSpeaker,exInfra, \
 			exAVLAN,vendor_backbone \
-			exSigns,HAM_BRIDGE 	-	// Downlink to BallroomH
+			exSigns,HAM_BRIDGE 	-	// Downlink
 TRUNK	ge-0/0/4	exSCALE-SLOW,exSCALE-FAST,exSpeaker,exInfra, \
 			exAVLAN,vendor_backbone \
-			exSigns,HAM_BRIDGE 	-	// 
+			exSigns,HAM_BRIDGE 	-	// Downlink
 TRUNK	ge-0/0/5	exSCALE-SLOW,exSCALE-FAST,exSpeaker,exInfra, \
 			exAVLAN,vendor_backbone \
-			exSigns,HAM_BRIDGE 	-	// 
+			exSigns,HAM_BRIDGE 	-	// Downlink
 TRUNK	ge-0/0/6	exSCALE-SLOW,exSCALE-FAST,exSpeaker,exInfra, \
 			exAVLAN,vendor_backbone \
-			exSigns,HAM_BRIDGE 	-	// 
+			exSigns,HAM_BRIDGE 	-	// Downlink
 TRUNK	ge-0/0/7	exSCALE-SLOW,exSCALE-FAST,exSpeaker,exInfra, \
 			exAVLAN,vendor_backbone \
-			exSigns,HAM_BRIDGE 	-	// 
+			exSigns,HAM_BRIDGE 	-	// Downlink
 TRUNK	ge-0/0/8	exSCALE-SLOW,exSCALE-FAST,exSpeaker,exInfra, \
 			exAVLAN,vendor_backbone \
-			exSigns,HAM_BRIDGE 	-	// 
+			exSigns,HAM_BRIDGE 	-	// Downlink
 TRUNK	ge-0/0/9	exSCALE-SLOW,exSCALE-FAST,exSpeaker,exInfra, \
 			exAVLAN,vendor_backbone \
-			exSigns,HAM_BRIDGE 	-	// 
+			exSigns,HAM_BRIDGE 	-	// Downlink
 TRUNK	ge-0/0/10	exSCALE-SLOW,exSCALE-FAST,exSpeaker,exInfra, \
 			exAVLAN,vendor_backbone \
-			exSigns,HAM_BRIDGE 	-	// 
+			exSigns,HAM_BRIDGE 	-	// Downlink
 TRUNK	ge-0/0/11	exSCALE-SLOW,exSCALE-FAST,exSpeaker,exInfra, \
 			exAVLAN,vendor_backbone \
-			exSigns,HAM_BRIDGE 	-	// 
+			exSigns,HAM_BRIDGE 	-	// Downlink
 TRUNK	ge-0/0/12	exSCALE-SLOW,exSCALE-FAST,exSpeaker,exInfra, \
 			exAVLAN,vendor_backbone \
-			exSigns,HAM_BRIDGE 	-	// 
+			exSigns,HAM_BRIDGE 	-	// Downlink
 TRUNK	ge-0/0/13	exSCALE-SLOW,exSCALE-FAST,exSpeaker,exInfra, \
 			exAVLAN,vendor_backbone \
-			exSigns,HAM_BRIDGE 	-	// 
+			exSigns,HAM_BRIDGE 	-	// Downlink
 TRUNK	ge-0/0/14	exSCALE-SLOW,exSCALE-FAST,exSpeaker,exInfra, \
 			exAVLAN,vendor_backbone \
-			exSigns,HAM_BRIDGE 	-	// 
+			exSigns,HAM_BRIDGE 	-	// Downlink
 TRUNK	ge-0/0/15	exSCALE-SLOW,exSCALE-FAST,exSpeaker,exInfra, \
 			exAVLAN,vendor_backbone \
-			exSigns,HAM_BRIDGE 	-	// 
+			exSigns,HAM_BRIDGE 	-	// Downlink
 TRUNK	ge-0/0/16	exSCALE-SLOW,exSCALE-FAST,exSpeaker,exInfra, \
 			exAVLAN,vendor_backbone \
-			exSigns,HAM_BRIDGE 	-	// 
+			exSigns,HAM_BRIDGE 	-	// Downlink
 TRUNK	ge-0/0/17	exSCALE-SLOW,exSCALE-FAST,exSpeaker,exInfra, \
 			exAVLAN,vendor_backbone \
-			exSigns,HAM_BRIDGE 	-	// 
+			exSigns,HAM_BRIDGE 	-	// Downlink
 TRUNK	ge-0/0/18	exSCALE-SLOW,exSCALE-FAST,exSpeaker,exInfra, \
 			exAVLAN,vendor_backbone \
-			exSigns,HAM_BRIDGE 	-	// 
+			exSigns,HAM_BRIDGE 	-	// Downlink
 TRUNK	ge-0/0/19	exSCALE-SLOW,exSCALE-FAST,exSpeaker,exInfra, \
 			exAVLAN,vendor_backbone \
-			exSigns,HAM_BRIDGE 	-	// 
+			exSigns,HAM_BRIDGE 	-	// Downlink
 TRUNK	ge-0/0/20	exSCALE-SLOW,exSCALE-FAST,exSpeaker,exInfra, \
 			exAVLAN,vendor_backbone \
-			exSigns,HAM_BRIDGE 	-	// 
+			exSigns,HAM_BRIDGE 	-	// Downlink
 TRUNK	ge-0/0/21	exSCALE-SLOW,exSCALE-FAST,exSpeaker,exInfra, \
 			exAVLAN,vendor_backbone \
-			exSigns,HAM_BRIDGE 	-	// 
+			exSigns,HAM_BRIDGE 	-	// Downlink
 TRUNK	ge-0/0/22	exSCALE-SLOW,exSCALE-FAST,exSpeaker,exInfra, \
 			exAVLAN,vendor_backbone \
-			exSigns,HAM_BRIDGE 	-	// 
+			exSigns,HAM_BRIDGE 	-	// Downlink
 TRUNK	ge-0/0/23	exSCALE-SLOW,exSCALE-FAST,exSpeaker,exInfra, \
 			exAVLAN,vendor_backbone \
-			exSigns,HAM_BRIDGE 	-	// 
+			exSigns,HAM_BRIDGE 	-	// Downlink
 TRUNK	ge-0/0/24	exSCALE-SLOW,exSCALE-FAST,exSpeaker,exInfra, \
 			exAVLAN,vendor_backbone \
-			exSigns,HAM_BRIDGE 	-	// 
+			exSigns,HAM_BRIDGE 	-	// Downlink
 TRUNK	ge-0/0/25	exSCALE-SLOW,exSCALE-FAST,exSpeaker,exInfra, \
 			exAVLAN,vendor_backbone \
-			exSigns,HAM_BRIDGE 	-	// 
+			exSigns,HAM_BRIDGE 	-	// Downlink
 TRUNK	ge-0/0/26	exSCALE-SLOW,exSCALE-FAST,exSpeaker,exInfra, \
 			exAVLAN,vendor_backbone \
-			exSigns,HAM_BRIDGE 	-	// 
+			exSigns,HAM_BRIDGE 	-	// Downlink
 TRUNK	ge-0/0/27	exSCALE-SLOW,exSCALE-FAST,exSpeaker,exInfra, \
 			exAVLAN,vendor_backbone \
-			exSigns,HAM_BRIDGE 	-	// 
+			exSigns,HAM_BRIDGE 	-	// Downlink
 TRUNK	ge-0/0/28	exSCALE-SLOW,exSCALE-FAST,exSpeaker,exInfra, \
 			exAVLAN,vendor_backbone \
-			exSigns,HAM_BRIDGE 	-	// 
+			exSigns,HAM_BRIDGE 	-	// Downlink
 TRUNK	ge-0/0/29	exSCALE-SLOW,exSCALE-FAST,exSpeaker,exInfra, \
 			exAVLAN,vendor_backbone \
-			exSigns,exVmVendor,HAM_BRIDGE 	-	// 
+			exSigns,exVmVendor,HAM_BRIDGE 	-	// Downlink
 TRUNK	ge-0/0/30	exSCALE-SLOW,exSCALE-FAST,exInfra	POE	// AP for Game Night
 TRUNK	ge-0/0/31	exSCALE-SLOW,exSCALE-FAST,exInfra	POE	// AP for Game Night
 TRUNK	ge-0/0/32	exSCALE-SLOW,exSCALE-FAST,exInfra	POE	// AP for Game Night

--- a/switch-configuration/config/types/Catwalk
+++ b/switch-configuration/config/types/Catwalk
@@ -1,109 +1,109 @@
 // Expo Center Catwalk Switch Configuration
 TRUNK	ge-0/0/0	exSCALE-SLOW,exSCALE-FAST,exSpeaker,exInfra, \
 			exAVLAN,vendor_backbone \
-			exSigns,HAM_BRIDGE 	-	// Uplink
+			exSigns,HAM_BRIDGE 	-	Uplink
 TRUNK	ge-0/0/1	exSCALE-SLOW,exSCALE-FAST,exSpeaker,exInfra, \
 			exAVLAN,vendor_backbone \
-			exSigns,HAM_BRIDGE 	-	// Downlink
+			exSigns,HAM_BRIDGE 	-	Downlink
 TRUNK	ge-0/0/2	exSCALE-SLOW,exSCALE-FAST,exSpeaker,exInfra, \
 			exAVLAN,vendor_backbone \
-			exSigns,HAM_BRIDGE 	-	// Downlink
+			exSigns,HAM_BRIDGE 	-	Downlink
 TRUNK	ge-0/0/3	exSCALE-SLOW,exSCALE-FAST,exSpeaker,exInfra, \
 			exAVLAN,vendor_backbone \
-			exSigns,HAM_BRIDGE 	-	// Downlink
+			exSigns,HAM_BRIDGE 	-	Downlink
 TRUNK	ge-0/0/4	exSCALE-SLOW,exSCALE-FAST,exSpeaker,exInfra, \
 			exAVLAN,vendor_backbone \
-			exSigns,HAM_BRIDGE 	-	// Downlink
+			exSigns,HAM_BRIDGE 	-	Downlink
 TRUNK	ge-0/0/5	exSCALE-SLOW,exSCALE-FAST,exSpeaker,exInfra, \
 			exAVLAN,vendor_backbone \
-			exSigns,HAM_BRIDGE 	-	// Downlink
+			exSigns,HAM_BRIDGE 	-	Downlink
 TRUNK	ge-0/0/6	exSCALE-SLOW,exSCALE-FAST,exSpeaker,exInfra, \
 			exAVLAN,vendor_backbone \
-			exSigns,HAM_BRIDGE 	-	// Downlink
+			exSigns,HAM_BRIDGE 	-	Downlink
 TRUNK	ge-0/0/7	exSCALE-SLOW,exSCALE-FAST,exSpeaker,exInfra, \
 			exAVLAN,vendor_backbone \
-			exSigns,HAM_BRIDGE 	-	// Downlink
+			exSigns,HAM_BRIDGE 	-	Downlink
 TRUNK	ge-0/0/8	exSCALE-SLOW,exSCALE-FAST,exSpeaker,exInfra, \
 			exAVLAN,vendor_backbone \
-			exSigns,HAM_BRIDGE 	-	// Downlink
+			exSigns,HAM_BRIDGE 	-	Downlink
 TRUNK	ge-0/0/9	exSCALE-SLOW,exSCALE-FAST,exSpeaker,exInfra, \
 			exAVLAN,vendor_backbone \
-			exSigns,HAM_BRIDGE 	-	// Downlink
+			exSigns,HAM_BRIDGE 	-	Downlink
 TRUNK	ge-0/0/10	exSCALE-SLOW,exSCALE-FAST,exSpeaker,exInfra, \
 			exAVLAN,vendor_backbone \
-			exSigns,HAM_BRIDGE 	-	// Downlink
+			exSigns,HAM_BRIDGE 	-	Downlink
 TRUNK	ge-0/0/11	exSCALE-SLOW,exSCALE-FAST,exSpeaker,exInfra, \
 			exAVLAN,vendor_backbone \
-			exSigns,HAM_BRIDGE 	-	// Downlink
+			exSigns,HAM_BRIDGE 	-	Downlink
 TRUNK	ge-0/0/12	exSCALE-SLOW,exSCALE-FAST,exSpeaker,exInfra, \
 			exAVLAN,vendor_backbone \
-			exSigns,HAM_BRIDGE 	-	// Downlink
+			exSigns,HAM_BRIDGE 	-	Downlink
 TRUNK	ge-0/0/13	exSCALE-SLOW,exSCALE-FAST,exSpeaker,exInfra, \
 			exAVLAN,vendor_backbone \
-			exSigns,HAM_BRIDGE 	-	// Downlink
+			exSigns,HAM_BRIDGE 	-	Downlink
 TRUNK	ge-0/0/14	exSCALE-SLOW,exSCALE-FAST,exSpeaker,exInfra, \
 			exAVLAN,vendor_backbone \
-			exSigns,HAM_BRIDGE 	-	// Downlink
+			exSigns,HAM_BRIDGE 	-	Downlink
 TRUNK	ge-0/0/15	exSCALE-SLOW,exSCALE-FAST,exSpeaker,exInfra, \
 			exAVLAN,vendor_backbone \
-			exSigns,HAM_BRIDGE 	-	// Downlink
+			exSigns,HAM_BRIDGE 	-	Downlink
 TRUNK	ge-0/0/16	exSCALE-SLOW,exSCALE-FAST,exSpeaker,exInfra, \
 			exAVLAN,vendor_backbone \
-			exSigns,HAM_BRIDGE 	-	// Downlink
+			exSigns,HAM_BRIDGE 	-	Downlink
 TRUNK	ge-0/0/17	exSCALE-SLOW,exSCALE-FAST,exSpeaker,exInfra, \
 			exAVLAN,vendor_backbone \
-			exSigns,HAM_BRIDGE 	-	// Downlink
+			exSigns,HAM_BRIDGE 	-	Downlink
 TRUNK	ge-0/0/18	exSCALE-SLOW,exSCALE-FAST,exSpeaker,exInfra, \
 			exAVLAN,vendor_backbone \
-			exSigns,HAM_BRIDGE 	-	// Downlink
+			exSigns,HAM_BRIDGE 	-	Downlink
 TRUNK	ge-0/0/19	exSCALE-SLOW,exSCALE-FAST,exSpeaker,exInfra, \
 			exAVLAN,vendor_backbone \
-			exSigns,HAM_BRIDGE 	-	// Downlink
+			exSigns,HAM_BRIDGE 	-	Downlink
 TRUNK	ge-0/0/20	exSCALE-SLOW,exSCALE-FAST,exSpeaker,exInfra, \
 			exAVLAN,vendor_backbone \
-			exSigns,HAM_BRIDGE 	-	// Downlink
+			exSigns,HAM_BRIDGE 	-	Downlink
 TRUNK	ge-0/0/21	exSCALE-SLOW,exSCALE-FAST,exSpeaker,exInfra, \
 			exAVLAN,vendor_backbone \
-			exSigns,HAM_BRIDGE 	-	// Downlink
+			exSigns,HAM_BRIDGE 	-	Downlink
 TRUNK	ge-0/0/22	exSCALE-SLOW,exSCALE-FAST,exSpeaker,exInfra, \
 			exAVLAN,vendor_backbone \
-			exSigns,HAM_BRIDGE 	-	// Downlink
+			exSigns,HAM_BRIDGE 	-	Downlink
 TRUNK	ge-0/0/23	exSCALE-SLOW,exSCALE-FAST,exSpeaker,exInfra, \
 			exAVLAN,vendor_backbone \
-			exSigns,HAM_BRIDGE 	-	// Downlink
+			exSigns,HAM_BRIDGE 	-	Downlink
 TRUNK	ge-0/0/24	exSCALE-SLOW,exSCALE-FAST,exSpeaker,exInfra, \
 			exAVLAN,vendor_backbone \
-			exSigns,HAM_BRIDGE 	-	// Downlink
+			exSigns,HAM_BRIDGE 	-	Downlink
 TRUNK	ge-0/0/25	exSCALE-SLOW,exSCALE-FAST,exSpeaker,exInfra, \
 			exAVLAN,vendor_backbone \
-			exSigns,HAM_BRIDGE 	-	// Downlink
+			exSigns,HAM_BRIDGE 	-	Downlink
 TRUNK	ge-0/0/26	exSCALE-SLOW,exSCALE-FAST,exSpeaker,exInfra, \
 			exAVLAN,vendor_backbone \
-			exSigns,HAM_BRIDGE 	-	// Downlink
+			exSigns,HAM_BRIDGE 	-	Downlink
 TRUNK	ge-0/0/27	exSCALE-SLOW,exSCALE-FAST,exSpeaker,exInfra, \
 			exAVLAN,vendor_backbone \
-			exSigns,HAM_BRIDGE 	-	// Downlink
+			exSigns,HAM_BRIDGE 	-	Downlink
 TRUNK	ge-0/0/28	exSCALE-SLOW,exSCALE-FAST,exSpeaker,exInfra, \
 			exAVLAN,vendor_backbone \
-			exSigns,HAM_BRIDGE 	-	// Downlink
+			exSigns,HAM_BRIDGE 	-	Downlink
 TRUNK	ge-0/0/29	exSCALE-SLOW,exSCALE-FAST,exSpeaker,exInfra, \
 			exAVLAN,vendor_backbone \
-			exSigns,exVmVendor,HAM_BRIDGE 	-	// Downlink
-TRUNK	ge-0/0/30	exSCALE-SLOW,exSCALE-FAST,exInfra	POE	// AP for Game Night
-TRUNK	ge-0/0/31	exSCALE-SLOW,exSCALE-FAST,exInfra	POE	// AP for Game Night
-TRUNK	ge-0/0/32	exSCALE-SLOW,exSCALE-FAST,exInfra	POE	// AP for Game Night
-TRUNK	ge-0/0/33	exSCALE-SLOW,exSCALE-FAST,exInfra	POE	// AP for Game Night
-TRUNK	ge-0/0/34	exSCALE-SLOW,exSCALE-FAST,exInfra	POE	// AP for Game Night
-TRUNK	ge-0/0/35	exSCALE-SLOW,exSCALE-FAST,exInfra	POE	// AP for Game Night
-TRUNK	ge-0/0/36	exSCALE-SLOW,exSCALE-FAST,exInfra	POE	// AP for Game Night
-TRUNK	ge-0/0/37	exSCALE-SLOW,exSCALE-FAST,exInfra	POE	// AP for Game Night
-TRUNK	ge-0/0/38	exSCALE-SLOW,exSCALE-FAST,exInfra	POE	// AP for Game Night
-TRUNK	ge-0/0/39	exSCALE-SLOW,exSCALE-FAST,exInfra	POE	// AP for Game Night
-TRUNK	ge-0/0/40	exSCALE-SLOW,exSCALE-FAST,exInfra	POE	// AP for Game Night
-TRUNK	ge-0/0/41	exSCALE-SLOW,exSCALE-FAST,exInfra	POE	// AP for Game Night
-TRUNK	ge-0/0/42	exSCALE-SLOW,exSCALE-FAST,exInfra	POE	// AP for Game Night
-TRUNK	ge-0/0/43	exSCALE-SLOW,exSCALE-FAST,exInfra	POE	// AP for Game Night
-TRUNK	ge-0/0/44	exSCALE-SLOW,exSCALE-FAST,exInfra	POE	// AP for Game Night
-TRUNK	ge-0/0/45	exSCALE-SLOW,exSCALE-FAST,exInfra	POE	// AP for Game Night
-TRUNK	ge-0/0/46	exSCALE-SLOW,exSCALE-FAST,exInfra	POE	// AP for Game Night
-TRUNK	ge-0/0/47	exSCALE-SLOW,exSCALE-FAST,exInfra	POE	// AP for Game Night
+			exSigns,exVmVendor,HAM_BRIDGE 	-	Downlink
+TRUNK	ge-0/0/30	exSCALE-SLOW,exSCALE-FAST,exInfra	POE	AP // for Game Night
+TRUNK	ge-0/0/31	exSCALE-SLOW,exSCALE-FAST,exInfra	POE	AP // for Game Night
+TRUNK	ge-0/0/32	exSCALE-SLOW,exSCALE-FAST,exInfra	POE	AP // for Game Night
+TRUNK	ge-0/0/33	exSCALE-SLOW,exSCALE-FAST,exInfra	POE	AP // for Game Night
+TRUNK	ge-0/0/34	exSCALE-SLOW,exSCALE-FAST,exInfra	POE	AP // for Game Night
+TRUNK	ge-0/0/35	exSCALE-SLOW,exSCALE-FAST,exInfra	POE	AP // for Game Night
+TRUNK	ge-0/0/36	exSCALE-SLOW,exSCALE-FAST,exInfra	POE	AP // for Game Night
+TRUNK	ge-0/0/37	exSCALE-SLOW,exSCALE-FAST,exInfra	POE	AP // for Game Night
+TRUNK	ge-0/0/38	exSCALE-SLOW,exSCALE-FAST,exInfra	POE	AP // for Game Night
+TRUNK	ge-0/0/39	exSCALE-SLOW,exSCALE-FAST,exInfra	POE	AP // for Game Night
+TRUNK	ge-0/0/40	exSCALE-SLOW,exSCALE-FAST,exInfra	POE	AP // for Game Night
+TRUNK	ge-0/0/41	exSCALE-SLOW,exSCALE-FAST,exInfra	POE	AP // for Game Night
+TRUNK	ge-0/0/42	exSCALE-SLOW,exSCALE-FAST,exInfra	POE	AP // for Game Night
+TRUNK	ge-0/0/43	exSCALE-SLOW,exSCALE-FAST,exInfra	POE	AP // for Game Night
+TRUNK	ge-0/0/44	exSCALE-SLOW,exSCALE-FAST,exInfra	POE	AP // for Game Night
+TRUNK	ge-0/0/45	exSCALE-SLOW,exSCALE-FAST,exInfra	POE	AP // for Game Night
+TRUNK	ge-0/0/46	exSCALE-SLOW,exSCALE-FAST,exInfra	POE	AP // for Game Night
+TRUNK	ge-0/0/47	exSCALE-SLOW,exSCALE-FAST,exInfra	POE	AP // for Game Night

--- a/switch-configuration/config/types/MassFlash
+++ b/switch-configuration/config/types/MassFlash
@@ -1,49 +1,49 @@
 // Mass Flashing Switch Configuration
-TRUNK	ge-0/0/0	cfInfra		POE
-TRUNK	ge-0/0/1	cfInfra		POE
-TRUNK	ge-0/0/2	cfInfra		POE
-TRUNK	ge-0/0/3	cfInfra		POE
-TRUNK	ge-0/0/4	cfInfra		POE
-TRUNK	ge-0/0/5	cfInfra		POE
-TRUNK	ge-0/0/6	cfInfra		POE
-TRUNK	ge-0/0/7	cfInfra		POE
-TRUNK	ge-0/0/8	cfInfra		POE
-TRUNK	ge-0/0/9	cfInfra		POE
-TRUNK	ge-0/0/10	cfInfra		POE
-TRUNK	ge-0/0/11	cfInfra		POE
-TRUNK	ge-0/0/12	cfInfra		POE
-TRUNK	ge-0/0/13	cfInfra		POE
-TRUNK	ge-0/0/14	cfInfra		POE
-TRUNK	ge-0/0/15	cfInfra		POE
-TRUNK	ge-0/0/16	cfInfra		POE
-TRUNK	ge-0/0/17	cfInfra		POE
-TRUNK	ge-0/0/18	cfInfra		POE
-TRUNK	ge-0/0/19	cfInfra		POE
-TRUNK	ge-0/0/20	cfInfra		POE
-TRUNK	ge-0/0/21	cfInfra		POE
-TRUNK	ge-0/0/22	cfInfra		POE
-TRUNK	ge-0/0/23	cfInfra		POE
-TRUNK	ge-0/0/24	cfInfra		POE
-TRUNK	ge-0/0/25	cfInfra		POE
-TRUNK	ge-0/0/26	cfInfra		POE
-TRUNK	ge-0/0/27	cfInfra		POE
-TRUNK	ge-0/0/28	cfInfra		POE
-TRUNK	ge-0/0/29	cfInfra		POE
-TRUNK	ge-0/0/30	cfInfra		POE
-TRUNK	ge-0/0/31	cfInfra		POE
-TRUNK	ge-0/0/32	cfInfra		POE
-TRUNK	ge-0/0/33	cfInfra		POE
-TRUNK	ge-0/0/34	cfInfra		POE
-TRUNK	ge-0/0/35	cfInfra		POE
-TRUNK	ge-0/0/36	cfInfra		POE
-TRUNK	ge-0/0/37	cfInfra		POE
-TRUNK	ge-0/0/38	cfInfra		POE
-TRUNK	ge-0/0/39	cfInfra		POE
-TRUNK	ge-0/0/40	cfInfra		POE
-TRUNK	ge-0/0/41	cfInfra		POE
-TRUNK	ge-0/0/42	cfInfra		POE
-TRUNK	ge-0/0/43	cfInfra		POE
-TRUNK	ge-0/0/44	cfInfra		POE
-TRUNK	ge-0/0/45	cfInfra		POE
-TRUNK	ge-0/0/46	cfInfra		POE
-TRUNK	ge-0/0/47	cfInfra		POE
+TRUNK	ge-0/0/0	cfInfra		POE	MassFlash
+TRUNK	ge-0/0/1	cfInfra		POE	MassFlash
+TRUNK	ge-0/0/2	cfInfra		POE	MassFlash
+TRUNK	ge-0/0/3	cfInfra		POE	MassFlash
+TRUNK	ge-0/0/4	cfInfra		POE	MassFlash
+TRUNK	ge-0/0/5	cfInfra		POE	MassFlash
+TRUNK	ge-0/0/6	cfInfra		POE	MassFlash
+TRUNK	ge-0/0/7	cfInfra		POE	MassFlash
+TRUNK	ge-0/0/8	cfInfra		POE	MassFlash
+TRUNK	ge-0/0/9	cfInfra		POE	MassFlash
+TRUNK	ge-0/0/10	cfInfra		POE	MassFlash
+TRUNK	ge-0/0/11	cfInfra		POE	MassFlash
+TRUNK	ge-0/0/12	cfInfra		POE	MassFlash
+TRUNK	ge-0/0/13	cfInfra		POE	MassFlash
+TRUNK	ge-0/0/14	cfInfra		POE	MassFlash
+TRUNK	ge-0/0/15	cfInfra		POE	MassFlash
+TRUNK	ge-0/0/16	cfInfra		POE	MassFlash
+TRUNK	ge-0/0/17	cfInfra		POE	MassFlash
+TRUNK	ge-0/0/18	cfInfra		POE	MassFlash
+TRUNK	ge-0/0/19	cfInfra		POE	MassFlash
+TRUNK	ge-0/0/20	cfInfra		POE	MassFlash
+TRUNK	ge-0/0/21	cfInfra		POE	MassFlash
+TRUNK	ge-0/0/22	cfInfra		POE	MassFlash
+TRUNK	ge-0/0/23	cfInfra		POE	MassFlash
+TRUNK	ge-0/0/24	cfInfra		POE	MassFlash
+TRUNK	ge-0/0/25	cfInfra		POE	MassFlash
+TRUNK	ge-0/0/26	cfInfra		POE	MassFlash
+TRUNK	ge-0/0/27	cfInfra		POE	MassFlash
+TRUNK	ge-0/0/28	cfInfra		POE	MassFlash
+TRUNK	ge-0/0/29	cfInfra		POE	MassFlash
+TRUNK	ge-0/0/30	cfInfra		POE	MassFlash
+TRUNK	ge-0/0/31	cfInfra		POE	MassFlash
+TRUNK	ge-0/0/32	cfInfra		POE	MassFlash
+TRUNK	ge-0/0/33	cfInfra		POE	MassFlash
+TRUNK	ge-0/0/34	cfInfra		POE	MassFlash
+TRUNK	ge-0/0/35	cfInfra		POE	MassFlash
+TRUNK	ge-0/0/36	cfInfra		POE	MassFlash
+TRUNK	ge-0/0/37	cfInfra		POE	MassFlash
+TRUNK	ge-0/0/38	cfInfra		POE	MassFlash
+TRUNK	ge-0/0/39	cfInfra		POE	MassFlash
+TRUNK	ge-0/0/40	cfInfra		POE	MassFlash
+TRUNK	ge-0/0/41	cfInfra		POE	MassFlash
+TRUNK	ge-0/0/42	cfInfra		POE	MassFlash
+TRUNK	ge-0/0/43	cfInfra		POE	MassFlash
+TRUNK	ge-0/0/44	cfInfra		POE	MassFlash
+TRUNK	ge-0/0/45	cfInfra		POE	MassFlash
+TRUNK	ge-0/0/46	cfInfra		POE	MassFlash
+TRUNK	ge-0/0/47	cfInfra		POE	MassFlash

--- a/switch-configuration/config/types/cfAV
+++ b/switch-configuration/config/types/cfAV
@@ -1,12 +1,12 @@
 // Room Switch Template -- AV Room Switch
-TRUNK	ge-0/0/0	cfSCALE-SLOW,cfSCALE-FAST,cfSpeaker,cfInfra,cfAVLAN,cfSigns,HAM_BRIDGE	-	// Uplink
-TRUNK	ge-0/0/1	cfSCALE-SLOW,cfSCALE-FAST,cfSpeaker,cfInfra,cfAVLAN,cfSigns,HAM_BRIDGE	-	// Downlink
-TRUNK	ge-0/0/2	cfInfra,cfSCALE-SLOW,cfSCALE-FAST,cfAVLAN				POE	// AP
-TRUNK	ge-0/0/3	cfInfra,cfSCALE-SLOW,cfSCALE-FAST,cfAVLAN				POE	// AP
-TRUNK	ge-0/0/4	cfInfra,cfSCALE-SLOW,cfSCALE-FAST,cfAVLAN				POE	// AP
-TRUNK	ge-0/0/5	cfInfra,cfSCALE-SLOW,cfSCALE-FAST,cfAVLAN				POE	// AP
-TRUNK	ge-0/0/6	cfInfra,cfSCALE-SLOW,cfSCALE-FAST,cfAVLAN				POE	// AP
-TRUNK	ge-0/0/7	cfInfra,cfSCALE-SLOW,cfSCALE-FAST,cfAVLAN				POE	// AP
+TRUNK	ge-0/0/0	cfSCALE-SLOW,cfSCALE-FAST,cfSpeaker,cfInfra,cfAVLAN,cfSigns,HAM_BRIDGE	-	Uplink
+TRUNK	ge-0/0/1	cfSCALE-SLOW,cfSCALE-FAST,cfSpeaker,cfInfra,cfAVLAN,cfSigns,HAM_BRIDGE	-	Downlink
+TRUNK	ge-0/0/2	cfInfra,cfSCALE-SLOW,cfSCALE-FAST,cfAVLAN				POE	AP
+TRUNK	ge-0/0/3	cfInfra,cfSCALE-SLOW,cfSCALE-FAST,cfAVLAN				POE	AP
+TRUNK	ge-0/0/4	cfInfra,cfSCALE-SLOW,cfSCALE-FAST,cfAVLAN				POE	AP
+TRUNK	ge-0/0/5	cfInfra,cfSCALE-SLOW,cfSCALE-FAST,cfAVLAN				POE	AP
+TRUNK	ge-0/0/6	cfInfra,cfSCALE-SLOW,cfSCALE-FAST,cfAVLAN				POE	AP
+TRUNK	ge-0/0/7	cfInfra,cfSCALE-SLOW,cfSCALE-FAST,cfAVLAN				POE	AP
 VLAN	cfSigns		4									POE	// ge-0/0/{8-11}
 VLAN	cfAVLAN		36									POE	// ge-0/0/{12-47}
 

--- a/switch-configuration/config/types/cfAV
+++ b/switch-configuration/config/types/cfAV
@@ -7,6 +7,6 @@ TRUNK	ge-0/0/4	cfInfra,cfSCALE-SLOW,cfSCALE-FAST,cfAVLAN				POE	// AP
 TRUNK	ge-0/0/5	cfInfra,cfSCALE-SLOW,cfSCALE-FAST,cfAVLAN				POE	// AP
 TRUNK	ge-0/0/6	cfInfra,cfSCALE-SLOW,cfSCALE-FAST,cfAVLAN				POE	// AP
 TRUNK	ge-0/0/7	cfInfra,cfSCALE-SLOW,cfSCALE-FAST,cfAVLAN				POE	// AP
-VLAN	cfSigns		4									-	// ge-0/0/{8-11}
+VLAN	cfSigns		4									POE	// ge-0/0/{8-11}
 VLAN	cfAVLAN		36									POE	// ge-0/0/{12-47}
 

--- a/switch-configuration/config/types/cfIDF
+++ b/switch-configuration/config/types/cfIDF
@@ -37,7 +37,7 @@ TRUNK	ge-0/0/32	cfSCALE-SLOW,cfSCALE-FAST,cfInfra				POE	AP
 TRUNK	ge-0/0/33	cfSCALE-SLOW,cfSCALE-FAST,cfInfra				POE	AP
 TRUNK	ge-0/0/34	cfSCALE-SLOW,cfSCALE-FAST,cfInfra				POE	AP
 TRUNK	ge-0/0/35	cfSCALE-SLOW,cfSCALE-FAST,cfInfra				POE	AP
-VLAN	cfCTF		6								-	/ ge-0/0/{36-45}
+VLAN	cfCTF		10								-	/ ge-0/0/{36-45}
 VLAN	cfInfra		1								-	// ge-0/0/46 -- Conference Center Bhyve Server
 VLAN	cfAVLAN		1								-	// ge-0/0/47 -- Conference Center AV Server
 

--- a/switch-configuration/config/types/cfIDF
+++ b/switch-configuration/config/types/cfIDF
@@ -1,42 +1,42 @@
 // Conference Center IDF Switch Configuration
 TRUNK	ge-0/0/0	cfSCALE-SLOW,cfSCALE-FAST,cfSpeaker,cfInfra,cfCTF,cfAVLAN,cfNOC, \
-			cfSigns,cfHam_N6S,HAM_BRIDGE 					-	// Uplink
+			cfSigns,cfHam_N6S,HAM_BRIDGE 					-	Uplink
 TRUNK	ge-0/0/1	cfSCALE-SLOW,cfSCALE-FAST,cfSpeaker,cfInfra,cfCTF,cfAVLAN,cfNOC, \
-			cfSigns,cfHam_N6S,HAM_BRIDGE 					-	// Uplink
-TRUNK	ge-0/0/2	cfSCALE-SLOW,cfSCALE-FAST,cfSpeaker,cfInfra,cfAVLAN,cfSigns	-
-TRUNK	ge-0/0/3	cfSCALE-SLOW,cfSCALE-FAST,cfSpeaker,cfInfra,cfAVLAN,cfSigns	-
-TRUNK	ge-0/0/4	cfSCALE-SLOW,cfSCALE-FAST,cfSpeaker,cfInfra,cfAVLAN,cfSigns	-
-TRUNK	ge-0/0/5	cfSCALE-SLOW,cfSCALE-FAST,cfSpeaker,cfInfra,cfAVLAN,cfSigns	-
-TRUNK	ge-0/0/6	cfSCALE-SLOW,cfSCALE-FAST,cfSpeaker,cfInfra,cfAVLAN,cfSigns	-
-TRUNK	ge-0/0/7	cfSCALE-SLOW,cfSCALE-FAST,cfSpeaker,cfInfra,cfAVLAN,cfSigns	-
-TRUNK	ge-0/0/8	cfSCALE-SLOW,cfSCALE-FAST,cfSpeaker,cfInfra,cfAVLAN,cfSigns	-
-TRUNK	ge-0/0/9	cfSCALE-SLOW,cfSCALE-FAST,cfSpeaker,cfInfra,cfAVLAN,cfSigns	-
-TRUNK	ge-0/0/10	cfSCALE-SLOW,cfSCALE-FAST,cfSpeaker,cfInfra,cfAVLAN,cfSigns	-
-TRUNK	ge-0/0/11	cfSCALE-SLOW,cfSCALE-FAST,cfSpeaker,cfInfra,cfAVLAN,cfSigns	-
-TRUNK	ge-0/0/12	cfSCALE-SLOW,cfSCALE-FAST,cfSpeaker,cfInfra,cfAVLAN,cfSigns	-
-TRUNK	ge-0/0/13	cfSCALE-SLOW,cfSCALE-FAST,cfSpeaker,cfInfra,cfAVLAN,cfSigns	-
-TRUNK	ge-0/0/14	cfSCALE-SLOW,cfSCALE-FAST,cfSpeaker,cfInfra,cfAVLAN,cfSigns	-
-TRUNK	ge-0/0/15	cfSCALE-SLOW,cfSCALE-FAST,cfSpeaker,cfInfra,cfAVLAN,cfSigns	-
-TRUNK	ge-0/0/16	cfSCALE-SLOW,cfSCALE-FAST,cfSpeaker,cfInfra,cfAVLAN,cfSigns	-
-TRUNK	ge-0/0/17	cfSCALE-SLOW,cfSCALE-FAST,cfSpeaker,cfInfra,cfAVLAN,cfSigns	-
-TRUNK	ge-0/0/18	cfSCALE-SLOW,cfSCALE-FAST,cfSpeaker,cfInfra,cfAVLAN,cfSigns	-
-TRUNK	ge-0/0/19	cfSCALE-SLOW,cfSCALE-FAST,cfSpeaker,cfInfra,cfAVLAN,cfSigns	-
-TRUNK	ge-0/0/20	cfSCALE-SLOW,cfSCALE-FAST,cfSpeaker,cfInfra,cfAVLAN,cfSigns	-
-TRUNK	ge-0/0/21	cfSCALE-SLOW,cfSCALE-FAST,cfSpeaker,cfInfra,cfAVLAN,cfSigns	-
-TRUNK	ge-0/0/22	cfSCALE-SLOW,cfSCALE-FAST,cfSpeaker,cfInfra,cfAVLAN,cfSigns	-
-TRUNK	ge-0/0/23	cfSCALE-SLOW,cfSCALE-FAST,cfSpeaker,cfInfra,cfAVLAN,cfSigns	-
-TRUNK	ge-0/0/24	cfSCALE-SLOW,cfSCALE-FAST,cfInfra				POE	// AP
-TRUNK	ge-0/0/25	cfSCALE-SLOW,cfSCALE-FAST,cfInfra				POE	// AP
-TRUNK	ge-0/0/26	cfSCALE-SLOW,cfSCALE-FAST,cfInfra				POE	// AP
-TRUNK	ge-0/0/27	cfSCALE-SLOW,cfSCALE-FAST,cfInfra				POE	// AP
-TRUNK	ge-0/0/28	cfSCALE-SLOW,cfSCALE-FAST,cfInfra				POE	// AP
-TRUNK	ge-0/0/29	cfSCALE-SLOW,cfSCALE-FAST,cfInfra				POE	// AP
-TRUNK	ge-0/0/30	cfSCALE-SLOW,cfSCALE-FAST,cfInfra				POE	// AP
-TRUNK	ge-0/0/31	cfSCALE-SLOW,cfSCALE-FAST,cfInfra				POE	// AP
-TRUNK	ge-0/0/32	cfSCALE-SLOW,cfSCALE-FAST,cfInfra				POE	// AP
-TRUNK	ge-0/0/33	cfSCALE-SLOW,cfSCALE-FAST,cfInfra				POE	// AP
-TRUNK	ge-0/0/34	cfSCALE-SLOW,cfSCALE-FAST,cfInfra				POE	// AP
-TRUNK	ge-0/0/35	cfSCALE-SLOW,cfSCALE-FAST,cfInfra				POE	// AP
+			cfSigns,cfHam_N6S,HAM_BRIDGE 					-	Uplink
+TRUNK	ge-0/0/2	cfSCALE-SLOW,cfSCALE-FAST,cfSpeaker,cfInfra,cfAVLAN,cfSigns	-	Downlink
+TRUNK	ge-0/0/3	cfSCALE-SLOW,cfSCALE-FAST,cfSpeaker,cfInfra,cfAVLAN,cfSigns	-	Downlink
+TRUNK	ge-0/0/4	cfSCALE-SLOW,cfSCALE-FAST,cfSpeaker,cfInfra,cfAVLAN,cfSigns	-	Downlink
+TRUNK	ge-0/0/5	cfSCALE-SLOW,cfSCALE-FAST,cfSpeaker,cfInfra,cfAVLAN,cfSigns	-	Downlink
+TRUNK	ge-0/0/6	cfSCALE-SLOW,cfSCALE-FAST,cfSpeaker,cfInfra,cfAVLAN,cfSigns	-	Downlink
+TRUNK	ge-0/0/7	cfSCALE-SLOW,cfSCALE-FAST,cfSpeaker,cfInfra,cfAVLAN,cfSigns	-	Downlink
+TRUNK	ge-0/0/8	cfSCALE-SLOW,cfSCALE-FAST,cfSpeaker,cfInfra,cfAVLAN,cfSigns	-	Downlink
+TRUNK	ge-0/0/9	cfSCALE-SLOW,cfSCALE-FAST,cfSpeaker,cfInfra,cfAVLAN,cfSigns	-	Downlink
+TRUNK	ge-0/0/10	cfSCALE-SLOW,cfSCALE-FAST,cfSpeaker,cfInfra,cfAVLAN,cfSigns	-	Downlink
+TRUNK	ge-0/0/11	cfSCALE-SLOW,cfSCALE-FAST,cfSpeaker,cfInfra,cfAVLAN,cfSigns	-	Downlink
+TRUNK	ge-0/0/12	cfSCALE-SLOW,cfSCALE-FAST,cfSpeaker,cfInfra,cfAVLAN,cfSigns	-	Downlink
+TRUNK	ge-0/0/13	cfSCALE-SLOW,cfSCALE-FAST,cfSpeaker,cfInfra,cfAVLAN,cfSigns	-	Downlink
+TRUNK	ge-0/0/14	cfSCALE-SLOW,cfSCALE-FAST,cfSpeaker,cfInfra,cfAVLAN,cfSigns	-	Downlink
+TRUNK	ge-0/0/15	cfSCALE-SLOW,cfSCALE-FAST,cfSpeaker,cfInfra,cfAVLAN,cfSigns	-	Downlink
+TRUNK	ge-0/0/16	cfSCALE-SLOW,cfSCALE-FAST,cfSpeaker,cfInfra,cfAVLAN,cfSigns	-	Downlink
+TRUNK	ge-0/0/17	cfSCALE-SLOW,cfSCALE-FAST,cfSpeaker,cfInfra,cfAVLAN,cfSigns	-	Downlink
+TRUNK	ge-0/0/18	cfSCALE-SLOW,cfSCALE-FAST,cfSpeaker,cfInfra,cfAVLAN,cfSigns	-	Downlink
+TRUNK	ge-0/0/19	cfSCALE-SLOW,cfSCALE-FAST,cfSpeaker,cfInfra,cfAVLAN,cfSigns	-	Downlink
+TRUNK	ge-0/0/20	cfSCALE-SLOW,cfSCALE-FAST,cfSpeaker,cfInfra,cfAVLAN,cfSigns	-	Downlink
+TRUNK	ge-0/0/21	cfSCALE-SLOW,cfSCALE-FAST,cfSpeaker,cfInfra,cfAVLAN,cfSigns	-	Downlink
+TRUNK	ge-0/0/22	cfSCALE-SLOW,cfSCALE-FAST,cfSpeaker,cfInfra,cfAVLAN,cfSigns	-	Downlink
+TRUNK	ge-0/0/23	cfSCALE-SLOW,cfSCALE-FAST,cfSpeaker,cfInfra,cfAVLAN,cfSigns	-	Downlink
+TRUNK	ge-0/0/24	cfSCALE-SLOW,cfSCALE-FAST,cfInfra				POE	AP
+TRUNK	ge-0/0/25	cfSCALE-SLOW,cfSCALE-FAST,cfInfra				POE	AP
+TRUNK	ge-0/0/26	cfSCALE-SLOW,cfSCALE-FAST,cfInfra				POE	AP
+TRUNK	ge-0/0/27	cfSCALE-SLOW,cfSCALE-FAST,cfInfra				POE	AP
+TRUNK	ge-0/0/28	cfSCALE-SLOW,cfSCALE-FAST,cfInfra				POE	AP
+TRUNK	ge-0/0/29	cfSCALE-SLOW,cfSCALE-FAST,cfInfra				POE	AP
+TRUNK	ge-0/0/30	cfSCALE-SLOW,cfSCALE-FAST,cfInfra				POE	AP
+TRUNK	ge-0/0/31	cfSCALE-SLOW,cfSCALE-FAST,cfInfra				POE	AP
+TRUNK	ge-0/0/32	cfSCALE-SLOW,cfSCALE-FAST,cfInfra				POE	AP
+TRUNK	ge-0/0/33	cfSCALE-SLOW,cfSCALE-FAST,cfInfra				POE	AP
+TRUNK	ge-0/0/34	cfSCALE-SLOW,cfSCALE-FAST,cfInfra				POE	AP
+TRUNK	ge-0/0/35	cfSCALE-SLOW,cfSCALE-FAST,cfInfra				POE	AP
 VLAN	cfCTF		6								-	/ ge-0/0/{36-45}
 VLAN	cfInfra		1								-	// ge-0/0/46 -- Conference Center Bhyve Server
 VLAN	cfAVLAN		1								-	// ge-0/0/47 -- Conference Center AV Server

--- a/switch-configuration/config/types/cfIDF
+++ b/switch-configuration/config/types/cfIDF
@@ -1,8 +1,8 @@
 // Conference Center IDF Switch Configuration
 TRUNK	ge-0/0/0	cfSCALE-SLOW,cfSCALE-FAST,cfSpeaker,cfInfra,cfCTF,cfAVLAN,cfNOC, \
-			cfSigns,cfHam_N6S,HAM_BRIDGE 					-	// Link to CF Router
+			cfSigns,cfHam_N6S,HAM_BRIDGE 					-	// Uplink
 TRUNK	ge-0/0/1	cfSCALE-SLOW,cfSCALE-FAST,cfSpeaker,cfInfra,cfCTF,cfAVLAN,cfNOC, \
-			cfSigns,cfHam_N6S,HAM_BRIDGE 					-	// Link to CF Router
+			cfSigns,cfHam_N6S,HAM_BRIDGE 					-	// Uplink
 TRUNK	ge-0/0/2	cfSCALE-SLOW,cfSCALE-FAST,cfSpeaker,cfInfra,cfAVLAN,cfSigns	-
 TRUNK	ge-0/0/3	cfSCALE-SLOW,cfSCALE-FAST,cfSpeaker,cfInfra,cfAVLAN,cfSigns	-
 TRUNK	ge-0/0/4	cfSCALE-SLOW,cfSCALE-FAST,cfSpeaker,cfInfra,cfAVLAN,cfSigns	-

--- a/switch-configuration/config/types/cfNOC
+++ b/switch-configuration/config/types/cfNOC
@@ -17,6 +17,6 @@ TRUNK	ge-0/0/14	cfInfra,cfSCALE-SLOW,cfSCALE-FAST						POE	// AP
 TRUNK	ge-0/0/15	cfInfra,cfSCALE-SLOW,cfSCALE-FAST						POE	// AP
 TRUNK	ge-0/0/16	cfInfra,cfSCALE-SLOW,cfSCALE-FAST						POE	// AP
 TRUNK	ge-0/0/17	cfInfra,cfSCALE-SLOW,cfSCALE-FAST						POE	// AP
-VLAN	cfSigns		6										-	// ge-0/0/{18-23}
+VLAN	cfSigns		6										POE	// ge-0/0/{18-23}
 VLAN	cfNOC		12										-	// ge-0/0/{24-35}
 VLAN	cfInfra		12										-	// ge-0/0/{36-47}

--- a/switch-configuration/config/types/cfNOC
+++ b/switch-configuration/config/types/cfNOC
@@ -1,22 +1,22 @@
 // Room Switch Template -- All conference rooms Conference Center
-TRUNK	ge-0/0/0	cfSCALE-SLOW,cfSCALE-FAST,cfSpeaker,cfInfra,cfAVLAN,cfSigns,HAM_BRIDGE,cfNOC	-	// Uplink
-TRUNK	ge-0/0/1	cfSCALE-SLOW,cfSCALE-FAST,cfSpeaker,cfInfra,cfAVLAN,cfSigns,HAM_BRIDGE,cfNOC	-	// Downlink
-TRUNK	ge-0/0/2	cfInfra,cfSCALE-SLOW,cfSCALE-FAST						POE	// AP
-TRUNK	ge-0/0/3	cfInfra,cfSCALE-SLOW,cfSCALE-FAST						POE	// AP
-TRUNK	ge-0/0/4	cfInfra,cfSCALE-SLOW,cfSCALE-FAST						POE	// AP
-TRUNK	ge-0/0/5	cfInfra,cfSCALE-SLOW,cfSCALE-FAST						POE	// AP
-TRUNK	ge-0/0/6	cfInfra,cfSCALE-SLOW,cfSCALE-FAST						POE	// AP
-TRUNK	ge-0/0/7	cfInfra,cfSCALE-SLOW,cfSCALE-FAST						POE	// AP
-TRUNK	ge-0/0/8	cfInfra,cfSCALE-SLOW,cfSCALE-FAST						POE	// AP
-TRUNK	ge-0/0/9	cfInfra,cfSCALE-SLOW,cfSCALE-FAST						POE	// AP
-TRUNK	ge-0/0/10	cfInfra,cfSCALE-SLOW,cfSCALE-FAST						POE	// AP
-TRUNK	ge-0/0/11	cfInfra,cfSCALE-SLOW,cfSCALE-FAST						POE	// AP
-TRUNK	ge-0/0/12	cfInfra,cfSCALE-SLOW,cfSCALE-FAST						POE	// AP
-TRUNK	ge-0/0/13	cfInfra,cfSCALE-SLOW,cfSCALE-FAST						POE	// AP
-TRUNK	ge-0/0/14	cfInfra,cfSCALE-SLOW,cfSCALE-FAST						POE	// AP
-TRUNK	ge-0/0/15	cfInfra,cfSCALE-SLOW,cfSCALE-FAST						POE	// AP
-TRUNK	ge-0/0/16	cfInfra,cfSCALE-SLOW,cfSCALE-FAST						POE	// AP
-TRUNK	ge-0/0/17	cfInfra,cfSCALE-SLOW,cfSCALE-FAST						POE	// AP
+TRUNK	ge-0/0/0	cfSCALE-SLOW,cfSCALE-FAST,cfSpeaker,cfInfra,cfAVLAN,cfSigns,HAM_BRIDGE,cfNOC	-	Uplink
+TRUNK	ge-0/0/1	cfSCALE-SLOW,cfSCALE-FAST,cfSpeaker,cfInfra,cfAVLAN,cfSigns,HAM_BRIDGE,cfNOC	-	Downlink
+TRUNK	ge-0/0/2	cfInfra,cfSCALE-SLOW,cfSCALE-FAST						POE	AP
+TRUNK	ge-0/0/3	cfInfra,cfSCALE-SLOW,cfSCALE-FAST						POE	AP
+TRUNK	ge-0/0/4	cfInfra,cfSCALE-SLOW,cfSCALE-FAST						POE	AP
+TRUNK	ge-0/0/5	cfInfra,cfSCALE-SLOW,cfSCALE-FAST						POE	AP
+TRUNK	ge-0/0/6	cfInfra,cfSCALE-SLOW,cfSCALE-FAST						POE	AP
+TRUNK	ge-0/0/7	cfInfra,cfSCALE-SLOW,cfSCALE-FAST						POE	AP
+TRUNK	ge-0/0/8	cfInfra,cfSCALE-SLOW,cfSCALE-FAST						POE	AP
+TRUNK	ge-0/0/9	cfInfra,cfSCALE-SLOW,cfSCALE-FAST						POE	AP
+TRUNK	ge-0/0/10	cfInfra,cfSCALE-SLOW,cfSCALE-FAST						POE	AP
+TRUNK	ge-0/0/11	cfInfra,cfSCALE-SLOW,cfSCALE-FAST						POE	AP
+TRUNK	ge-0/0/12	cfInfra,cfSCALE-SLOW,cfSCALE-FAST						POE	AP
+TRUNK	ge-0/0/13	cfInfra,cfSCALE-SLOW,cfSCALE-FAST						POE	AP
+TRUNK	ge-0/0/14	cfInfra,cfSCALE-SLOW,cfSCALE-FAST						POE	AP
+TRUNK	ge-0/0/15	cfInfra,cfSCALE-SLOW,cfSCALE-FAST						POE	AP
+TRUNK	ge-0/0/16	cfInfra,cfSCALE-SLOW,cfSCALE-FAST						POE	AP
+TRUNK	ge-0/0/17	cfInfra,cfSCALE-SLOW,cfSCALE-FAST						POE	AP
 VLAN	cfSigns		6										POE	// ge-0/0/{18-23}
 VLAN	cfNOC		12										-	// ge-0/0/{24-35}
 VLAN	cfInfra		12										-	// ge-0/0/{36-47}

--- a/switch-configuration/config/types/cfRoom
+++ b/switch-configuration/config/types/cfRoom
@@ -12,7 +12,7 @@ TRUNK	ge-0/0/14	cfInfra,cfSCALE-SLOW,cfSCALE-FAST					POE	// AP
 TRUNK	ge-0/0/15	cfInfra,cfSCALE-SLOW,cfSCALE-FAST					POE	// AP
 TRUNK	ge-0/0/16	cfInfra,cfSCALE-SLOW,cfSCALE-FAST					POE	// AP
 TRUNK	ge-0/0/17	cfInfra,cfSCALE-SLOW,cfSCALE-FAST					POE	// AP
-VLAN	cfSigns		4									-	// ge-0/0/{18-21}
+VLAN	cfSigns		4									POE	// ge-0/0/{18-21}
 VLAN	cfAVLAN		6									POE	// ge-0/0/{22-27}
 VLAN	cfSpeaker	2									-	// ge-0/0/{28,29}
 VLAN	cfCTF		1									-	// ge-0/0/30

--- a/switch-configuration/config/types/cfRoom
+++ b/switch-configuration/config/types/cfRoom
@@ -1,17 +1,17 @@
 // Room Switch Template -- All conference rooms Conference Center
-TRUNK	ge-0/0/0	cfSCALE-SLOW,cfSCALE-FAST,cfSpeaker,cfInfra,cfAVLAN,cfSigns,HAM_BRIDGE	-	// Uplink
-TRUNK	ge-0/0/1	cfSCALE-SLOW,cfSCALE-FAST,cfSpeaker,cfInfra,cfAVLAN,cfSigns,HAM_BRIDGE	-	// Downlink
+TRUNK	ge-0/0/0	cfSCALE-SLOW,cfSCALE-FAST,cfSpeaker,cfInfra,cfAVLAN,cfSigns,HAM_BRIDGE	-	Uplink
+TRUNK	ge-0/0/1	cfSCALE-SLOW,cfSCALE-FAST,cfSpeaker,cfInfra,cfAVLAN,cfSigns,HAM_BRIDGE	-	Downlink
 RSRVD	6
-TRUNK	ge-0/0/8	cfInfra,cfSCALE-SLOW,cfSCALE-FAST					POE	// AP
-TRUNK	ge-0/0/9	cfInfra,cfSCALE-SLOW,cfSCALE-FAST					POE	// AP
-TRUNK	ge-0/0/10	cfInfra,cfSCALE-SLOW,cfSCALE-FAST					POE	// AP
-TRUNK	ge-0/0/11	cfInfra,cfSCALE-SLOW,cfSCALE-FAST					POE	// AP
-TRUNK	ge-0/0/12	cfInfra,cfSCALE-SLOW,cfSCALE-FAST					POE	// AP
-TRUNK	ge-0/0/13	cfInfra,cfSCALE-SLOW,cfSCALE-FAST					POE	// AP
-TRUNK	ge-0/0/14	cfInfra,cfSCALE-SLOW,cfSCALE-FAST					POE	// AP
-TRUNK	ge-0/0/15	cfInfra,cfSCALE-SLOW,cfSCALE-FAST					POE	// AP
-TRUNK	ge-0/0/16	cfInfra,cfSCALE-SLOW,cfSCALE-FAST					POE	// AP
-TRUNK	ge-0/0/17	cfInfra,cfSCALE-SLOW,cfSCALE-FAST					POE	// AP
+TRUNK	ge-0/0/8	cfInfra,cfSCALE-SLOW,cfSCALE-FAST					POE	AP
+TRUNK	ge-0/0/9	cfInfra,cfSCALE-SLOW,cfSCALE-FAST					POE	AP
+TRUNK	ge-0/0/10	cfInfra,cfSCALE-SLOW,cfSCALE-FAST					POE	AP
+TRUNK	ge-0/0/11	cfInfra,cfSCALE-SLOW,cfSCALE-FAST					POE	AP
+TRUNK	ge-0/0/12	cfInfra,cfSCALE-SLOW,cfSCALE-FAST					POE	AP
+TRUNK	ge-0/0/13	cfInfra,cfSCALE-SLOW,cfSCALE-FAST					POE	AP
+TRUNK	ge-0/0/14	cfInfra,cfSCALE-SLOW,cfSCALE-FAST					POE	AP
+TRUNK	ge-0/0/15	cfInfra,cfSCALE-SLOW,cfSCALE-FAST					POE	AP
+TRUNK	ge-0/0/16	cfInfra,cfSCALE-SLOW,cfSCALE-FAST					POE	AP
+TRUNK	ge-0/0/17	cfInfra,cfSCALE-SLOW,cfSCALE-FAST					POE	AP
 VLAN	cfSigns		4									POE	// ge-0/0/{18-21}
 VLAN	cfAVLAN		6									POE	// ge-0/0/{22-27}
 VLAN	cfSpeaker	2									-	// ge-0/0/{28,29}

--- a/switch-configuration/config/types/exIDF
+++ b/switch-configuration/config/types/exIDF
@@ -1,16 +1,16 @@
-// Expo Center IDF Switch Configuration
+// Expo Center IDF(s) Switch Configuration Template
 TRUNK	ge-0/0/0	exSCALE-SLOW,exSCALE-FAST,exSpeaker,exInfra, \
             		exAVLAN, \
-			exSigns,HAM_BRIDGE,exRegistration 			-	// Link to EX Router
+			exSigns,HAM_BRIDGE,exRegistration 			-	// Uplink
 TRUNK	ge-0/0/1	exSCALE-SLOW,exSCALE-FAST,exSpeaker,exInfra, \
             		exAVLAN, \
-			exSigns,HAM_BRIDGE,exRegistration 			-	// Downlink to BallroomF
+			exSigns,HAM_BRIDGE,exRegistration 			-	// Downlink
 TRUNK	ge-0/0/2	exSCALE-SLOW,exSCALE-FAST,exSpeaker,exInfra, \
             		exAVLAN, \
-			exSigns,HAM_BRIDGE,exRegistration 			-	// Downlink to BallroomG
+			exSigns,HAM_BRIDGE,exRegistration 			-	// Downlink
 TRUNK	ge-0/0/3	exSCALE-SLOW,exSCALE-FAST,exSpeaker,exInfra, \
             		exAVLAN, \
-			exSigns,HAM_BRIDGE,exRegistration 			-	// Downlink to BallroomH
+			exSigns,HAM_BRIDGE,exRegistration 			-	// Downlink
 TRUNK	ge-0/0/4	exSCALE-SLOW,exSCALE-FAST,exSpeaker,exInfra, \
             		exAVLAN, \
 			exSigns,HAM_BRIDGE,exRegistration 			-	// Downlink
@@ -83,8 +83,8 @@ TRUNK	ge-0/0/32	exSCALE-SLOW,exSCALE-FAST,exInfra 			POE	// AP
 TRUNK	ge-0/0/33	exSCALE-SLOW,exSCALE-FAST,exInfra 			POE	// AP
 TRUNK	ge-0/0/34	exSCALE-SLOW,exSCALE-FAST,exInfra 			POE	// AP
 TRUNK	ge-0/0/35	exSCALE-SLOW,exSCALE-FAST,exInfra 			POE	// AP
-VLAN	exSigns		4							-	// ge-0/0/{36-39}
+VLAN	exSigns		4							POE	// ge-0/0/{36-39}
 RSRVD	8										// ge-0/0/{40-47}
 FIBER	ge-0/1/0	exSCALE-SLOW,exSCALE-FAST,exSpeaker,exInfra, \
             			exAVLAN, \
-			        exSigns,HAM_BRIDGE,exRegistration // Uplink to ExMDF Switch
+			        exSigns,HAM_BRIDGE,exRegistration // Uplink

--- a/switch-configuration/config/types/exIDF
+++ b/switch-configuration/config/types/exIDF
@@ -1,90 +1,90 @@
 // Expo Center IDF(s) Switch Configuration Template
 TRUNK	ge-0/0/0	exSCALE-SLOW,exSCALE-FAST,exSpeaker,exInfra, \
             		exAVLAN, \
-			exSigns,HAM_BRIDGE,exRegistration 			-	// Uplink
+			exSigns,HAM_BRIDGE,exRegistration 			-	Uplink
 TRUNK	ge-0/0/1	exSCALE-SLOW,exSCALE-FAST,exSpeaker,exInfra, \
             		exAVLAN, \
-			exSigns,HAM_BRIDGE,exRegistration 			-	// Downlink
+			exSigns,HAM_BRIDGE,exRegistration 			-	Downlink
 TRUNK	ge-0/0/2	exSCALE-SLOW,exSCALE-FAST,exSpeaker,exInfra, \
             		exAVLAN, \
-			exSigns,HAM_BRIDGE,exRegistration 			-	// Downlink
+			exSigns,HAM_BRIDGE,exRegistration 			-	Downlink
 TRUNK	ge-0/0/3	exSCALE-SLOW,exSCALE-FAST,exSpeaker,exInfra, \
             		exAVLAN, \
-			exSigns,HAM_BRIDGE,exRegistration 			-	// Downlink
+			exSigns,HAM_BRIDGE,exRegistration 			-	Downlink
 TRUNK	ge-0/0/4	exSCALE-SLOW,exSCALE-FAST,exSpeaker,exInfra, \
             		exAVLAN, \
-			exSigns,HAM_BRIDGE,exRegistration 			-	// Downlink
+			exSigns,HAM_BRIDGE,exRegistration 			-	Downlink
 TRUNK	ge-0/0/5	exSCALE-SLOW,exSCALE-FAST,exSpeaker,exInfra, \
             		exAVLAN, \
-			exSigns,HAM_BRIDGE,exRegistration 			-	// Downlink
+			exSigns,HAM_BRIDGE,exRegistration 			-	Downlink
 TRUNK	ge-0/0/6	exSCALE-SLOW,exSCALE-FAST,exSpeaker,exInfra, \
             		exAVLAN, \
-			exSigns,HAM_BRIDGE,exRegistration 			-	// Downlink
+			exSigns,HAM_BRIDGE,exRegistration 			-	Downlink
 TRUNK	ge-0/0/7	exSCALE-SLOW,exSCALE-FAST,exSpeaker,exInfra, \
             		exAVLAN, \
-			exSigns,HAM_BRIDGE,exRegistration 			-	// Downlink
+			exSigns,HAM_BRIDGE,exRegistration 			-	Downlink
 TRUNK	ge-0/0/8	exSCALE-SLOW,exSCALE-FAST,exSpeaker,exInfra, \
             		exAVLAN, \
-			exSigns,HAM_BRIDGE,exRegistration 			-	// Downlink
+			exSigns,HAM_BRIDGE,exRegistration 			-	Downlink
 TRUNK	ge-0/0/9	exSCALE-SLOW,exSCALE-FAST,exSpeaker,exInfra, \
             		exAVLAN, \
-			exSigns,HAM_BRIDGE,exRegistration 			-	// Downlink
+			exSigns,HAM_BRIDGE,exRegistration 			-	Downlink
 TRUNK	ge-0/0/10	exSCALE-SLOW,exSCALE-FAST,exSpeaker,exInfra, \
             		exAVLAN, \
-			exSigns,HAM_BRIDGE,exRegistration 			-	// Downlink
+			exSigns,HAM_BRIDGE,exRegistration 			-	Downlink
 TRUNK	ge-0/0/11	exSCALE-SLOW,exSCALE-FAST,exSpeaker,exInfra, \
             		exAVLAN, \
-			exSigns,HAM_BRIDGE,exRegistration 			-	// Downlink
+			exSigns,HAM_BRIDGE,exRegistration 			-	Downlink
 TRUNK	ge-0/0/12	exSCALE-SLOW,exSCALE-FAST,exSpeaker,exInfra, \
             		exAVLAN, \
-			exSigns,HAM_BRIDGE,exRegistration 			-	// Downlink
+			exSigns,HAM_BRIDGE,exRegistration 			-	Downlink
 TRUNK	ge-0/0/13	exSCALE-SLOW,exSCALE-FAST,exSpeaker,exInfra, \
             		exAVLAN, \
-			exSigns,HAM_BRIDGE,exRegistration 			-	// Downlink
+			exSigns,HAM_BRIDGE,exRegistration 			-	Downlink
 TRUNK	ge-0/0/14	exSCALE-SLOW,exSCALE-FAST,exSpeaker,exInfra, \
             		exAVLAN, \
-			exSigns,HAM_BRIDGE,exRegistration 			-	// Downlink
+			exSigns,HAM_BRIDGE,exRegistration 			-	Downlink
 TRUNK	ge-0/0/15	exSCALE-SLOW,exSCALE-FAST,exSpeaker,exInfra, \
             		exAVLAN, \
-			exSigns,HAM_BRIDGE,exRegistration 			-	// Downlink
+			exSigns,HAM_BRIDGE,exRegistration 			-	Downlink
 TRUNK	ge-0/0/16	exSCALE-SLOW,exSCALE-FAST,exSpeaker,exInfra, \
             		exAVLAN, \
-			exSigns,HAM_BRIDGE,exRegistration 			-	// Downlink
+			exSigns,HAM_BRIDGE,exRegistration 			-	Downlink
 TRUNK	ge-0/0/17	exSCALE-SLOW,exSCALE-FAST,exSpeaker,exInfra, \
             		exAVLAN, \
-			exSigns,HAM_BRIDGE,exRegistration 			-	// Downlink
+			exSigns,HAM_BRIDGE,exRegistration 			-	Downlink
 TRUNK	ge-0/0/18	exSCALE-SLOW,exSCALE-FAST,exSpeaker,exInfra, \
             		exAVLAN, \
-			exSigns,HAM_BRIDGE,exRegistration 			-	// Downlink
+			exSigns,HAM_BRIDGE,exRegistration 			-	Downlink
 TRUNK	ge-0/0/19	exSCALE-SLOW,exSCALE-FAST,exSpeaker,exInfra, \
             		exAVLAN, \
-			exSigns,HAM_BRIDGE,exRegistration 			-	// Downlink
+			exSigns,HAM_BRIDGE,exRegistration 			-	Downlink
 TRUNK	ge-0/0/20	exSCALE-SLOW,exSCALE-FAST,exSpeaker,exInfra, \
             		exAVLAN, \
-			exSigns,HAM_BRIDGE,exRegistration 			-	// Downlink
+			exSigns,HAM_BRIDGE,exRegistration 			-	Downlink
 TRUNK	ge-0/0/21	exSCALE-SLOW,exSCALE-FAST,exSpeaker,exInfra, \
             		exAVLAN, \
-			exSigns,HAM_BRIDGE,exRegistration 			-	// Downlink
+			exSigns,HAM_BRIDGE,exRegistration 			-	Downlink
 TRUNK	ge-0/0/22	exSCALE-SLOW,exSCALE-FAST,exSpeaker,exInfra, \
             		exAVLAN, \
-			exSigns,HAM_BRIDGE,exRegistration 			-	// Downlink
+			exSigns,HAM_BRIDGE,exRegistration 			-	Downlink
 TRUNK	ge-0/0/23	exSCALE-SLOW,exSCALE-FAST,exSpeaker,exInfra, \
             		exAVLAN, \
-			exSigns,HAM_BRIDGE,exRegistration 			-	// Downlink
-TRUNK	ge-0/0/24	exSCALE-SLOW,exSCALE-FAST,exInfra 			POE	// AP
-TRUNK	ge-0/0/25	exSCALE-SLOW,exSCALE-FAST,exInfra 			POE	// AP
-TRUNK	ge-0/0/26	exSCALE-SLOW,exSCALE-FAST,exInfra 			POE	// AP
-TRUNK	ge-0/0/27	exSCALE-SLOW,exSCALE-FAST,exInfra 			POE	// AP
-TRUNK	ge-0/0/28	exSCALE-SLOW,exSCALE-FAST,exInfra 			POE	// AP
-TRUNK	ge-0/0/29	exSCALE-SLOW,exSCALE-FAST,exInfra 			POE	// AP
-TRUNK	ge-0/0/30	exSCALE-SLOW,exSCALE-FAST,exInfra 			POE	// AP
-TRUNK	ge-0/0/31	exSCALE-SLOW,exSCALE-FAST,exInfra 			POE	// AP
-TRUNK	ge-0/0/32	exSCALE-SLOW,exSCALE-FAST,exInfra 			POE	// AP
-TRUNK	ge-0/0/33	exSCALE-SLOW,exSCALE-FAST,exInfra 			POE	// AP
-TRUNK	ge-0/0/34	exSCALE-SLOW,exSCALE-FAST,exInfra 			POE	// AP
-TRUNK	ge-0/0/35	exSCALE-SLOW,exSCALE-FAST,exInfra 			POE	// AP
+			exSigns,HAM_BRIDGE,exRegistration 			-	Downlink
+TRUNK	ge-0/0/24	exSCALE-SLOW,exSCALE-FAST,exInfra 			POE	AP
+TRUNK	ge-0/0/25	exSCALE-SLOW,exSCALE-FAST,exInfra 			POE	AP
+TRUNK	ge-0/0/26	exSCALE-SLOW,exSCALE-FAST,exInfra 			POE	AP
+TRUNK	ge-0/0/27	exSCALE-SLOW,exSCALE-FAST,exInfra 			POE	AP
+TRUNK	ge-0/0/28	exSCALE-SLOW,exSCALE-FAST,exInfra 			POE	AP
+TRUNK	ge-0/0/29	exSCALE-SLOW,exSCALE-FAST,exInfra 			POE	AP
+TRUNK	ge-0/0/30	exSCALE-SLOW,exSCALE-FAST,exInfra 			POE	AP
+TRUNK	ge-0/0/31	exSCALE-SLOW,exSCALE-FAST,exInfra 			POE	AP
+TRUNK	ge-0/0/32	exSCALE-SLOW,exSCALE-FAST,exInfra 			POE	AP
+TRUNK	ge-0/0/33	exSCALE-SLOW,exSCALE-FAST,exInfra 			POE	AP
+TRUNK	ge-0/0/34	exSCALE-SLOW,exSCALE-FAST,exInfra 			POE	AP
+TRUNK	ge-0/0/35	exSCALE-SLOW,exSCALE-FAST,exInfra 			POE	AP
 VLAN	exSigns		4							POE	// ge-0/0/{36-39}
 RSRVD	8										// ge-0/0/{40-47}
 FIBER	ge-0/1/0	exSCALE-SLOW,exSCALE-FAST,exSpeaker,exInfra, \
             			exAVLAN, \
-			        exSigns,HAM_BRIDGE,exRegistration // Uplink
+			        exSigns,HAM_BRIDGE,exRegistration Uplink

--- a/switch-configuration/config/types/exRoom
+++ b/switch-configuration/config/types/exRoom
@@ -12,7 +12,7 @@ TRUNK	ge-0/0/14	exInfra,exSCALE-SLOW,exSCALE-FAST					POE	// AP
 TRUNK	ge-0/0/15	exInfra,exSCALE-SLOW,exSCALE-FAST					POE	// AP
 TRUNK	ge-0/0/16	exInfra,exSCALE-SLOW,exSCALE-FAST					POE	// AP
 TRUNK	ge-0/0/17	exInfra,exSCALE-SLOW,exSCALE-FAST					POE	// AP
-VLAN	exSigns		4									-	// ge-0/0/{18-21}
+VLAN	exSigns		4									POE	// ge-0/0/{18-21}
 VLAN	exAVLAN		6									POE	// ge-0/0/{22-27}
 VLAN	exSpeaker	2									-	// ge-0/0/{28,29}
 RSRVD	18

--- a/switch-configuration/config/types/exRoom
+++ b/switch-configuration/config/types/exRoom
@@ -1,17 +1,17 @@
 // Room Switch Template -- All conference rooms Expo Center
-TRUNK	ge-0/0/0	exSCALE-SLOW,exSCALE-FAST,exSpeaker,exInfra,exAVLAN,exSigns		-	// Uplink
-TRUNK	ge-0/0/1	exSCALE-SLOW,exSCALE-FAST,exSpeaker,exInfra,exAVLAN,exSigns		-	// Downlink
+TRUNK	ge-0/0/0	exSCALE-SLOW,exSCALE-FAST,exSpeaker,exInfra,exAVLAN,exSigns		-	Uplink
+TRUNK	ge-0/0/1	exSCALE-SLOW,exSCALE-FAST,exSpeaker,exInfra,exAVLAN,exSigns		-	Downlink
 RSRVD	6
-TRUNK	ge-0/0/8	exInfra,exSCALE-SLOW,exSCALE-FAST					POE	// AP
-TRUNK	ge-0/0/9	exInfra,exSCALE-SLOW,exSCALE-FAST					POE	// AP
-TRUNK	ge-0/0/10	exInfra,exSCALE-SLOW,exSCALE-FAST					POE	// AP
-TRUNK	ge-0/0/11	exInfra,exSCALE-SLOW,exSCALE-FAST					POE	// AP
-TRUNK	ge-0/0/12	exInfra,exSCALE-SLOW,exSCALE-FAST					POE	// AP
-TRUNK	ge-0/0/13	exInfra,exSCALE-SLOW,exSCALE-FAST					POE	// AP
-TRUNK	ge-0/0/14	exInfra,exSCALE-SLOW,exSCALE-FAST					POE	// AP
-TRUNK	ge-0/0/15	exInfra,exSCALE-SLOW,exSCALE-FAST					POE	// AP
-TRUNK	ge-0/0/16	exInfra,exSCALE-SLOW,exSCALE-FAST					POE	// AP
-TRUNK	ge-0/0/17	exInfra,exSCALE-SLOW,exSCALE-FAST					POE	// AP
+TRUNK	ge-0/0/8	exInfra,exSCALE-SLOW,exSCALE-FAST					POE	AP
+TRUNK	ge-0/0/9	exInfra,exSCALE-SLOW,exSCALE-FAST					POE	AP
+TRUNK	ge-0/0/10	exInfra,exSCALE-SLOW,exSCALE-FAST					POE	AP
+TRUNK	ge-0/0/11	exInfra,exSCALE-SLOW,exSCALE-FAST					POE	AP
+TRUNK	ge-0/0/12	exInfra,exSCALE-SLOW,exSCALE-FAST					POE	AP
+TRUNK	ge-0/0/13	exInfra,exSCALE-SLOW,exSCALE-FAST					POE	AP
+TRUNK	ge-0/0/14	exInfra,exSCALE-SLOW,exSCALE-FAST					POE	AP
+TRUNK	ge-0/0/15	exInfra,exSCALE-SLOW,exSCALE-FAST					POE	AP
+TRUNK	ge-0/0/16	exInfra,exSCALE-SLOW,exSCALE-FAST					POE	AP
+TRUNK	ge-0/0/17	exInfra,exSCALE-SLOW,exSCALE-FAST					POE	AP
 VLAN	exSigns		4									POE	// ge-0/0/{18-21}
 VLAN	exAVLAN		6									POE	// ge-0/0/{22-27}
 VLAN	exSpeaker	2									-	// ge-0/0/{28,29}

--- a/switch-configuration/config/types/registration
+++ b/switch-configuration/config/types/registration
@@ -1,6 +1,6 @@
 // Registration Desk Switch Template
-TRUNK	ge-0/0/0	exSCALE-SLOW,exSCALE-FAST,exSpeaker,exInfra,exAVLAN,exSigns,exRegistration	-
-TRUNK	ge-0/0/1	exSCALE-SLOW,exSCALE-FAST,exSpeaker,exInfra,exAVLAN,exSigns,exRegistration	-
+TRUNK	ge-0/0/0	exSCALE-SLOW,exSCALE-FAST,exSpeaker,exInfra,exAVLAN,exSigns,exRegistration	-	// Uplink
+TRUNK	ge-0/0/1	exSCALE-SLOW,exSCALE-FAST,exSpeaker,exInfra,exAVLAN,exSigns,exRegistration	-	// Downlink
 RSRVD	6
 TRUNK	ge-0/0/8	exInfra,exSCALE-SLOW,exSCALE-FAST						POE	// AP
 TRUNK	ge-0/0/9	exInfra,exSCALE-SLOW,exSCALE-FAST						POE	// AP
@@ -10,9 +10,9 @@ TRUNK	ge-0/0/12	exInfra,exSCALE-SLOW,exSCALE-FAST						POE	// AP
 TRUNK	ge-0/0/13	exInfra,exSCALE-SLOW,exSCALE-FAST						POE	// AP
 TRUNK	ge-0/0/14	exInfra,exSCALE-SLOW,exSCALE-FAST						POE	// AP
 TRUNK	ge-0/0/15	exInfra,exSCALE-SLOW,exSCALE-FAST						POE	// AP
-VLAN	exSigns		2										-	//ge-0/0/{16,17}
+VLAN	exSigns		2										POE	//ge-0/0/{16,17}
 RSRVD	2
-VLAN	exRegistration	20										-	//ge-0/0/20 thru ge-0/0/39
+VLAN	exRegistration	20										POE	//ge-0/0/20 thru ge-0/0/39
 RSRVD	7                   //ge-0/0/{40-46}
 VLAN	exInfra		1           									-	//ge-0/0/47
 

--- a/switch-configuration/config/types/registration
+++ b/switch-configuration/config/types/registration
@@ -1,15 +1,15 @@
 // Registration Desk Switch Template
-TRUNK	ge-0/0/0	exSCALE-SLOW,exSCALE-FAST,exSpeaker,exInfra,exAVLAN,exSigns,exRegistration	-	// Uplink
-TRUNK	ge-0/0/1	exSCALE-SLOW,exSCALE-FAST,exSpeaker,exInfra,exAVLAN,exSigns,exRegistration	-	// Downlink
+TRUNK	ge-0/0/0	exSCALE-SLOW,exSCALE-FAST,exSpeaker,exInfra,exAVLAN,exSigns,exRegistration	-	Uplink
+TRUNK	ge-0/0/1	exSCALE-SLOW,exSCALE-FAST,exSpeaker,exInfra,exAVLAN,exSigns,exRegistration	-	Downlink
 RSRVD	6
-TRUNK	ge-0/0/8	exInfra,exSCALE-SLOW,exSCALE-FAST						POE	// AP
-TRUNK	ge-0/0/9	exInfra,exSCALE-SLOW,exSCALE-FAST						POE	// AP
-TRUNK	ge-0/0/10	exInfra,exSCALE-SLOW,exSCALE-FAST						POE	// AP
-TRUNK	ge-0/0/11	exInfra,exSCALE-SLOW,exSCALE-FAST						POE	// AP
-TRUNK	ge-0/0/12	exInfra,exSCALE-SLOW,exSCALE-FAST						POE	// AP
-TRUNK	ge-0/0/13	exInfra,exSCALE-SLOW,exSCALE-FAST						POE	// AP
-TRUNK	ge-0/0/14	exInfra,exSCALE-SLOW,exSCALE-FAST						POE	// AP
-TRUNK	ge-0/0/15	exInfra,exSCALE-SLOW,exSCALE-FAST						POE	// AP
+TRUNK	ge-0/0/8	exInfra,exSCALE-SLOW,exSCALE-FAST						POE	AP
+TRUNK	ge-0/0/9	exInfra,exSCALE-SLOW,exSCALE-FAST						POE	AP
+TRUNK	ge-0/0/10	exInfra,exSCALE-SLOW,exSCALE-FAST						POE	AP
+TRUNK	ge-0/0/11	exInfra,exSCALE-SLOW,exSCALE-FAST						POE	AP
+TRUNK	ge-0/0/12	exInfra,exSCALE-SLOW,exSCALE-FAST						POE	AP
+TRUNK	ge-0/0/13	exInfra,exSCALE-SLOW,exSCALE-FAST						POE	AP
+TRUNK	ge-0/0/14	exInfra,exSCALE-SLOW,exSCALE-FAST						POE	AP
+TRUNK	ge-0/0/15	exInfra,exSCALE-SLOW,exSCALE-FAST						POE	AP
 VLAN	exSigns		2										POE	//ge-0/0/{16,17}
 RSRVD	2
 VLAN	exRegistration	20										POE	//ge-0/0/20 thru ge-0/0/39


### PR DESCRIPTION
## Description of PR
Many improvements to sticker generation process and some fixes to types files

## Previous Behavior
All trunks were same color.
Trunktypes field didn't exist in types files.
Did not automatically generate PDFs from PS files.
Makefile contained obsolete targets.

## New Behavior
Improved Makefile
Color coded different trunks by type.
Changed trunk label from TRUNK to trunk type.
Makefile now autogenerates PDFs from generated PS.
Eliminated obsolete "bundle" target for PS from Makefile.

## Tests
Generated sticker and refs PDF files viewed in Apple Preview (PDF viewer)
Output loosely validated by a pair of Mark 1 eyeballs as input devices to a Mark 1 HumanBrain.
HumanBrain output: "Looks about right."
