### PR TITLE
[READY] - switch_pinger: leverage linux ping binary

### DIFF
--- a/switch-configuration/config/scripts/switch_pinger
+++ b/switch-configuration/config/scripts/switch_pinger
@@ -83,7 +83,7 @@ foreach(sort(keys(%Hierarchy)))
             }
             else
             {
-                $r = system('ping6 -c 1 -W 1 -n -q '.${$sw}[1].' >&/dev/null');
+                $r = system('ping -c 1 -W 1 -n -q '.${$sw}[1].' >&/dev/null');
             }
             if ($r == -1)
             {


### PR DESCRIPTION
## Description of PR

`ping` binary for linux so switch_pinger and related flags work as expected.

Also on `NixOS` it seems that `ping6` needs root permissions, more to see here: https://github.com/NixOS/nixpkgs/issues/85345
## Previous Behavior
- `ping6` binary for switch_pinger

## New Behavior
- `ping` binary for switch_pinger

## Tests

- Testing on my nixos laptop
