### PR TITLE
[REVIEW] - Adds test for switch config types

### DIFF
--- a/facts/datasource.py
+++ b/facts/datasource.py
@@ -217,6 +217,8 @@ def test_datafile(delimiter, meta):
             continue
         # run the validators for each column
         for i, val in enumerate(elems):
+            if val.startswith("//"):
+                continue
             if not meta["cols"][i](val.rstrip("\n")):
                 return False, "invalid field " + val + " failed " + meta["cols"][
                     i

--- a/facts/datasource.py
+++ b/facts/datasource.py
@@ -161,13 +161,16 @@ def isvalidtype(val):
         return True
     return False
 
+
 def isvalidport(val):
-    """"test for valid port config [FIBER, RSRVD, TRUNK, VLAN, VVBB, VVLAN]"""
+    """test for valid port config [FIBER, RSRVD, TRUNK, VLAN, VVBB, VVLAN]"""
     return val in ["FIBER", "RSRVD", "TRUNK", "VLAN", "VVBB", "VVLAN"]
 
+
 def isvalidlink(val):
-    """"test for valid link type [Uplink, Downlink, AP, MassFlash]"""
+    """test for valid link type [Uplink, Downlink, AP, MassFlash]"""
     return val in ["Uplink", "Downlink", "AP", "MassFlash", "-"]
+
 
 def test_csvfile(meta):
     """csv wrapper for test_datafile"""

--- a/facts/datasource.py
+++ b/facts/datasource.py
@@ -165,6 +165,9 @@ def isvalidport(val):
     """"test for valid port config [FIBER, RSRVD, TRUNK, VLAN, VVBB, VVLAN]"""
     return val in ["FIBER", "RSRVD", "TRUNK", "VLAN", "VVBB", "VVLAN"]
 
+def isvalidlink(val):
+    """"test for valid link type [Uplink, Downlink, AP, MassFlash]"""
+    return val in ["Uplink", "Downlink", "AP", "MassFlash"]
 
 def test_csvfile(meta):
     """csv wrapper for test_datafile"""

--- a/facts/datasource.py
+++ b/facts/datasource.py
@@ -161,6 +161,10 @@ def isvalidtype(val):
         return True
     return False
 
+def isvalidport(val):
+    """"test for valid port config [FIBER, RSRVD, TRUNK, VLAN, VVBB, VVLAN]"""
+    return val in ["FIBER", "RSRVD", "TRUNK", "VLAN", "VVBB", "VVLAN"]
+
 
 def test_csvfile(meta):
     """csv wrapper for test_datafile"""

--- a/facts/datasource.py
+++ b/facts/datasource.py
@@ -167,7 +167,7 @@ def isvalidport(val):
 
 def isvalidlink(val):
     """"test for valid link type [Uplink, Downlink, AP, MassFlash]"""
-    return val in ["Uplink", "Downlink", "AP", "MassFlash"]
+    return val in ["Uplink", "Downlink", "AP", "MassFlash", "-"]
 
 def test_csvfile(meta):
     """csv wrapper for test_datafile"""

--- a/facts/test_datasources.py
+++ b/facts/test_datasources.py
@@ -107,6 +107,7 @@ def test_switchtypes_tsv():
     result, err = ds.test_tsvfile(meta)
     assert result, err
 
+
 def test_switchconfigs_tsv():
     """test switchconfigs"""
 
@@ -127,6 +128,7 @@ def test_switchconfigs_tsv():
         }
         result, err = ds.test_tsvfile(meta)
         assert result, err
+
 
 def test_vlansd_tsv():
     """test vlans.d/"""

--- a/facts/test_datasources.py
+++ b/facts/test_datasources.py
@@ -121,7 +121,7 @@ def test_switchconfigs_tsv():
                 ds.isuntested,
                 ds.isuntested,
                 ds.isuntested,
-                ds.isuntested,
+                ds.isvalidlink,
                 ds.isuntested,
             ],
         }

--- a/facts/test_datasources.py
+++ b/facts/test_datasources.py
@@ -107,6 +107,26 @@ def test_switchtypes_tsv():
     result, err = ds.test_tsvfile(meta)
     assert result, err
 
+def test_switchconfigs_tsv():
+    """test switchconfigs"""
+
+    directory = "../switch-configuration/config/types/"
+    for filename in os.listdir(directory):
+        meta = {
+            "file": directory + filename,
+            "header": False,
+            "count": "1+",
+            "cols": [
+                ds.isvalidport,
+                ds.isuntested,
+                ds.isuntested,
+                ds.isuntested,
+                ds.isuntested,
+                ds.isuntested,
+            ],
+        }
+        result, err = ds.test_tsvfile(meta)
+        assert result, err
 
 def test_vlansd_tsv():
     """test vlans.d/"""

--- a/switch-configuration/config/types/Booth
+++ b/switch-configuration/config/types/Booth
@@ -1,8 +1,6 @@
 // Expo Booth Area switch Template
-TRUNK	ge-0/0/0	exSCALE-SLOW,exSCALE-FAST,exSpeaker,exInfra,exAVLAN, \
-				exSigns,exVmVendor,vendor_backbone			-	Uplink
-TRUNK	ge-0/0/1	exSCALE-SLOW,exSCALE-FAST,exSpeaker,exInfra,exAVLAN, \
-				exSigns,exVmVendor,vendor_backbone			-	Downlink
+TRUNK	ge-0/0/0	exSCALE-SLOW,exSCALE-FAST,exSpeaker,exInfra,exAVLAN, exSigns,exVmVendor,vendor_backbone			-	Uplink
+TRUNK	ge-0/0/1	exSCALE-SLOW,exSCALE-FAST,exSpeaker,exInfra,exAVLAN, exSigns,exVmVendor,vendor_backbone			-	Downlink
 RSRVD	6
 TRUNK	ge-0/0/8	exInfra,exSCALE-SLOW,exSCALE-FAST		POE	AP
 TRUNK	ge-0/0/9	exInfra,exSCALE-SLOW,exSCALE-FAST		POE	AP

--- a/switch-configuration/config/types/Catwalk
+++ b/switch-configuration/config/types/Catwalk
@@ -29,21 +29,21 @@ TRUNK	ge-0/0/26	exSCALE-SLOW,exSCALE-FAST,exSpeaker,exInfra, exAVLAN,vendor_back
 TRUNK	ge-0/0/27	exSCALE-SLOW,exSCALE-FAST,exSpeaker,exInfra, exAVLAN,vendor_backbone,exVmVendor exSigns,HAM_BRIDGE 	-	Downlink
 TRUNK	ge-0/0/28	exSCALE-SLOW,exSCALE-FAST,exSpeaker,exInfra, exAVLAN,vendor_backbone,exVmVendor exSigns,HAM_BRIDGE 	-	Downlink
 TRUNK	ge-0/0/29	exSCALE-SLOW,exSCALE-FAST,exSpeaker,exInfra, exAVLAN,vendor_backbone,exVmVendor exSigns,exVmVendor,HAM_BRIDGE 	-	Downlink
-TRUNK	ge-0/0/30	exSCALE-SLOW,exSCALE-FAST,exInfra	POE	AP // for Game Night
-TRUNK	ge-0/0/31	exSCALE-SLOW,exSCALE-FAST,exInfra	POE	AP // for Game Night
-TRUNK	ge-0/0/32	exSCALE-SLOW,exSCALE-FAST,exInfra	POE	AP // for Game Night
-TRUNK	ge-0/0/33	exSCALE-SLOW,exSCALE-FAST,exInfra	POE	AP // for Game Night
-TRUNK	ge-0/0/34	exSCALE-SLOW,exSCALE-FAST,exInfra	POE	AP // for Game Night
-TRUNK	ge-0/0/35	exSCALE-SLOW,exSCALE-FAST,exInfra	POE	AP // for Game Night
-TRUNK	ge-0/0/36	exSCALE-SLOW,exSCALE-FAST,exInfra	POE	AP // for Game Night
-TRUNK	ge-0/0/37	exSCALE-SLOW,exSCALE-FAST,exInfra	POE	AP // for Game Night
-TRUNK	ge-0/0/38	exSCALE-SLOW,exSCALE-FAST,exInfra	POE	AP // for Game Night
-TRUNK	ge-0/0/39	exSCALE-SLOW,exSCALE-FAST,exInfra	POE	AP // for Game Night
-TRUNK	ge-0/0/40	exSCALE-SLOW,exSCALE-FAST,exInfra	POE	AP // for Game Night
-TRUNK	ge-0/0/41	exSCALE-SLOW,exSCALE-FAST,exInfra	POE	AP // for Game Night
-TRUNK	ge-0/0/42	exSCALE-SLOW,exSCALE-FAST,exInfra	POE	AP // for Game Night
-TRUNK	ge-0/0/43	exSCALE-SLOW,exSCALE-FAST,exInfra	POE	AP // for Game Night
-TRUNK	ge-0/0/44	exSCALE-SLOW,exSCALE-FAST,exInfra	POE	AP // for Game Night
-TRUNK	ge-0/0/45	exSCALE-SLOW,exSCALE-FAST,exInfra	POE	AP // for Game Night
-TRUNK	ge-0/0/46	exSCALE-SLOW,exSCALE-FAST,exInfra	POE	AP // for Game Night
-TRUNK	ge-0/0/47	exSCALE-SLOW,exSCALE-FAST,exInfra	POE	AP // for Game Night
+TRUNK	ge-0/0/30	exSCALE-SLOW,exSCALE-FAST,exInfra	POE	AP	// for Game Night
+TRUNK	ge-0/0/31	exSCALE-SLOW,exSCALE-FAST,exInfra	POE	AP	// for Game Night
+TRUNK	ge-0/0/32	exSCALE-SLOW,exSCALE-FAST,exInfra	POE	AP	// for Game Night
+TRUNK	ge-0/0/33	exSCALE-SLOW,exSCALE-FAST,exInfra	POE	AP	// for Game Night
+TRUNK	ge-0/0/34	exSCALE-SLOW,exSCALE-FAST,exInfra	POE	AP	// for Game Night
+TRUNK	ge-0/0/35	exSCALE-SLOW,exSCALE-FAST,exInfra	POE	AP	// for Game Night
+TRUNK	ge-0/0/36	exSCALE-SLOW,exSCALE-FAST,exInfra	POE	AP	// for Game Night
+TRUNK	ge-0/0/37	exSCALE-SLOW,exSCALE-FAST,exInfra	POE	AP	// for Game Night
+TRUNK	ge-0/0/38	exSCALE-SLOW,exSCALE-FAST,exInfra	POE	AP	// for Game Night
+TRUNK	ge-0/0/39	exSCALE-SLOW,exSCALE-FAST,exInfra	POE	AP	// for Game Night
+TRUNK	ge-0/0/40	exSCALE-SLOW,exSCALE-FAST,exInfra	POE	AP	// for Game Night
+TRUNK	ge-0/0/41	exSCALE-SLOW,exSCALE-FAST,exInfra	POE	AP	// for Game Night
+TRUNK	ge-0/0/42	exSCALE-SLOW,exSCALE-FAST,exInfra	POE	AP	// for Game Night
+TRUNK	ge-0/0/43	exSCALE-SLOW,exSCALE-FAST,exInfra	POE	AP	// for Game Night
+TRUNK	ge-0/0/44	exSCALE-SLOW,exSCALE-FAST,exInfra	POE	AP	// for Game Night
+TRUNK	ge-0/0/45	exSCALE-SLOW,exSCALE-FAST,exInfra	POE	AP	// for Game Night
+TRUNK	ge-0/0/46	exSCALE-SLOW,exSCALE-FAST,exInfra	POE	AP	// for Game Night
+TRUNK	ge-0/0/47	exSCALE-SLOW,exSCALE-FAST,exInfra	POE	AP	// for Game Night

--- a/switch-configuration/config/types/Catwalk
+++ b/switch-configuration/config/types/Catwalk
@@ -1,94 +1,34 @@
 // Expo Center Catwalk Switch Configuration
-TRUNK	ge-0/0/0	exSCALE-SLOW,exSCALE-FAST,exSpeaker,exInfra, \
-			exAVLAN,vendor_backbone,exVmVendor \
-			exSigns,HAM_BRIDGE 	-	Uplink
-TRUNK	ge-0/0/1	exSCALE-SLOW,exSCALE-FAST,exSpeaker,exInfra, \
-			exAVLAN,vendor_backbone,exVmVendor \
-			exSigns,HAM_BRIDGE 	-	Downlink
-TRUNK	ge-0/0/2	exSCALE-SLOW,exSCALE-FAST,exSpeaker,exInfra, \
-			exAVLAN,vendor_backbone,exVmVendor \
-			exSigns,HAM_BRIDGE 	-	Downlink
-TRUNK	ge-0/0/3	exSCALE-SLOW,exSCALE-FAST,exSpeaker,exInfra, \
-			exAVLAN,vendor_backbone,exVmVendor \
-			exSigns,HAM_BRIDGE 	-	Downlink
-TRUNK	ge-0/0/4	exSCALE-SLOW,exSCALE-FAST,exSpeaker,exInfra, \
-			exAVLAN,vendor_backbone,exVmVendor \
-			exSigns,HAM_BRIDGE 	-	Downlink
-TRUNK	ge-0/0/5	exSCALE-SLOW,exSCALE-FAST,exSpeaker,exInfra, \
-			exAVLAN,vendor_backbone,exVmVendor \
-			exSigns,HAM_BRIDGE 	-	Downlink
-TRUNK	ge-0/0/6	exSCALE-SLOW,exSCALE-FAST,exSpeaker,exInfra, \
-			exAVLAN,vendor_backbone,exVmVendor \
-			exSigns,HAM_BRIDGE 	-	Downlink
-TRUNK	ge-0/0/7	exSCALE-SLOW,exSCALE-FAST,exSpeaker,exInfra, \
-			exAVLAN,vendor_backbone,exVmVendor \
-			exSigns,HAM_BRIDGE 	-	Downlink
-TRUNK	ge-0/0/8	exSCALE-SLOW,exSCALE-FAST,exSpeaker,exInfra, \
-			exAVLAN,vendor_backbone,exVmVendor \
-			exSigns,HAM_BRIDGE 	-	Downlink
-TRUNK	ge-0/0/9	exSCALE-SLOW,exSCALE-FAST,exSpeaker,exInfra, \
-			exAVLAN,vendor_backbone,exVmVendor \
-			exSigns,HAM_BRIDGE 	-	Downlink
-TRUNK	ge-0/0/10	exSCALE-SLOW,exSCALE-FAST,exSpeaker,exInfra, \
-			exAVLAN,vendor_backbone,exVmVendor \
-			exSigns,HAM_BRIDGE 	-	Downlink
-TRUNK	ge-0/0/11	exSCALE-SLOW,exSCALE-FAST,exSpeaker,exInfra, \
-			exAVLAN,vendor_backbone,exVmVendor \
-			exSigns,HAM_BRIDGE 	-	Downlink
-TRUNK	ge-0/0/12	exSCALE-SLOW,exSCALE-FAST,exSpeaker,exInfra, \
-			exAVLAN,vendor_backbone,exVmVendor \
-			exSigns,HAM_BRIDGE 	-	Downlink
-TRUNK	ge-0/0/13	exSCALE-SLOW,exSCALE-FAST,exSpeaker,exInfra, \
-			exAVLAN,vendor_backbone,exVmVendor \
-			exSigns,HAM_BRIDGE 	-	Downlink
-TRUNK	ge-0/0/14	exSCALE-SLOW,exSCALE-FAST,exSpeaker,exInfra, \
-			exAVLAN,vendor_backbone,exVmVendor \
-			exSigns,HAM_BRIDGE 	-	Downlink
-TRUNK	ge-0/0/15	exSCALE-SLOW,exSCALE-FAST,exSpeaker,exInfra, \
-			exAVLAN,vendor_backbone,exVmVendor \
-			exSigns,HAM_BRIDGE 	-	Downlink
-TRUNK	ge-0/0/16	exSCALE-SLOW,exSCALE-FAST,exSpeaker,exInfra, \
-			exAVLAN,vendor_backbone,exVmVendor \
-			exSigns,HAM_BRIDGE 	-	Downlink
-TRUNK	ge-0/0/17	exSCALE-SLOW,exSCALE-FAST,exSpeaker,exInfra, \
-			exAVLAN,vendor_backbone,exVmVendor \
-			exSigns,HAM_BRIDGE 	-	Downlink
-TRUNK	ge-0/0/18	exSCALE-SLOW,exSCALE-FAST,exSpeaker,exInfra, \
-			exAVLAN,vendor_backbone,exVmVendor \
-			exSigns,HAM_BRIDGE 	-	Downlink
-TRUNK	ge-0/0/19	exSCALE-SLOW,exSCALE-FAST,exSpeaker,exInfra, \
-			exAVLAN,vendor_backbone,exVmVendor \
-			exSigns,HAM_BRIDGE 	-	Downlink
-TRUNK	ge-0/0/20	exSCALE-SLOW,exSCALE-FAST,exSpeaker,exInfra, \
-			exAVLAN,vendor_backbone,exVmVendor \
-			exSigns,HAM_BRIDGE 	-	Downlink
-TRUNK	ge-0/0/21	exSCALE-SLOW,exSCALE-FAST,exSpeaker,exInfra, \
-			exAVLAN,vendor_backbone,exVmVendor \
-			exSigns,HAM_BRIDGE 	-	Downlink
-TRUNK	ge-0/0/22	exSCALE-SLOW,exSCALE-FAST,exSpeaker,exInfra, \
-			exAVLAN,vendor_backbone,exVmVendor \
-			exSigns,HAM_BRIDGE 	-	Downlink
-TRUNK	ge-0/0/23	exSCALE-SLOW,exSCALE-FAST,exSpeaker,exInfra, \
-			exAVLAN,vendor_backbone,exVmVendor \
-			exSigns,HAM_BRIDGE 	-	Downlink
-TRUNK	ge-0/0/24	exSCALE-SLOW,exSCALE-FAST,exSpeaker,exInfra, \
-			exAVLAN,vendor_backbone,exVmVendor \
-			exSigns,HAM_BRIDGE 	-	Downlink
-TRUNK	ge-0/0/25	exSCALE-SLOW,exSCALE-FAST,exSpeaker,exInfra, \
-			exAVLAN,vendor_backbone,exVmVendor \
-			exSigns,HAM_BRIDGE 	-	Downlink
-TRUNK	ge-0/0/26	exSCALE-SLOW,exSCALE-FAST,exSpeaker,exInfra, \
-			exAVLAN,vendor_backbone,exVmVendor \
-			exSigns,HAM_BRIDGE 	-	Downlink
-TRUNK	ge-0/0/27	exSCALE-SLOW,exSCALE-FAST,exSpeaker,exInfra, \
-			exAVLAN,vendor_backbone,exVmVendor \
-			exSigns,HAM_BRIDGE 	-	Downlink
-TRUNK	ge-0/0/28	exSCALE-SLOW,exSCALE-FAST,exSpeaker,exInfra, \
-			exAVLAN,vendor_backbone,exVmVendor \
-			exSigns,HAM_BRIDGE 	-	Downlink
-TRUNK	ge-0/0/29	exSCALE-SLOW,exSCALE-FAST,exSpeaker,exInfra, \
-			exAVLAN,vendor_backbone,exVmVendor \
-			exSigns,exVmVendor,HAM_BRIDGE 	-	Downlink
+TRUNK	ge-0/0/0	exSCALE-SLOW,exSCALE-FAST,exSpeaker,exInfra, exAVLAN,vendor_backbone,exVmVendor exSigns,HAM_BRIDGE 	-	Uplink
+TRUNK	ge-0/0/1	exSCALE-SLOW,exSCALE-FAST,exSpeaker,exInfra, exAVLAN,vendor_backbone,exVmVendor exSigns,HAM_BRIDGE 	-	Downlink
+TRUNK	ge-0/0/2	exSCALE-SLOW,exSCALE-FAST,exSpeaker,exInfra, exAVLAN,vendor_backbone,exVmVendor exSigns,HAM_BRIDGE 	-	Downlink
+TRUNK	ge-0/0/3	exSCALE-SLOW,exSCALE-FAST,exSpeaker,exInfra, exAVLAN,vendor_backbone,exVmVendor exSigns,HAM_BRIDGE 	-	Downlink
+TRUNK	ge-0/0/4	exSCALE-SLOW,exSCALE-FAST,exSpeaker,exInfra, exAVLAN,vendor_backbone,exVmVendor exSigns,HAM_BRIDGE 	-	Downlink
+TRUNK	ge-0/0/5	exSCALE-SLOW,exSCALE-FAST,exSpeaker,exInfra, exAVLAN,vendor_backbone,exVmVendor exSigns,HAM_BRIDGE 	-	Downlink
+TRUNK	ge-0/0/6	exSCALE-SLOW,exSCALE-FAST,exSpeaker,exInfra, exAVLAN,vendor_backbone,exVmVendor exSigns,HAM_BRIDGE 	-	Downlink
+TRUNK	ge-0/0/7	exSCALE-SLOW,exSCALE-FAST,exSpeaker,exInfra, exAVLAN,vendor_backbone,exVmVendor exSigns,HAM_BRIDGE 	-	Downlink
+TRUNK	ge-0/0/8	exSCALE-SLOW,exSCALE-FAST,exSpeaker,exInfra, exAVLAN,vendor_backbone,exVmVendor exSigns,HAM_BRIDGE 	-	Downlink
+TRUNK	ge-0/0/9	exSCALE-SLOW,exSCALE-FAST,exSpeaker,exInfra, exAVLAN,vendor_backbone,exVmVendor exSigns,HAM_BRIDGE 	-	Downlink
+TRUNK	ge-0/0/10	exSCALE-SLOW,exSCALE-FAST,exSpeaker,exInfra, exAVLAN,vendor_backbone,exVmVendor exSigns,HAM_BRIDGE 	-	Downlink
+TRUNK	ge-0/0/11	exSCALE-SLOW,exSCALE-FAST,exSpeaker,exInfra, exAVLAN,vendor_backbone,exVmVendor exSigns,HAM_BRIDGE 	-	Downlink
+TRUNK	ge-0/0/12	exSCALE-SLOW,exSCALE-FAST,exSpeaker,exInfra, exAVLAN,vendor_backbone,exVmVendor exSigns,HAM_BRIDGE 	-	Downlink
+TRUNK	ge-0/0/13	exSCALE-SLOW,exSCALE-FAST,exSpeaker,exInfra, exAVLAN,vendor_backbone,exVmVendor exSigns,HAM_BRIDGE 	-	Downlink
+TRUNK	ge-0/0/14	exSCALE-SLOW,exSCALE-FAST,exSpeaker,exInfra, exAVLAN,vendor_backbone,exVmVendor exSigns,HAM_BRIDGE 	-	Downlink
+TRUNK	ge-0/0/15	exSCALE-SLOW,exSCALE-FAST,exSpeaker,exInfra, exAVLAN,vendor_backbone,exVmVendor exSigns,HAM_BRIDGE 	-	Downlink
+TRUNK	ge-0/0/16	exSCALE-SLOW,exSCALE-FAST,exSpeaker,exInfra, exAVLAN,vendor_backbone,exVmVendor exSigns,HAM_BRIDGE 	-	Downlink
+TRUNK	ge-0/0/17	exSCALE-SLOW,exSCALE-FAST,exSpeaker,exInfra, exAVLAN,vendor_backbone,exVmVendor exSigns,HAM_BRIDGE 	-	Downlink
+TRUNK	ge-0/0/18	exSCALE-SLOW,exSCALE-FAST,exSpeaker,exInfra, exAVLAN,vendor_backbone,exVmVendor exSigns,HAM_BRIDGE 	-	Downlink
+TRUNK	ge-0/0/19	exSCALE-SLOW,exSCALE-FAST,exSpeaker,exInfra, exAVLAN,vendor_backbone,exVmVendor exSigns,HAM_BRIDGE 	-	Downlink
+TRUNK	ge-0/0/20	exSCALE-SLOW,exSCALE-FAST,exSpeaker,exInfra, exAVLAN,vendor_backbone,exVmVendor exSigns,HAM_BRIDGE 	-	Downlink
+TRUNK	ge-0/0/21	exSCALE-SLOW,exSCALE-FAST,exSpeaker,exInfra, exAVLAN,vendor_backbone,exVmVendor exSigns,HAM_BRIDGE 	-	Downlink
+TRUNK	ge-0/0/22	exSCALE-SLOW,exSCALE-FAST,exSpeaker,exInfra, exAVLAN,vendor_backbone,exVmVendor exSigns,HAM_BRIDGE 	-	Downlink
+TRUNK	ge-0/0/23	exSCALE-SLOW,exSCALE-FAST,exSpeaker,exInfra, exAVLAN,vendor_backbone,exVmVendor exSigns,HAM_BRIDGE 	-	Downlink
+TRUNK	ge-0/0/24	exSCALE-SLOW,exSCALE-FAST,exSpeaker,exInfra, exAVLAN,vendor_backbone,exVmVendor exSigns,HAM_BRIDGE 	-	Downlink
+TRUNK	ge-0/0/25	exSCALE-SLOW,exSCALE-FAST,exSpeaker,exInfra, exAVLAN,vendor_backbone,exVmVendor exSigns,HAM_BRIDGE 	-	Downlink
+TRUNK	ge-0/0/26	exSCALE-SLOW,exSCALE-FAST,exSpeaker,exInfra, exAVLAN,vendor_backbone,exVmVendor exSigns,HAM_BRIDGE 	-	Downlink
+TRUNK	ge-0/0/27	exSCALE-SLOW,exSCALE-FAST,exSpeaker,exInfra, exAVLAN,vendor_backbone,exVmVendor exSigns,HAM_BRIDGE 	-	Downlink
+TRUNK	ge-0/0/28	exSCALE-SLOW,exSCALE-FAST,exSpeaker,exInfra, exAVLAN,vendor_backbone,exVmVendor exSigns,HAM_BRIDGE 	-	Downlink
+TRUNK	ge-0/0/29	exSCALE-SLOW,exSCALE-FAST,exSpeaker,exInfra, exAVLAN,vendor_backbone,exVmVendor exSigns,exVmVendor,HAM_BRIDGE 	-	Downlink
 TRUNK	ge-0/0/30	exSCALE-SLOW,exSCALE-FAST,exInfra	POE	AP // for Game Night
 TRUNK	ge-0/0/31	exSCALE-SLOW,exSCALE-FAST,exInfra	POE	AP // for Game Night
 TRUNK	ge-0/0/32	exSCALE-SLOW,exSCALE-FAST,exInfra	POE	AP // for Game Night

--- a/switch-configuration/config/types/cfIDF
+++ b/switch-configuration/config/types/cfIDF
@@ -35,7 +35,7 @@ TRUNK	ge-0/0/32	cfSCALE-SLOW,cfSCALE-FAST,cfInfra				POE	AP
 TRUNK	ge-0/0/33	cfSCALE-SLOW,cfSCALE-FAST,cfInfra				POE	AP
 TRUNK	ge-0/0/34	cfSCALE-SLOW,cfSCALE-FAST,cfInfra				POE	AP
 TRUNK	ge-0/0/35	cfSCALE-SLOW,cfSCALE-FAST,cfInfra				POE	AP
-VLAN	cfCTF		10								-	/ ge-0/0/{36-45}
+VLAN	cfCTF		10								-	// ge-0/0/{36-45}
 VLAN	cfInfra		1								-	// ge-0/0/46 -- Conference Center Bhyve Server
 VLAN	cfAVLAN		1								-	// ge-0/0/47 -- Conference Center AV Server
 

--- a/switch-configuration/config/types/cfIDF
+++ b/switch-configuration/config/types/cfIDF
@@ -1,8 +1,6 @@
 // Conference Center IDF Switch Configuration
-TRUNK	ge-0/0/0	cfSCALE-SLOW,cfSCALE-FAST,cfSpeaker,cfInfra,cfCTF,cfAVLAN,cfNOC, \
-			cfSigns,cfHam_N6S,HAM_BRIDGE 					-	Uplink
-TRUNK	ge-0/0/1	cfSCALE-SLOW,cfSCALE-FAST,cfSpeaker,cfInfra,cfCTF,cfAVLAN,cfNOC, \
-			cfSigns,cfHam_N6S,HAM_BRIDGE 					-	Uplink
+TRUNK	ge-0/0/0	cfSCALE-SLOW,cfSCALE-FAST,cfSpeaker,cfInfra,cfCTF,cfAVLAN,cfNOC, cfSigns,cfHam_N6S,HAM_BRIDGE 					-	Uplink
+TRUNK	ge-0/0/1	cfSCALE-SLOW,cfSCALE-FAST,cfSpeaker,cfInfra,cfCTF,cfAVLAN,cfNOC, cfSigns,cfHam_N6S,HAM_BRIDGE 					-	Uplink
 TRUNK	ge-0/0/2	cfSCALE-SLOW,cfSCALE-FAST,cfSpeaker,cfInfra,cfAVLAN,cfSigns	-	Downlink
 TRUNK	ge-0/0/3	cfSCALE-SLOW,cfSCALE-FAST,cfSpeaker,cfInfra,cfAVLAN,cfSigns	-	Downlink
 TRUNK	ge-0/0/4	cfSCALE-SLOW,cfSCALE-FAST,cfSpeaker,cfInfra,cfAVLAN,cfSigns	-	Downlink

--- a/switch-configuration/config/types/exIDF
+++ b/switch-configuration/config/types/exIDF
@@ -1,76 +1,28 @@
 // Expo Center IDF(s) Switch Configuration Template
-TRUNK	ge-0/0/0	exSCALE-SLOW,exSCALE-FAST,exSpeaker,exInfra, \
-			exAVLAN,exVmVendor, \
-			exSigns,HAM_BRIDGE,exRegistration 			-	Uplink
-TRUNK	ge-0/0/1	exSCALE-SLOW,exSCALE-FAST,exSpeaker,exInfra, \
-			exAVLAN,exVmVendor, \
-			exSigns,HAM_BRIDGE,exRegistration 			-	Downlink
-TRUNK	ge-0/0/2	exSCALE-SLOW,exSCALE-FAST,exSpeaker,exInfra, \
-			exAVLAN,exVmVendor, \
-			exSigns,HAM_BRIDGE,exRegistration 			-	Downlink
-TRUNK	ge-0/0/3	exSCALE-SLOW,exSCALE-FAST,exSpeaker,exInfra, \
-			exAVLAN,exVmVendor, \
-			exSigns,HAM_BRIDGE,exRegistration 			-	Downlink
-TRUNK	ge-0/0/4	exSCALE-SLOW,exSCALE-FAST,exSpeaker,exInfra, \
-			exAVLAN,exVmVendor, \
-			exSigns,HAM_BRIDGE,exRegistration 			-	Downlink
-TRUNK	ge-0/0/5	exSCALE-SLOW,exSCALE-FAST,exSpeaker,exInfra, \
-			exAVLAN,exVmVendor, \
-			exSigns,HAM_BRIDGE,exRegistration 			-	Downlink
-TRUNK	ge-0/0/6	exSCALE-SLOW,exSCALE-FAST,exSpeaker,exInfra, \
-					exAVLAN,exVmVendor, \
-			exSigns,HAM_BRIDGE,exRegistration 			-	Downlink
-TRUNK	ge-0/0/7	exSCALE-SLOW,exSCALE-FAST,exSpeaker,exInfra, \
-			exAVLAN,exVmVendor, \
-			exSigns,HAM_BRIDGE,exRegistration 			-	Downlink
-TRUNK	ge-0/0/8	exSCALE-SLOW,exSCALE-FAST,exSpeaker,exInfra, \
-			exAVLAN,exVmVendor, \
-			exSigns,HAM_BRIDGE,exRegistration 			-	Downlink
-TRUNK	ge-0/0/9	exSCALE-SLOW,exSCALE-FAST,exSpeaker,exInfra, \
-			exAVLAN,exVmVendor, \
-			exSigns,HAM_BRIDGE,exRegistration 			-	Downlink
-TRUNK	ge-0/0/10	exSCALE-SLOW,exSCALE-FAST,exSpeaker,exInfra, \
-			exAVLAN,exVmVendor, \
-			exSigns,HAM_BRIDGE,exRegistration 			-	Downlink
-TRUNK	ge-0/0/11	exSCALE-SLOW,exSCALE-FAST,exSpeaker,exInfra, \
-			exAVLAN,exVmVendor, \
-			exSigns,HAM_BRIDGE,exRegistration 			-	Downlink
-TRUNK	ge-0/0/12	exSCALE-SLOW,exSCALE-FAST,exSpeaker,exInfra, \
-			exAVLAN,exVmVendor, \
-			exSigns,HAM_BRIDGE,exRegistration 			-	Downlink
-TRUNK	ge-0/0/13	exSCALE-SLOW,exSCALE-FAST,exSpeaker,exInfra, \
-			exAVLAN,exVmVendor, \
-			exSigns,HAM_BRIDGE,exRegistration 			-	Downlink
-TRUNK	ge-0/0/14	exSCALE-SLOW,exSCALE-FAST,exSpeaker,exInfra, \
-			exAVLAN,exVmVendor, \
-			exSigns,HAM_BRIDGE,exRegistration 			-	Downlink
-TRUNK	ge-0/0/15	exSCALE-SLOW,exSCALE-FAST,exSpeaker,exInfra, \
-			exAVLAN,exVmVendor, \
-			exSigns,HAM_BRIDGE,exRegistration 			-	Downlink
-TRUNK	ge-0/0/16	exSCALE-SLOW,exSCALE-FAST,exSpeaker,exInfra, \
-			exAVLAN,exVmVendor, \
-			exSigns,HAM_BRIDGE,exRegistration 			-	Downlink
-TRUNK	ge-0/0/17	exSCALE-SLOW,exSCALE-FAST,exSpeaker,exInfra, \
-			exAVLAN,exVmVendor, \
-			exSigns,HAM_BRIDGE,exRegistration 			-	Downlink
-TRUNK	ge-0/0/18	exSCALE-SLOW,exSCALE-FAST,exSpeaker,exInfra, \
-			exAVLAN,exVmVendor, \
-			exSigns,HAM_BRIDGE,exRegistration 			-	Downlink
-TRUNK	ge-0/0/19	exSCALE-SLOW,exSCALE-FAST,exSpeaker,exInfra, \
-			exAVLAN,exVmVendor, \
-			exSigns,HAM_BRIDGE,exRegistration 			-	Downlink
-TRUNK	ge-0/0/20	exSCALE-SLOW,exSCALE-FAST,exSpeaker,exInfra, \
-			exAVLAN,exVmVendor, \
-			exSigns,HAM_BRIDGE,exRegistration 			-	Downlink
-TRUNK	ge-0/0/21	exSCALE-SLOW,exSCALE-FAST,exSpeaker,exInfra, \
-			exAVLAN,exVmVendor, \
-			exSigns,HAM_BRIDGE,exRegistration 			-	Downlink
-TRUNK	ge-0/0/22	exSCALE-SLOW,exSCALE-FAST,exSpeaker,exInfra, \
-			exAVLAN,exVmVendor, \
-			exSigns,HAM_BRIDGE,exRegistration 			-	Downlink
-TRUNK	ge-0/0/23	exSCALE-SLOW,exSCALE-FAST,exSpeaker,exInfra, \
-			exAVLAN,exVmVendor, \
-			exSigns,HAM_BRIDGE,exRegistration 			-	Downlink
+TRUNK	ge-0/0/0	exSCALE-SLOW,exSCALE-FAST,exSpeaker,exInfra, exAVLAN,exVmVendor, exSigns,HAM_BRIDGE,exRegistration 			-	Uplink
+TRUNK	ge-0/0/1	exSCALE-SLOW,exSCALE-FAST,exSpeaker,exInfra, exAVLAN,exVmVendor, exSigns,HAM_BRIDGE,exRegistration 			-	Downlink
+TRUNK	ge-0/0/2	exSCALE-SLOW,exSCALE-FAST,exSpeaker,exInfra, exAVLAN,exVmVendor, exSigns,HAM_BRIDGE,exRegistration 			-	Downlink
+TRUNK	ge-0/0/3	exSCALE-SLOW,exSCALE-FAST,exSpeaker,exInfra, exAVLAN,exVmVendor, exSigns,HAM_BRIDGE,exRegistration 			-	Downlink
+TRUNK	ge-0/0/4	exSCALE-SLOW,exSCALE-FAST,exSpeaker,exInfra, exAVLAN,exVmVendor, exSigns,HAM_BRIDGE,exRegistration 			-	Downlink
+TRUNK	ge-0/0/5	exSCALE-SLOW,exSCALE-FAST,exSpeaker,exInfra, exAVLAN,exVmVendor, exSigns,HAM_BRIDGE,exRegistration 			-	Downlink
+TRUNK	ge-0/0/6	exSCALE-SLOW,exSCALE-FAST,exSpeaker,exInfra, exAVLAN,exVmVendor, exSigns,HAM_BRIDGE,exRegistration 			-	Downlink
+TRUNK	ge-0/0/7	exSCALE-SLOW,exSCALE-FAST,exSpeaker,exInfra, exAVLAN,exVmVendor, exSigns,HAM_BRIDGE,exRegistration 			-	Downlink
+TRUNK	ge-0/0/8	exSCALE-SLOW,exSCALE-FAST,exSpeaker,exInfra, exAVLAN,exVmVendor, exSigns,HAM_BRIDGE,exRegistration 			-	Downlink
+TRUNK	ge-0/0/9	exSCALE-SLOW,exSCALE-FAST,exSpeaker,exInfra, exAVLAN,exVmVendor, exSigns,HAM_BRIDGE,exRegistration 			-	Downlink
+TRUNK	ge-0/0/10	exSCALE-SLOW,exSCALE-FAST,exSpeaker,exInfra, exAVLAN,exVmVendor, exSigns,HAM_BRIDGE,exRegistration 			-	Downlink
+TRUNK	ge-0/0/11	exSCALE-SLOW,exSCALE-FAST,exSpeaker,exInfra, exAVLAN,exVmVendor, exSigns,HAM_BRIDGE,exRegistration 			-	Downlink
+TRUNK	ge-0/0/12	exSCALE-SLOW,exSCALE-FAST,exSpeaker,exInfra, exAVLAN,exVmVendor, exSigns,HAM_BRIDGE,exRegistration 			-	Downlink
+TRUNK	ge-0/0/13	exSCALE-SLOW,exSCALE-FAST,exSpeaker,exInfra, exAVLAN,exVmVendor, exSigns,HAM_BRIDGE,exRegistration 			-	Downlink
+TRUNK	ge-0/0/14	exSCALE-SLOW,exSCALE-FAST,exSpeaker,exInfra, exAVLAN,exVmVendor, exSigns,HAM_BRIDGE,exRegistration 			-	Downlink
+TRUNK	ge-0/0/15	exSCALE-SLOW,exSCALE-FAST,exSpeaker,exInfra, exAVLAN,exVmVendor, exSigns,HAM_BRIDGE,exRegistration 			-	Downlink
+TRUNK	ge-0/0/16	exSCALE-SLOW,exSCALE-FAST,exSpeaker,exInfra, exAVLAN,exVmVendor, exSigns,HAM_BRIDGE,exRegistration 			-	Downlink
+TRUNK	ge-0/0/17	exSCALE-SLOW,exSCALE-FAST,exSpeaker,exInfra, exAVLAN,exVmVendor, exSigns,HAM_BRIDGE,exRegistration 			-	Downlink
+TRUNK	ge-0/0/18	exSCALE-SLOW,exSCALE-FAST,exSpeaker,exInfra, exAVLAN,exVmVendor, exSigns,HAM_BRIDGE,exRegistration 			-	Downlink
+TRUNK	ge-0/0/19	exSCALE-SLOW,exSCALE-FAST,exSpeaker,exInfra, exAVLAN,exVmVendor, exSigns,HAM_BRIDGE,exRegistration 			-	Downlink
+TRUNK	ge-0/0/20	exSCALE-SLOW,exSCALE-FAST,exSpeaker,exInfra, exAVLAN,exVmVendor, exSigns,HAM_BRIDGE,exRegistration 			-	Downlink
+TRUNK	ge-0/0/21	exSCALE-SLOW,exSCALE-FAST,exSpeaker,exInfra, exAVLAN,exVmVendor, exSigns,HAM_BRIDGE,exRegistration 			-	Downlink
+TRUNK	ge-0/0/22	exSCALE-SLOW,exSCALE-FAST,exSpeaker,exInfra, exAVLAN,exVmVendor, exSigns,HAM_BRIDGE,exRegistration 			-	Downlink
+TRUNK	ge-0/0/23	exSCALE-SLOW,exSCALE-FAST,exSpeaker,exInfra, exAVLAN,exVmVendor, exSigns,HAM_BRIDGE,exRegistration 			-	Downlink
 TRUNK	ge-0/0/24	exSCALE-SLOW,exSCALE-FAST,exInfra 			POE	AP
 TRUNK	ge-0/0/25	exSCALE-SLOW,exSCALE-FAST,exInfra 			POE	AP
 TRUNK	ge-0/0/26	exSCALE-SLOW,exSCALE-FAST,exInfra 			POE	AP
@@ -85,6 +37,4 @@ TRUNK	ge-0/0/34	exSCALE-SLOW,exSCALE-FAST,exInfra 			POE	AP
 TRUNK	ge-0/0/35	exSCALE-SLOW,exSCALE-FAST,exInfra 			POE	AP
 VLAN	exSigns		4							POE	// ge-0/0/{36-39}
 RSRVD	8										// ge-0/0/{40-47}
-FIBER	ge-0/1/0	exSCALE-SLOW,exSCALE-FAST,exSpeaker,exInfra, \
-			exAVLAN,exVmVendor, \
-			exSigns,HAM_BRIDGE,exRegistration	Uplink
+FIBER	ge-0/1/0	exSCALE-SLOW,exSCALE-FAST,exSpeaker,exInfra, exAVLAN,exVmVendor, exSigns,HAM_BRIDGE,exRegistration	Uplink


### PR DESCRIPTION
## Description of PR

- Formats switch-config/type so that each config is a single line
- Adds a datasources test for switchconfig types

## Previous Behavior

There was no automation to enforce consistency across switch config types.

## Tests

This pr adds tests. I would appreciate feed back on how to make sure I didn't break any automation that parses the switch configs and relies on using \ to split a config across lines.

closes #676 
