### PR TITLE
[READY] - massflash routing table fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@ switch-configuration/config/switch-maps
 # Ignore nix-isms
 result
 **/*.qcow2
+**/*.nixos-test-history
 
 # Created by https://www.gitignore.io/api/osx,vim,emacs,windows,libreoffice,sublimetext
 

--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ switch-configuration/config/switch-maps
 
 # Ignore nix-isms
 result
+**/*.qcow2
 
 # Created by https://www.gitignore.io/api/osx,vim,emacs,windows,libreoffice,sublimetext
 

--- a/nix/machines/massflash.nix
+++ b/nix/machines/massflash.nix
@@ -61,7 +61,6 @@ in
 
         [Network]
         Address=192.168.252.1/22
-        Gateway=192.168.252.1
       '';
       flash1.extraConfig = ''
         [Match]

--- a/openwrt/docs/MASSFLASH.md
+++ b/openwrt/docs/MASSFLASH.md
@@ -27,9 +27,9 @@ Setup wifi:
 
 Add wireless config directly to `/var/run/wpa_supplicant/wpa_supplicant.conf`
 ```
-network = {
+network={
   ssid="<name>"
-  psk="<password">
+  psk="<password>"
 }
 ```
 
@@ -66,8 +66,6 @@ wndr3800ch/flash.bin
 arg: lease4_renew
 env: QUERY4_TYPE, LEASE4_ADDRESS, LEASE4_HWADDR
 ```
-
-- Hardcoded paths. These will get cleaned up in followups to the repo. Right now they will be left in for as references.
 
 ## Running oneoff
 


### PR DESCRIPTION
## Description of PR

Fixes: #587

Routing table shouldnt set the default route to the massflash vlan. Prior to this we would have to run the following after the massflash laptop joined a wifi network to get out to the internet:

```
ip route del default via 192.168.252.1
```

## Previous Behavior
- Explicitly setting `massflash` vlan as default route

## New Behavior
- Omit any default route for the `massflash` vlan
- update docs for massflash since there were formatting errors
- .gitignores for some of the nixosTest vm images and history

## Tests
- `nix build .#nixosConfigurations.massflash.config.system.build.isoImage` and added massflash to wifi network and it was able to reach the internet without having to remove the default route
