### PR TITLE
[READY] reference duplicates check from github workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,7 @@ jobs:
       - uses: DeterminateSystems/nix-installer-action@main
       - uses: DeterminateSystems/magic-nix-cache-action@main
       - run: nix build -L .#checks.x86_64-linux.pytest-facts
+      - run: nix build -L .#checks.x86_64-linux.duplicates-facts
       - run: nix build -L .#checks.x86_64-linux.perl-switches
       - run: nix build -L .#checks.x86_64-linux.openwrt-golden
       - run: nix build -L .#scaleInventory

--- a/nix/tests/flake-module.nix
+++ b/nix/tests/flake-module.nix
@@ -22,7 +22,7 @@
         ${testPython}/bin/pytest -vv -p no:cacheprovider
         touch $out
       '');
-      duplicates-facts = (pkgs.runCommand "facts-duplicates"
+      duplicates-facts = (pkgs.runCommand "duplicates-facts"
         {
           buildInputs = [pkgs.fish ];
         } ''


### PR DESCRIPTION
## Description of PR
Created script to check for duplicates in datafiles but didn't actually reference it from Github Actions Workflow. (The NOC is too distracting sometimes)

## Previous Behavior
- Github Actions not running duplicates check script

## New Behavior
- Github Actions now running duplicates check script

## Tests
This PR: 
- https://github.com/socallinuxexpo/scale-network/actions/runs/8305421089/job/22732294997
- https://github.com/socallinuxexpo/scale-network/actions/runs/8305432083/job/22732321538?pr=741
