### PR TITLE
[READY] - inventory fix for aps and apsuse

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,3 +19,4 @@ jobs:
       - run: nix build -L .#checks.x86_64-linux.pytest-facts
       - run: nix build -L .#checks.x86_64-linux.perl-switches
       - run: nix build -L .#checks.x86_64-linux.openwrt-golden
+      - run: nix build -L .#scaleInventory

--- a/facts/inventory.py
+++ b/facts/inventory.py
@@ -296,7 +296,11 @@ def populateaps(apsfile, apusefile):
     # key: n8t-0054
     # values: c4:04:15:ad:a3:93,unknown-2,10.128.3.249,6,36,0,0,50,50
     for key, elems in result.items():
-        ipaddr = elems[2]
+        try:
+            ipaddr = elems[2]
+        except IndexError:
+            ipaddr = None
+
         # Lets bail if ip address is invalid
         if not isvalidip(ipaddr):
             continue


### PR DESCRIPTION
## Description of PR

related to: https://github.com/socallinuxexpo/scale-network/pull/698

Currently failing off master when aps are all defined in `apuse.csv`:
```
$ nix build .#scaleInventory
path '/home/rherna/workspace/scale-network/nix' does not contain a 'flake.nix', searching up
error: builder for '/nix/store/0v2dvmnmngz4lislshijlgjbybs2sxqm-scaleInventory.drv' failed with exit code 1;
       last 8 log lines:
       > Traceback (most recent call last):
       >   File "/nix/store/lfs3m43yvcn3hrphicc132py43zqg9x5-scaleInventory/.repo/facts/inventory.py", line 718, in <module>
       >     main()
       >   File "/nix/store/lfs3m43yvcn3hrphicc132py43zqg9x5-scaleInventory/.repo/facts/inventory.py", line 697, in main
       >     aps = populateaps(apsfile, apusefile)
       >   File "/nix/store/lfs3m43yvcn3hrphicc132py43zqg9x5-scaleInventory/.repo/facts/inventory.py", line 299, in populateaps
       >     ipaddr = elems[2]
       > IndexError: list index out of range
       For full logs, run 'nix log /nix/store/0v2dvmnmngz4lislshijlgjbybs2sxqm-scaleInventory.drv'.
```

## Previous Behavior
- broken on `master`

## New Behavior
- fixed for scaleInventory
- include ci build as sanity check for scaleInventory

## Tests
- ci
