### PR TITLE
[READY] migrate monitor vm to other hypervisor and disable nginx

### DIFF
--- a/facts/servers/serverlist.csv
+++ b/facts/servers/serverlist.csv
@@ -1,7 +1,7 @@
 name,mac-address,ipv6,ipv4,role
 coreexpo,58:9c:fc:00:38:5f,2001:470:f026:103::5,10.0.3.5,core
 coreconf,4c:72:b9:7c:41:17,2001:470:f026:503::5,10.128.3.5,core
-monitoring1,58:9c:fc:0a:a8:f3,2001:470:f026:503::6,10.128.3.6,monitoring
+monitoring1,58:9c:fc:0a:a8:f3,2001:470:f026:103::6,10.0.3.6,monitoring
 hypervisorexpo,ea:51:b9:70:f0:58,2001:470:f026:103::20,10.0.3.20,bhyve
 hypervisorconf,62:96:b1:59:b8:9a,2001:470:f026:503::20,10.128.3.20,bhyve
 tftp,58:9c:fc:0e:cb:90,2001:470:f026:503::10,10.128.3.10,bhyve

--- a/nix/machines/hypervisor/hypervisor1.nix
+++ b/nix/machines/hypervisor/hypervisor1.nix
@@ -65,7 +65,6 @@
 
   microvm.autostart = [
     "coreMaster"
-    "monitor"
     "signs"
   ];
 

--- a/nix/machines/hypervisor/hypervisor2.nix
+++ b/nix/machines/hypervisor/hypervisor2.nix
@@ -60,9 +60,10 @@
   environment.systemPackages = with pkgs; [
     tio
   ];
-  
+
   microvm.autostart = [
     "coreSlave"
+    "monitor"
   ];
 
   services.openssh = {

--- a/nix/machines/monitor/monitor.nix
+++ b/nix/machines/monitor/monitor.nix
@@ -18,14 +18,15 @@ in
         # to match enp0 or eth0
         name = "e*0*";
         enable = true;
-        address = [ "10.128.3.6/24" "2001:470:f026:503::6" ];
+        address = [ "10.0.3.6/24" "2001:470:f026:103::6" ];
         routes = [
-          { routeConfig.Gateway = "10.128.3.1"; }
-          { routeConfig.Gateway = "2001:470:f026:503::1"; }
+          { routeConfig.Gateway = "10.0.3.1"; }
+          { routeConfig.Gateway = "2001:470:f026:103::1"; }
         ];
       };
     };
   };
+  networking.hostName = "monitor";
   networking.firewall.allowedTCPPorts = [ 80 443 ];
 
   # TODO: How to handle sudo esculation
@@ -90,7 +91,7 @@ in
     };
 
     nginx = {
-      enable = true;
+      enable = false;
       # TODO: TLS enabled
       # Good example enable TLS, but would like to keep it out of the /nix/store
       # ref: https://github.com/NixOS/nixpkgs/blob/c6fd903606866634312e40cceb2caee8c0c9243f/nixos/tests/custom-ca.nix#L80


### PR DESCRIPTION
## Description of PR
Moving monitor vm to other building

## Previous Behavior
Monitoring vm was configured for conference building but un-deployable due to other issue

## New Behavior
Monitoring vm now configured for expo building and should be deployable

## Tests
doin it live
