### PR TITLE
[WAIT] - [PENDING ABANDON] rpi tftpboot via dhcpv6 config

### DIFF
--- a/facts/inventory.py
+++ b/facts/inventory.py
@@ -504,6 +504,70 @@ def generatekeaconfig(servers, aps, vlans, outputdir):
       }
     keav6_config = {
         "Dhcp6": {
+            "option-def": [
+                  {
+                    "name": "PXEDiscoveryControl",
+                    "code": 6,
+                    "space": "vendor-40712",
+                    "type": "uint8",
+                    "array": False
+                  },
+                  {
+                    "name": "PXEMenuPrompt",
+                    "code": 10,
+                    "space": "vendor-40712",
+                    "type": "record",
+                    "array": False,
+                    "record-types": "uint8,string"
+                  },
+                  {
+                    "name": "PXEBootMenu",
+                    "code": 9,
+                    "space": "vendor-40712",
+                    "type": "record",
+                    "array": False,
+                    "record-types": "uint16,uint8,string"
+                  }
+            ],
+            "client-classes": [
+                  {
+                    "name": "rpi-pxe",
+                    "test": "option[client-arch-type].hex == 0x0029",
+                    "option-data":
+                    [
+                      {
+                        "name": "bootfile-url",
+                        "always-send": True,
+                        "data": "tftp://2001:470:f026:503::10/start4.elf"
+                      },
+                      {
+                        "name": "vendor-opts",
+                            "always-send": True,
+                            "data": "40712"
+                          },
+                      {
+                        "name": "PXEBootMenu",
+                        "always-send": True,
+                        "csv-format": True,
+                        "data": "0,17,Raspberry Pi Boot",
+                        "space": "vendor-40712"
+                      },
+                      {
+                        "name": "PXEDiscoveryControl",
+                        "always-send": True,
+                        "data": "3",
+                        "space": "vendor-40712"
+                      },
+                      {
+                        "name": "PXEMenuPrompt",
+                        "always-send": True,
+                        "csv-format": True,
+                        "data": "0,pxe",
+                        "space": "vendor-40712"
+                      }
+                    ]
+                }
+            ],
             # First we set up global values
             "valid-lifetime": 1440,
             "min-valid-lifetime": 1440,
@@ -529,7 +593,6 @@ def generatekeaconfig(servers, aps, vlans, outputdir):
              "data": ','.join([x['ipv6'] for x in servers if x['role'] == 'core'])
             },
             ],
-            "option-def": [],
             "reservations-global": True,
             "reservations-in-subnet": False,
             "reservations": [],


### PR DESCRIPTION
## Description of PR

Relates to: #537 

Captures the efforts of Tuesday and Wednesday during Scale 21x to get tftpboot working on ipv6. We still have an outstanding issue with the rpi firmware (https://github.com/raspberrypi/firmware/issues/1808) and booting from rpi4 still isnt working. At this time we cannot incorporate it into the kea dhcpv6 server since then any rpis with dhcpv6 boot enabled will fail to boot or boot into a blank screen (if tftpboot server exists). We dont want to lose the work so well leave it here for now.

## Previous Behavior
- No tftpboot configuration in kea dhcpv6

## New Behavior
- Initial tftpboot configuration for kea dhcpv6 (still WIP)

## Tests
- Debugging directly on the Rpi4
- TBD: `nix build .#checks.x86_64-linux.core.driverInteractive` works as expected for all vms
- TBD: `nix build .#checks.x86_64-linux.core` works