### PR TITLE
[REVIEW] - udhcp.user uci commit only new hostnames

### DIFF
--- a/openwrt/files/etc/udhcpc.user
+++ b/openwrt/files/etc/udhcpc.user
@@ -21,17 +21,18 @@ case "$1" in
       /root/bin/apinger-pop.sh "$router"
     fi
 
-    if [ ! -z "$hostname" ]; then
+    if [ ! -z "$hostname" ] && [ `echo "$HOSTNAME" | tr '[A-Z]' '[a-z]'` != `echo "$hostname" | tr '[A-Z]' '[a-z]'` ]; then
+      # set new hostname
       uci set 'system.@system[0].hostname'="$hostname"
       uci commit
-      if [ `echo "$HOSTNAME" | tr '[A-Z]' '[a-z]'` != `echo "$hostname" | tr '[A-Z]' '[a-z]'` ]; then
-        # reload/restart whatever needs the hostname updated
-        /etc/init.d/system reload
-        service zabbix_agentd restart
-        service rsyslog restart
-        service lldpd restart
-      fi
+
+      # reload/restart whatever needs the hostname updated
+      /etc/init.d/system reload
+      service zabbix_agentd restart
+      service rsyslog restart
+      service lldpd restart
     fi
+
     if [ ! -z "$opt226" ]; then
       /root/bin/config-version.sh -c $(printf %d "0x$opt226")
     fi

--- a/tests/unit/openwrt/golden/ar71xx/etc/udhcpc.user
+++ b/tests/unit/openwrt/golden/ar71xx/etc/udhcpc.user
@@ -21,17 +21,18 @@ case "$1" in
       /root/bin/apinger-pop.sh "$router"
     fi
 
-    if [ ! -z "$hostname" ]; then
+    if [ ! -z "$hostname" ] && [ `echo "$HOSTNAME" | tr '[A-Z]' '[a-z]'` != `echo "$hostname" | tr '[A-Z]' '[a-z]'` ]; then
+      # set new hostname
       uci set 'system.@system[0].hostname'="$hostname"
       uci commit
-      if [ `echo "$HOSTNAME" | tr '[A-Z]' '[a-z]'` != `echo "$hostname" | tr '[A-Z]' '[a-z]'` ]; then
-        # reload/restart whatever needs the hostname updated
-        /etc/init.d/system reload
-        service zabbix_agentd restart
-        service rsyslog restart
-        service lldpd restart
-      fi
+
+      # reload/restart whatever needs the hostname updated
+      /etc/init.d/system reload
+      service zabbix_agentd restart
+      service rsyslog restart
+      service lldpd restart
     fi
+
     if [ ! -z "$opt226" ]; then
       /root/bin/config-version.sh -c $(printf %d "0x$opt226")
     fi

--- a/tests/unit/openwrt/golden/ipq806x/etc/udhcpc.user
+++ b/tests/unit/openwrt/golden/ipq806x/etc/udhcpc.user
@@ -21,17 +21,18 @@ case "$1" in
       /root/bin/apinger-pop.sh "$router"
     fi
 
-    if [ ! -z "$hostname" ]; then
+    if [ ! -z "$hostname" ] && [ `echo "$HOSTNAME" | tr '[A-Z]' '[a-z]'` != `echo "$hostname" | tr '[A-Z]' '[a-z]'` ]; then
+      # set new hostname
       uci set 'system.@system[0].hostname'="$hostname"
       uci commit
-      if [ `echo "$HOSTNAME" | tr '[A-Z]' '[a-z]'` != `echo "$hostname" | tr '[A-Z]' '[a-z]'` ]; then
-        # reload/restart whatever needs the hostname updated
-        /etc/init.d/system reload
-        service zabbix_agentd restart
-        service rsyslog restart
-        service lldpd restart
-      fi
+
+      # reload/restart whatever needs the hostname updated
+      /etc/init.d/system reload
+      service zabbix_agentd restart
+      service rsyslog restart
+      service lldpd restart
     fi
+
     if [ ! -z "$opt226" ]; then
       /root/bin/config-version.sh -c $(printf %d "0x$opt226")
     fi


### PR DESCRIPTION
## Description of PR

Instead of always committing a provided hostname, only commit new hostnames, where the new hostname doesn't match the current hostname.

Resolves #442 

## Previous Behavior

Any time a hostname value was available, `udhcp.user` would `uci commit` the new hostname.

## New Behavior

`udhcp.user` will only `uci commit` the hostname if it is different than the current hostname.

## Tests

(need some help here)
- [ ] test against AP hardware (monitor for `uci commits`)
- [ ] provide the same hostname change to the device
- [ ] provide a new hostname to the device
