### PR TITLE
[READY] - disable dhcpv6 for now

### DIFF
--- a/nix/machines/core/common.nix
+++ b/nix/machines/core/common.nix
@@ -58,7 +58,8 @@
 
         in
         {
-          enable = true;
+          # TODO: Reenable after bumping to new nix release
+          enable = false;
           configFile = "${dhcp6PopulateConfig}/dhcp6-server.conf";
         };
     };


### PR DESCRIPTION
## Description of PR

Since we arent using tftp over v6 and theres a race condition with both the kea v4 and v6 daemons

## Previous Behavior
Remove this section if not relevant

## New Behavior
Remove this section if not relevant

## Tests
How was this PR tested?
