### PR TITLE
[READY] Fixed filter and other errors

### DIFF
--- a/switch-configuration/config/scripts/build_switch_configs.pl
+++ b/switch-configuration/config/scripts/build_switch_configs.pl
@@ -26,7 +26,7 @@ if(scalar(@ARGV)) # One or more switch names specified
 }
 else
 {
-    $switchlist = get_switchlist();
+    $switchlist = get_switchlist(1);
 }
 my @outputs = ();
 my @maps = ();

--- a/switch-configuration/config/scripts/switch_config_loader
+++ b/switch-configuration/config/scripts/switch_config_loader
@@ -56,6 +56,8 @@
 #
 #       -u <username> -- username to provide to swtiches for authentication
 #
+#       -z -- Go ahead and process switches in the Z (unused) hierarchy
+#
 #       <switch_spec> -- One or more switch names and/or groups
 #           Cannot be used with -l or any of the options that imply -l
 #             unless it resolves to a single switch.
@@ -103,7 +105,8 @@ our $opt_n;
 our $opt_p;
 our $opt_t;
 our $opt_u;
-getopts('bc:hklnpt:u:');
+our $opt_z;
+getopts('bc:hklnpt:u:z');
 
 # Check for implicit or incompatible arguments.
 if ($opt_h)
@@ -133,7 +136,7 @@ if ($opt_c && $opt_l && scalar(@list) == 0)
 
 if (scalar(@list) == 0)
 {
-  @list = @{Loader::get_switchlist()};
+  @list = @{Loader::get_switchlist($opt_z)};
   print "Pulled ", scalar(@list), " switches from configuration list\n";
 }
 else
@@ -145,6 +148,7 @@ else
 
 print "List expansion yielded ", scalar(@list), " Switch names.\n";
 
+exit 0;
 
 if ($opt_t && (scalar(@list) != 1))
 {

--- a/switch-configuration/config/scripts/switch_config_loader
+++ b/switch-configuration/config/scripts/switch_config_loader
@@ -148,8 +148,6 @@ else
 
 print "List expansion yielded ", scalar(@list), " Switch names.\n";
 
-exit 0;
-
 if ($opt_t && (scalar(@list) != 1))
 {
   warn("Use of -t requires exactly one switch be specified.\n");

--- a/switch-configuration/config/scripts/switch_template.pm
+++ b/switch-configuration/config/scripts/switch_template.pm
@@ -191,7 +191,20 @@ sub read_config_file
 
 sub get_switchlist
 {
-  my @list = sort(keys(%Switchtypes));
+  my $include_Z = shift(@_);
+  my @list=();
+  foreach(sort(keys(%Switchtypes)))
+  {
+    if ($include_z || $switchtyps{$_}[4] -ne "Z")
+    {
+      push @list, $_;
+      debug(9, "Adding $_ to list with group $switchtypes{$_}[4]\n");
+    }
+    else
+    {
+      debug(9, "Skipping $_ with group $switchtypes{$_}[4]\n");
+    }
+  }
   debug(5, "get_switchlist called\n");
   if (scalar(@list))
   {
@@ -1058,7 +1071,7 @@ sub VV_init_firewall
                   destination-address {
                         2001:470:f026::/48
                   }
-                  icmp-type [ neighbor-solicit neighbor-advertise router-solicit packet-too-big time-exceeded ];
+                  icmp-type [ neighbor-solicit neighbor-advertisement router-solicit packet-too-big time-exceeded ];
               }
               then {
                   accept;
@@ -1112,7 +1125,7 @@ sub VV_init_firewall
         filter only_from_internet6 {
 	  term ipv6_icmp_basics {
               from {
-                  icmp-type [ neighbor-solicit neighbor-advertise router-advertise packet-too-big time-exceeded ];
+                  icmp-type [ neighbor-solicit neighbor-advertisement router-advertisement packet-too-big time-exceeded ];
               }
               then {
                   accept;

--- a/switch-configuration/config/scripts/switch_template.pm
+++ b/switch-configuration/config/scripts/switch_template.pm
@@ -195,14 +195,14 @@ sub get_switchlist
   my @list=();
   foreach(sort(keys(%Switchtypes)))
   {
-    if ($include_Z || $switchtyps{$_}[4] -ne "Z")
+    if ($include_Z || $Switchtypes{$_}[4] ne "Z")
     {
       push @list, $_;
-      debug(9, "Adding $_ to list with group $switchtypes{$_}[4]\n");
+      debug(9, "Adding $_ to list with group $Switchtypes{$_}[4]\n");
     }
     else
     {
-      debug(9, "Skipping $_ with group $switchtypes{$_}[4]\n");
+      debug(9, "Skipping $_ with group $Switchtypes{$_}[4]\n");
     }
   }
   debug(5, "get_switchlist called\n");

--- a/switch-configuration/config/scripts/switch_template.pm
+++ b/switch-configuration/config/scripts/switch_template.pm
@@ -1112,9 +1112,6 @@ sub VV_init_firewall
         filter only_from_internet6 {
 	  term ipv6_icmp_basics {
               from {
-                  destination-address {
-                        2001:470:f026::/48
-                  }
                   icmp-type [ neighbor-solicit neighbor-advertise router-advertise packet-too-big time-exceeded ];
               }
               then {

--- a/switch-configuration/config/scripts/switch_template.pm
+++ b/switch-configuration/config/scripts/switch_template.pm
@@ -195,7 +195,7 @@ sub get_switchlist
   my @list=();
   foreach(sort(keys(%Switchtypes)))
   {
-    if ($include_z || $switchtyps{$_}[4] -ne "Z")
+    if ($include_Z || $switchtyps{$_}[4] -ne "Z")
     {
       push @list, $_;
       debug(9, "Adding $_ to list with group $switchtypes{$_}[4]\n");


### PR DESCRIPTION
## Description of PR
Packet Packet Packet --- Packet --- Packet Packet

## Previous Behavior
Switch didn't like config file error

## New Behavior
Switch will digest the config file without reflux
Also includes improvements to config loader and push to allow skipping group Z (default for push) or including it (default for build)

## Tests
Gave the switch a whole bunch of malox and threw the resulting configs at it.
