### PR TITLE
[READY] - massflash includes common utils

### DIFF
--- a/nix/machines/flake-module.nix
+++ b/nix/machines/flake-module.nix
@@ -61,6 +61,8 @@ in
               "${ toString modulesPath}/installer/cd-dvd/installation-cd-minimal.nix"
             ];
           })
+          ./_common/base.nix
+          ./_common/users.nix
           ./massflash.nix
         ];
         specialArgs = { inherit inputs; };

--- a/nix/machines/massflash.nix
+++ b/nix/machines/massflash.nix
@@ -8,9 +8,6 @@ let
     '';
 in
 {
-  # If not present then warning and will be set to latest release during build
-  system.stateVersion = "22.11";
-
   fileSystems."/" = {
     device = "/dev/disk/by-label/nixos";
     fsType = "ext4";
@@ -92,17 +89,10 @@ in
   };
 
   # root user doesnt need credentials for massflash liveCD
-  users.extraUsers.root.password = "";
+  users.extraUsers.root.password = lib.mkForce "";
 
-  # TODO: Consume users from facts/keys instead of single key
-  users.users = {
-    rherna = {
-      isNormalUser = true;
-      uid = 2005;
-      extraGroups = [ "wheel" ];
-      openssh.authorizedKeys.keys = [ "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIMEiESod7DOT2cmT2QEYjBIrzYqTDnJLld1em3doDROq" ];
-    };
-  };
+  # we set the hashedPassword in _common so just ensure that this is actually null
+  users.extraUsers.root.hashedPassword = lib.mkForce null;
 
   security.sudo.wheelNeedsPassword = false;
 


### PR DESCRIPTION
## Description of PR

Relates to: #587

Figured it would be a good idea to include the common utilities in our massflash livecd.

## Previous Behavior
- Basic utils were only included in `massflash` livecd

## New Behavior
- `massflash` has all our utilies from `base.nix`

## Tests

- Built livecd and tested on lenovo laptop
