### PR TITLE
[READY] - reenable dhcpv6 kea and nixosTest core updates

### DIFF
--- a/nix/machines/core/common.nix
+++ b/nix/machines/core/common.nix
@@ -58,8 +58,7 @@
 
         in
         {
-          # TODO: Reenable after bumping to new nix release
-          enable = false;
+          enable = true;
           configFile = "${dhcp6PopulateConfig}/dhcp6-server.conf";
         };
     };

--- a/nix/tests/core.nix
+++ b/nix/tests/core.nix
@@ -19,7 +19,6 @@ in
     # temporary router since we do not have the junipers for ipv6 router advertisement
     router = { ... }: {
       virtualisation.vlans = [ 1 ];
-      virtualisation.graphics = false;
       systemd.services.systemd-networkd.environment.SYSTEMD_LOG_LEVEL = "debug";
       # since this is a router we need to set enable ipv6 forwarding or radvd will complain
       boot.kernel.sysctl."net.ipv6.conf.all.forwarding" = true;
@@ -79,7 +78,6 @@ in
       };
 
       virtualisation.vlans = [ 1 ];
-      virtualisation.graphics = false;
       systemd.services.systemd-networkd.environment.SYSTEMD_LOG_LEVEL = "debug";
       systemd.network = {
         networks = lib.mkForce {

--- a/nix/tests/core.nix
+++ b/nix/tests/core.nix
@@ -145,10 +145,10 @@ in
       coremaster.succeed("named-checkzone scale.lan ${scaleZone}")
       client1.wait_for_unit("systemd-networkd-wait-online.service")
       client1.wait_until_succeeds("ping -c 5 ${coremasterAddr.ipv4}")
-      #client1.wait_until_succeeds("ping -c 5 -6 ${coremasterAddr.ipv6}")
+      client1.wait_until_succeeds("ping -c 5 -6 ${coremasterAddr.ipv6}")
       client1.wait_until_succeeds("ip route show | grep default | grep -w ${routerAddr.ipv4}")
       # ensure that we got the correct prefix and suffix on dhcpv6
-      #client1.wait_until_succeeds("ip addr show dev eth1 | grep inet6 | grep ${chomp}:d8c")
+      client1.wait_until_succeeds("ip addr show dev eth1 | grep inet6 | grep ${chomp}:d8c")
       # Have to wrap drill since retcode isnt necessarily 1 on query failure
       client1.wait_until_succeeds("test ! -z \"$(drill -Q -z scale.lan SOA)\"")
       client1.wait_until_succeeds("test ! -z \"$(drill -Q -z coreexpo.scale.lan A)\"")

--- a/nix/tests/core.nix
+++ b/nix/tests/core.nix
@@ -155,4 +155,27 @@ in
       client1.wait_until_succeeds("test ! -z \"$(drill -Q -z coreexpo.scale.lan AAAA)\"")
       client1.wait_until_succeeds("test ! -z \"$(drill -Q -z -x ${coremasterAddr.ipv4})\"")
     '';
+
+  interactive.nodes =
+    let
+      interactiveDefaults = hostPort:
+        {
+          services.openssh.enable = true;
+          services.openssh.settings.PermitRootLogin = "yes";
+          users.extraUsers.root.initialPassword = "";
+          systemd.network.networks."01-eth0" = {
+            name = "eth0";
+            enable = true;
+            networkConfig.DHCP = "yes";
+          };
+          virtualisation.forwardPorts = [
+            { from = "host"; host.port = hostPort; guest.port = 22; }
+          ];
+        };
+    in
+    {
+      router = interactiveDefaults 2222;
+      coremaster = interactiveDefaults 2223;
+      client1 = interactiveDefaults 2224;
+    };
 }

--- a/nix/tests/core.nix
+++ b/nix/tests/core.nix
@@ -80,8 +80,9 @@ in
       virtualisation.vlans = [ 1 ];
       systemd.services.systemd-networkd.environment.SYSTEMD_LOG_LEVEL = "debug";
       systemd.network = {
-        networks = lib.mkForce {
-          "01-eth1" = {
+        networks = {
+          # Override the phyiscal interface config
+          "10-lan" = lib.mkForce {
             name = "eth1";
             enable = true;
             address = [ "${coremasterAddr.ipv6}/64" "${coremasterAddr.ipv4}/24" ];


### PR DESCRIPTION
## Description of PR

Relates to: #537 #753

Reenable the dhcpv6 server without any rpi specific tftpboot options. We will reenable the option when #753 and the rpi firmware supports it.

## Previous Behavior
- disabled dhcpv6 on `core` server

## New Behavior
- reenable dhcpv6 on `core` server
- add `driverInteractive` specific config for `nixosTest.core` to allow for `ssh` to each test vm
- reenable `driverInteractive` graphics during tests 

## Tests
- `nix build .#checks.x86_64-linux.core.driverInteractive` works as expected for all vms
- `nix build .#checks.x86_64-linux.core` works