### PR TITLE
[READY] Fix recursive lookups against IPv6 interface of core master

### DIFF
--- a/nix/machines/core/master.nix
+++ b/nix/machines/core/master.nix
@@ -47,7 +47,7 @@ in
   services = {
     bind = {
       enable = true;
-      cacheNetworks = [ "::1/128" "127.0.0.0/8" "2001:470:f0fb::/48" "10.0.0.0/8" ];
+      cacheNetworks = [ "::1/128" "127.0.0.0/8" "2001:470:f026::/48" "10.0.0.0/8" ];
       forwarders = [ "8.8.8.8" "8.8.4.4" ];
       zones =
         {

--- a/tests/serverspec/spec/shared/dns/resolvable.rb
+++ b/tests/serverspec/spec/shared/dns/resolvable.rb
@@ -3,17 +3,29 @@ require 'serverspec' # If you want to use serverspec matchers, you will need thi
 
 RSpec.shared_examples "resolvable" do
 
+  DNSSERVERS = [
+    "10.0.3.5",
+    "10.128.3.5",
+    "2001:470:f026:103::5",
+    "2001:470:f026:503::5"
+  ]
+
   RESOLVABLE=[
     "ntp.scale.lan",
     "loghost.scale.lan",
-    "zabbix.scale.lan",
+    "lobste.rs",
     "google.com"
   ]
 
 
   RESOLVABLE.each do |host|
-    describe command("dig +short #{host} | grep -v -e '^$'") do
-      its(:exit_status) { should eq 0 }
+    DNSSERVERS.each do |dnsserver|
+      describe command("dig @#{dnsserver} +short #{host} A | grep -v -e '^$'") do
+        its(:exit_status) { should eq 0 }
+      end
+      describe command("dig @#{dnsserver} +short #{host} AAAA | grep -v -e '^$'") do
+        its(:exit_status) { should eq 0 }
+      end
     end
   end
 end


### PR DESCRIPTION
## Description of PR
Found issues with DNS lookups over the IPv6 interface only on the core master server.

## Previous Behavior
- serverspec tests for recursive DNS didn't exist
- cache network config for core master had the wrong /64 defined

## New Behavior
- serverspec tests for recursive DNS now exist
- cache network config for core master has been corrected

## Tests
- serverspec locally
- this PR branch being applied to core master after closing keynote is complete. 
