### PR TITLE
[READY] - hypervisor and core bits

### DIFF
--- a/facts/inventory.py
+++ b/facts/inventory.py
@@ -506,7 +506,8 @@ def generatekeaconfig(servers, aps, vlans, outputdir):
             "max-valid-lifetime": 1440,
             # Next we set up the interfaces to be used by the server.
             "interfaces-config": {
-                "interfaces": ["*"],
+                # TODO: Better definition of for populating this
+                "interfaces": ["@@INTERFACE@@", "@@INTERFACE@@/@@SERVERADDRESS@@"],
                 "service-sockets-max-retries": 5,
                 "service-sockets-retry-wait-time": 5000
             },
@@ -609,7 +610,7 @@ def generatekeaconfig(servers, aps, vlans, outputdir):
                 # TODO: we should figure out a better way of dynamically allocating this config of the
                 # interface so is not hardcoded
                 # https://kea.readthedocs.io/en/kea-2.2.0/arm/dhcp6-srv.html#ipv6-subnet-selection
-                subnet["interface"] = "eth0"
+                subnet["interface"] = "@@INTERFACE@@"
             subnets6_dict.append(subnet)
 
     keav6_config["Dhcp6"]["subnet6"] = subnets6_dict

--- a/facts/servers/serverlist.csv
+++ b/facts/servers/serverlist.csv
@@ -2,9 +2,7 @@ name,mac-address,ipv6,ipv4,role
 coreexpo,58:9c:fc:00:38:5f,2001:470:f026:103::5,10.0.3.5,core
 coreconf,4c:72:b9:7c:41:17,2001:470:f026:503::5,10.128.3.5,core
 monitoring1,58:9c:fc:0a:a8:f3,2001:470:f026:503::6,10.128.3.6,monitoring
-automation1,58:9c:fc:05:4a:f9,2001:470:f026:103::7,10.0.3.7,automation
 hypervisorexpo,0c:c4:7a:d9:51:a6,2001:470:f026:103::20,10.0.3.20,bhyve
 hypervisorconf,62:96:b1:59:b8:9a,2001:470:f026:503::20,10.128.3.20,bhyve
 tftp,58:9c:fc:0e:cb:90,2001:470:f026:503::10,10.128.3.10,bhyve
 signs,58:9c:fc:06:1c:79,2001:470:f026:503::11,10.128.3.11,sign
-monitoring2,58:9c:fc:06:1c:79,2001:470:f026:503::12,10.128.3.12,monitor

--- a/facts/servers/serverlist.csv
+++ b/facts/servers/serverlist.csv
@@ -3,8 +3,8 @@ coreexpo,58:9c:fc:00:38:5f,2001:470:f026:103::5,10.0.3.5,core
 coreconf,4c:72:b9:7c:41:17,2001:470:f026:503::5,10.128.3.5,core
 monitoring1,58:9c:fc:0a:a8:f3,2001:470:f026:503::6,10.128.3.6,monitoring
 automation1,58:9c:fc:05:4a:f9,2001:470:f026:103::7,10.0.3.7,automation
-bhyveexpo,0c:c4:7a:d9:51:a6,2001:470:f026:103::20,10.0.3.20,bhyve
-bhyveconf,02:d7:ea:6f:f5:0b,2001:470:f026:503::20,10.128.3.20,bhyve
+hypervisorexpo,0c:c4:7a:d9:51:a6,2001:470:f026:103::20,10.0.3.20,bhyve
+hypervisorconf,62:96:b1:59:b8:9a,2001:470:f026:503::20,10.128.3.20,bhyve
 tftp,58:9c:fc:0e:cb:90,2001:470:f026:503::10,10.128.3.10,bhyve
 signs,58:9c:fc:06:1c:79,2001:470:f026:503::11,10.128.3.11,sign
 monitoring2,58:9c:fc:06:1c:79,2001:470:f026:503::12,10.128.3.12,monitor

--- a/facts/servers/serverlist.csv
+++ b/facts/servers/serverlist.csv
@@ -2,7 +2,7 @@ name,mac-address,ipv6,ipv4,role
 coreexpo,58:9c:fc:00:38:5f,2001:470:f026:103::5,10.0.3.5,core
 coreconf,4c:72:b9:7c:41:17,2001:470:f026:503::5,10.128.3.5,core
 monitoring1,58:9c:fc:0a:a8:f3,2001:470:f026:503::6,10.128.3.6,monitoring
-hypervisorexpo,0c:c4:7a:d9:51:a6,2001:470:f026:103::20,10.0.3.20,bhyve
+hypervisorexpo,ea:51:b9:70:f0:58,2001:470:f026:103::20,10.0.3.20,bhyve
 hypervisorconf,62:96:b1:59:b8:9a,2001:470:f026:503::20,10.128.3.20,bhyve
 tftp,58:9c:fc:0e:cb:90,2001:470:f026:503::10,10.128.3.10,bhyve
 signs,58:9c:fc:06:1c:79,2001:470:f026:503::11,10.128.3.11,sign

--- a/nix/machines/_common/ssh/vm.nix
+++ b/nix/machines/_common/ssh/vm.nix
@@ -1,0 +1,21 @@
+{
+  services.openssh = {
+    enable = true;
+    hostKeys = [
+      {
+        path = "/var/lib/ssh/ssh_host_ed25519_key";
+        type = "ed25519";
+      }
+      {
+        path = "/var/lib/ssh/ssh_host_rsa_key";
+        type = "rsa";
+        bits = 4096;
+      }
+    ];
+    settings = {
+      PermitRootLogin = "no";
+      PasswordAuthentication = false;
+      KbdInteractiveAuthentication = false;
+    };
+  };
+}

--- a/nix/machines/core/common.nix
+++ b/nix/machines/core/common.nix
@@ -40,9 +40,6 @@
 
   services = {
     resolved.enable = false;
-    openssh = {
-      enable = true;
-    };
     kea = {
       dhcp4 = {
         enable = true;

--- a/nix/machines/core/common.nix
+++ b/nix/machines/core/common.nix
@@ -45,10 +45,22 @@
         enable = true;
         configFile = "${inputs.self.packages.${pkgs.system}.scaleInventory}/config/dhcp4-server.conf";
       };
-      dhcp6 = {
-        enable = true;
-        configFile = "${inputs.self.packages.${pkgs.system}.scaleInventory}/config/dhcp6-server.conf";
-      };
+      dhcp6 =
+        let
+          dhcp6PopulateConfig = pkgs.runCommand "replace" {} ''
+            mkdir $out
+            cp ${inputs.self.packages.${pkgs.system}.scaleInventory}/config/dhcp6-server.conf $TMP/dhcp6-server.conf
+            substituteInPlace "$TMP/dhcp6-server.conf" \
+              --replace '@@SERVERADDRESS@@' '${builtins.head (lib.splitString "/" config.facts.ipv6)}' \
+              --replace '@@INTERFACE@@' '${config.facts.eth}'
+            cp $TMP/dhcp6-server.conf $out
+          '';
+
+        in
+        {
+          enable = true;
+          configFile = "${dhcp6PopulateConfig}/dhcp6-server.conf";
+        };
     };
     ntp = {
       enable = true;

--- a/nix/machines/core/master.nix
+++ b/nix/machines/core/master.nix
@@ -9,6 +9,12 @@ in
       ./common.nix
     ];
 
+  facts = {
+    ipv4 = "10.128.3.5/24";
+    ipv6 = "2001:470:f026:503::5/64";
+    eth  = "eth0";
+  };
+
   networking.hostName = "coremaster";
 
   # disable legacy networking bits as recommended by:
@@ -29,7 +35,7 @@ in
         # to match enp0 or eth0
         name = "e*0*";
         enable = true;
-        address = [ "10.128.3.5/24" "2001:470:f026:503::5/64" ];
+        address = [ config.facts.ipv4 config.facts.ipv6 ];
         routes = [
           { routeConfig.Gateway = "10.128.3.1"; }
           { routeConfig.Gateway = "2001:470:f026:503::1"; }
@@ -47,7 +53,7 @@ in
         {
           "scale.lan." = {
             master = true;
-            slaves = [ "2001:470:f026:503::5" ];
+            slaves = [ "2001:470:f026:103::5" ];
             file = pkgs.writeText "named.scale.lan" (lib.strings.concatStrings [
               ''
                 $ORIGIN scale.lan.
@@ -67,7 +73,7 @@ in
           };
           "10.in-addr.arpa." = {
             master = true;
-            slaves = [ "2001:470:f026:503::5" ];
+            slaves = [ "2001:470:f026:103::5" ];
             file = pkgs.writeText "named-10.rev" (lib.strings.concatStrings [
               ''
                 $ORIGIN 10.in-addr.arpa.

--- a/nix/machines/core/master.nix
+++ b/nix/machines/core/master.nix
@@ -30,7 +30,10 @@ in
         name = "e*0*";
         enable = true;
         address = [ "10.128.3.5/24" "2001:470:f026:503::5/64" ];
-        gateway = [ "10.128.3.1" ];
+        routes = [
+          { routeConfig.Gateway = "10.128.3.1"; }
+          { routeConfig.Gateway = "2001:470:f026:503::1"; }
+        ];
       };
     };
   };

--- a/nix/machines/core/master.nix
+++ b/nix/machines/core/master.nix
@@ -94,7 +94,7 @@ in
           # 2001:470:f026::
           "6.2.0.f.0.7.4.0.1.0.0.2.ip6.arpa." = {
             master = true;
-            slaves = [ "2001:470:f026:503::5" ];
+            slaves = [ "2001:470:f026:103::5" ];
             file = pkgs.writeText "named-2001.470.f026-48.rev" (lib.strings.concatStrings [
               ''
                 $ORIGIN 6.2.0.f.0.7.4.0.1.0.0.2.ip6.arpa.

--- a/nix/machines/core/master.nix
+++ b/nix/machines/core/master.nix
@@ -16,7 +16,7 @@ in
   #  https://github.com/NixOS/nixpkgs/blob/82935bfed15d680aa66d9020d4fe5c4e8dc09123/nixos/tests/systemd-networkd-dhcpserver.nix
   networking = {
     extraHosts = ''
-      10.0.3.5 coreexpo.scale.lan
+      10.128.3.5 coreconf.scale.lan
     '';
   };
 
@@ -29,8 +29,8 @@ in
         # to match enp0 or eth0
         name = "e*0*";
         enable = true;
-        address = [ "10.0.3.5/24" "2001:470:f026:103::5/64" ];
-        gateway = [ "10.0.3.1" ];
+        address = [ "10.128.3.5/24" "2001:470:f026:503::5/64" ];
+        gateway = [ "10.128.3.1" ];
       };
     };
   };

--- a/nix/machines/core/microvm-config.nix
+++ b/nix/machines/core/microvm-config.nix
@@ -13,7 +13,7 @@
       type = "tap";
       id = "vm-${config.networking.hostName}";
       # Will eventually pull this from facts
-      mac =  if config.networking.hostName == "coremaster" then "58:9c:fc:00:38:5f" else "4c:72:b9:7c:41:17";
+      mac =  if config.networking.hostName == "coremaster" then "4c:72:b9:7c:41:17" else "58:9c:fc:00:38:5f";
     }
   ];
 

--- a/nix/machines/core/slave.nix
+++ b/nix/machines/core/slave.nix
@@ -20,7 +20,7 @@
     enable = true;
     networks = {
       "10-lan" = {
-        name = "enp0*";
+        name = "e*0";
         enable = true;
         address = [ "10.0.3.5/24" "2001:470:f026:103::5/64" ];
         routes = [

--- a/nix/machines/core/slave.nix
+++ b/nix/machines/core/slave.nix
@@ -41,6 +41,9 @@
       enable = true;
       cacheNetworks = [ "::1/128" "127.0.0.0/8" "2001:470:f026::/48" "10.0.0.0/8" ];
       forwarders = [ "8.8.8.8" "8.8.4.4" ];
+      extraOptions = ''
+         transfer-source-v6 ${builtins.head (lib.splitString "/" config.facts.ipv6)};
+      '';
       zones =
         {
           "scale.lan." = {

--- a/nix/machines/core/slave.nix
+++ b/nix/machines/core/slave.nix
@@ -5,6 +5,11 @@
     [
       ./common.nix
     ];
+  facts = {
+    ipv4 = "10.0.3.5/24";
+    ipv6 = "2001:470:f026:103::5/64";
+    eth = "eth0";
+  };
 
   networking.hostName = "coreslave";
 
@@ -22,7 +27,7 @@
       "10-lan" = {
         name = "e*0";
         enable = true;
-        address = [ "10.0.3.5/24" "2001:470:f026:103::5/64" ];
+        address = [ config.facts.ipv4 config.facts.ipv6 ];
         routes = [
           { routeConfig.Gateway = "10.0.3.1"; }
           { routeConfig.Gateway = "2001:470:f026:103::1"; }

--- a/nix/machines/core/slave.nix
+++ b/nix/machines/core/slave.nix
@@ -10,7 +10,7 @@
 
   networking = {
     extraHosts = ''
-      10.128.3.5 coreconf.scale.lan
+      10.0.3.5 coreexpo.scale.lan
     '';
   };
 
@@ -22,8 +22,8 @@
       "10-lan" = {
         name = "enp0*";
         enable = true;
-        address = [ "10.128.3.5/24" "2001:470:f026:503::5/64" ];
-        gateway = [ "10.128.3.1" ];
+        address = [ "10.0.3.5/24" "2001:470:f026:103::5/64" ];
+        gateway = [ "10.0.3.1" ];
         # TODO: Causes double entry of [Network] in .network file
         # Need to look into unifying into one block
         extraConfig = ''
@@ -46,18 +46,18 @@
         {
           "scale.lan." = {
             master = false;
-            masters = [ "2001:470:f026:103::5" ];
+            masters = [ "2001:470:f026:503::5" ];
             file = "/var/run/named/sec-scale.lan";
           };
           "10.in-addr.arpa." = {
             master = false;
-            masters = [ "2001:470:f026:103::5" ];
+            masters = [ "2001:470:f026:503::5" ];
             file = "/var/run/named/sec-10.rev";
           };
           # 2001:470:f026::
           "6.2.0.f.0.7.4.0.1.0.0.2.ip6.arpa." = {
             master = false;
-            masters = [ "2001:470:f026:103::5" ];
+            masters = [ "2001:470:f026:503::5" ];
             file = "/var/run/named/sec-2001.470.f026-48.rev";
           };
         };

--- a/nix/machines/core/slave.nix
+++ b/nix/machines/core/slave.nix
@@ -23,16 +23,10 @@
         name = "enp0*";
         enable = true;
         address = [ "10.0.3.5/24" "2001:470:f026:103::5/64" ];
-        gateway = [ "10.0.3.1" ];
-        # TODO: Causes double entry of [Network] in .network file
-        # Need to look into unifying into one block
-        extraConfig = ''
-          [Network]
-          IPv6Token=static:::5
-          LLDP=true
-          EmitLLDP=true;
-          IPv6PrivacyExtensions=false
-        '';
+        routes = [
+          { routeConfig.Gateway = "10.0.3.1"; }
+          { routeConfig.Gateway = "2001:470:f026:103::1"; }
+        ];
       };
     };
   };

--- a/nix/machines/flake-module.nix
+++ b/nix/machines/flake-module.nix
@@ -6,6 +6,7 @@ let
   common = {
     imports = [
       inputs.microvm.nixosModules.microvm
+      inputs.self.nixosModules.facts
       ./_common
       ./_common/time.nix
       ./_common/ssh/vm.nix

--- a/nix/machines/flake-module.nix
+++ b/nix/machines/flake-module.nix
@@ -86,6 +86,16 @@ in
         ];
         specialArgs = { inherit inputs; };
       };
+      hypervisor1 = lib.nixosSystem {
+        inherit system;
+        modules = [
+          ./_common
+          inputs.microvm.nixosModules.host
+          ./hypervisor/hypervisor1.nix
+          ./hypervisor/hardware-configuration.nix
+        ];
+        specialArgs = { inherit inputs; };
+      };
       hypervisor2 = lib.nixosSystem {
         inherit system;
         modules = [

--- a/nix/machines/flake-module.nix
+++ b/nix/machines/flake-module.nix
@@ -8,6 +8,7 @@ let
       inputs.microvm.nixosModules.microvm
       ./_common
       ./_common/time.nix
+      ./_common/ssh/vm.nix
     ];
   };
 in

--- a/nix/machines/hypervisor/hypervisor1.nix
+++ b/nix/machines/hypervisor/hypervisor1.nix
@@ -1,0 +1,59 @@
+{ config, pkgs, lib, ... }:
+{
+
+  # ZFS uniq system ID
+  # to generate: head -c4 /dev/urandom | od -A none -t x4
+  networking.hostId = "25c531dc";
+
+  networking = {
+    # use systemd.networkd
+    useNetworkd = true;
+    useDHCP = false;
+    firewall.enable = true;
+  };
+
+  systemd.network = {
+    enable = true;
+    netdevs.virbr0.netdevConfig = {
+      Kind = "bridge";
+      Name = "virbr0";
+    };
+
+    networks = {
+      "1-virbr0" = {
+        matchConfig.Name = "virbr0";
+        enable = true;
+        address = [ "10.128.3.20/24" "2001:470:f026:503::20/64" ];
+        routes = [
+          { routeConfig.Gateway = "10.128.3.1"; }
+          { routeConfig.Gateway = "2001:470:f026:503::1"; }
+        ];
+      };
+      "20-microvm-eth0" = {
+        matchConfig.Name = "vm-*";
+        networkConfig.Bridge = "virbr0";
+      };
+      "10-lan-eno2" = {
+        matchConfig.Name = "eno2";
+        networkConfig.Bridge = "virbr0";
+      };
+      # Keep this for troubleshooting
+      "10-lan" = {
+        matchConfig.Name = "eno1";
+        enable = true;
+        networkConfig.DHCP = "yes";
+      };
+    };
+  };
+
+  systemd.services.systemd-networkd-wait-online.enable = lib.mkForce false;
+
+  environment.systemPackages = with pkgs; [
+    tio
+  ];
+
+  services.openssh = {
+    enable = true;
+    openFirewall = true;
+  };
+}

--- a/nix/machines/hypervisor/hypervisor1.nix
+++ b/nix/machines/hypervisor/hypervisor1.nix
@@ -66,6 +66,7 @@
   microvm.autostart = [
     "coreMaster"
     "monitor"
+    "signs"
   ];
 
   services.openssh = {

--- a/nix/machines/hypervisor/hypervisor1.nix
+++ b/nix/machines/hypervisor/hypervisor1.nix
@@ -56,6 +56,10 @@
     tio
   ];
 
+  microvm.autostart = [
+    "coreMaster"
+  ];
+
   services.openssh = {
     enable = true;
     openFirewall = true;

--- a/nix/machines/hypervisor/hypervisor1.nix
+++ b/nix/machines/hypervisor/hypervisor1.nix
@@ -37,6 +37,10 @@
         matchConfig.Name = "eno2";
         networkConfig.Bridge = "virbr0";
       };
+      "10-lan-eno3" = {
+        matchConfig.Name = "eno3";
+        networkConfig.Bridge = "virbr0";
+      };
       # Keep this for troubleshooting
       "10-lan" = {
         matchConfig.Name = "eno1";

--- a/nix/machines/hypervisor/hypervisor1.nix
+++ b/nix/machines/hypervisor/hypervisor1.nix
@@ -1,5 +1,8 @@
 { config, pkgs, lib, ... }:
 {
+  imports = [
+    ./libvirt.nix
+  ];
 
   # ZFS uniq system ID
   # to generate: head -c4 /dev/urandom | od -A none -t x4

--- a/nix/machines/hypervisor/hypervisor1.nix
+++ b/nix/machines/hypervisor/hypervisor1.nix
@@ -36,6 +36,10 @@
       "10-lan-eno2" = {
         matchConfig.Name = "eno2";
         networkConfig.Bridge = "virbr0";
+        networkConfig = {
+          LLDP = true;
+          EmitLLDP = true;
+        };
       };
       "10-lan-eno3" = {
         matchConfig.Name = "eno3";

--- a/nix/machines/hypervisor/hypervisor1.nix
+++ b/nix/machines/hypervisor/hypervisor1.nix
@@ -58,6 +58,7 @@
 
   microvm.autostart = [
     "coreMaster"
+    "monitor"
   ];
 
   services.openssh = {

--- a/nix/machines/hypervisor/hypervisor2.nix
+++ b/nix/machines/hypervisor/hypervisor2.nix
@@ -60,6 +60,10 @@
   environment.systemPackages = with pkgs; [
     tio
   ];
+  
+  microvm.autostart = [
+    "coreSlave"
+  ];
 
   services.openssh = {
     enable = true;

--- a/nix/machines/hypervisor/hypervisor2.nix
+++ b/nix/machines/hypervisor/hypervisor2.nix
@@ -24,13 +24,11 @@
       "1-virbr0" = {
         matchConfig.Name = "virbr0";
         enable = true;
-        #networkConfig.DHCP = "yes";
         address = [ "10.0.3.20/24" "2001:470:f026:103::20/64" ];
-        gateway = [ "10.0.3.20" ];
-        #[Route]
-        #Gateway=192.168.0.10
-        #Destination=10.0.0.0/8
-        #GatewayOnlink=yes
+        routes = [
+          { routeConfig.Gateway = "10.0.3.1"; }
+          { routeConfig.Gateway = "2001:470:f026:103::1"; }
+        ];
       };
       "20-microvm-eth0" = {
         matchConfig.Name = "vm-*";
@@ -38,6 +36,10 @@
       };
       "10-lan-eno2" = {
         matchConfig.Name = "eno2";
+        networkConfig.Bridge = "virbr0";
+      };
+      "10-lan-eno3" = {
+        matchConfig.Name = "eno3";
         networkConfig.Bridge = "virbr0";
       };
       # Keep this for troubleshooting

--- a/nix/machines/hypervisor/hypervisor2.nix
+++ b/nix/machines/hypervisor/hypervisor2.nix
@@ -37,6 +37,10 @@
       "10-lan-eno2" = {
         matchConfig.Name = "eno2";
         networkConfig.Bridge = "virbr0";
+        networkConfig = {
+          LLDP = true;
+          EmitLLDP = true;
+        };
       };
       "10-lan-eno3" = {
         matchConfig.Name = "eno3";

--- a/nix/machines/hypervisor/libvirt.nix
+++ b/nix/machines/hypervisor/libvirt.nix
@@ -1,0 +1,17 @@
+{ config,  ... }:
+{
+  security.polkit.enable = true;
+
+  virtualisation.libvirtd = {
+    enable = true;
+    qemu = {
+      ovmf.enable = true;
+      runAsRoot = false;
+    };
+    onBoot = "ignore";
+    onShutdown = "shutdown";
+  };
+
+  # Add any users in the 'wheel' group to the 'libvirt' group.
+  users.groups.libvirt.members = builtins.filter (x: builtins.elem "wheel" config.users.users."${x}".extraGroups) (builtins.attrNames config.users.users);
+}

--- a/nix/machines/monitor/monitor.nix
+++ b/nix/machines/monitor/monitor.nix
@@ -38,10 +38,6 @@ in
   ];
 
   services = {
-    openssh = {
-      enable = true;
-    };
-
     prometheus = {
       enable = true;
       enableReload = true;

--- a/nix/machines/signs/signs.nix
+++ b/nix/machines/signs/signs.nix
@@ -24,8 +24,6 @@
         address = [ "10.128.3.11/24" "2001:470:f026:503::11/64" ];
         gateway = [ "10.128.3.1" ];
         networkConfig = {
-          LLDP = true;
-          EmitLLDP = true;
           IPv6PrivacyExtensions = false;
         };
       };

--- a/nix/modules/facts.nix
+++ b/nix/modules/facts.nix
@@ -1,0 +1,17 @@
+{ config, lib, ... }:
+
+with lib;
+
+{
+  options.facts = {
+    ipv4 = mkOption {
+      type = types.str;
+    };
+    ipv6 = mkOption {
+      type = types.str;
+    };
+    eth = mkOption {
+      type = types.str;
+    };
+  };
+}

--- a/nix/modules/flake-module.nix
+++ b/nix/modules/flake-module.nix
@@ -1,3 +1,4 @@
 {
   flake.nixosModules.bhyve-image = ./bhyve-image.nix;
+  flake.nixosModules.facts = ./facts.nix;
 }


### PR DESCRIPTION
## Description of PR

Setting up hypervisor1, flipping coreSlave and coreMaster so that master is now in conference building

## Previous Behavior
- no config for hypervisor1
- coreSlave was in conf building
- coreMaster was in expo building

## New Behavior
- config hypervisor1
- coreSlave in expo building
- coreMaster in conf building
- explicitly set `transfer-source` for bind slave

## Tests
- Testing on `hypervisor1`, `coreMaster`, and `coreSlave`
- `nix flake check` passes
