### PR TITLE
Update switch_config_loader

### DIFF
--- a/switch-configuration/config/scripts/switch_config_loader
+++ b/switch-configuration/config/scripts/switch_config_loader
@@ -12,7 +12,7 @@
 #
 # Original funciton/intent of the initial scripts:
 #
-# bulk_local_laod_switches
+# bulk_local_load_switches
 #        Built on override_switches, but optimized for loading multiple switches
 #        at a work party or similar situation.
 #


### PR DESCRIPTION
Comment had load spelled wrong

## Description of PR

The comment in the top of the file was referencing a bulk_local_load_switches

## Previous Behavior

The header to the referenced part was that it was spelled with the 'o' and the 'a' were switched around

## New Behavior

The header is read with the word spelled correctly