### PR TITLE
[READY] - devServer disko config

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,5 +1,26 @@
 {
   "nodes": {
+    "disko": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs-unstable"
+        ]
+      },
+      "locked": {
+        "lastModified": 1725377834,
+        "narHash": "sha256-tqoAO8oT6zEUDXte98cvA1saU9+1dLJQe3pMKLXv8ps=",
+        "owner": "nix-community",
+        "repo": "disko",
+        "rev": "e55f9a8678adc02024a4877c2a403e3f6daf24fe",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "disko",
+        "rev": "e55f9a8678adc02024a4877c2a403e3f6daf24fe",
+        "type": "github"
+      }
+    },
     "flake-parts": {
       "inputs": {
         "nixpkgs-lib": [
@@ -95,6 +116,7 @@
     },
     "root": {
       "inputs": {
+        "disko": "disko",
         "flake-parts": "flake-parts",
         "microvm": "microvm",
         "nixpkgs": "nixpkgs",

--- a/flake.nix
+++ b/flake.nix
@@ -17,6 +17,10 @@
       url = "github:numtide/treefmt-nix";
       inputs.nixpkgs.follows = "nixpkgs-unstable";
     };
+    disko = {
+      url = "github:nix-community/disko/e55f9a8678adc02024a4877c2a403e3f6daf24fe";
+      inputs.nixpkgs.follows = "nixpkgs-unstable";
+    };
   };
 
   outputs =

--- a/nix/machines/devServer/disko.nix
+++ b/nix/machines/devServer/disko.nix
@@ -1,0 +1,100 @@
+{
+  disko.devices = {
+    disk = {
+      one = {
+        type = "disk";
+        device = "/dev/disk/by-id/wwn-0x5000c500b794a007";
+        content = {
+          type = "gpt";
+          partitions = {
+            ESP = {
+              size = "512M";
+              type = "EF00";
+              content = {
+                type = "filesystem";
+                format = "vfat";
+                mountpoint = "/boot";
+              };
+            };
+            zfs = {
+              size = "100%";
+              content = {
+                type = "zfs";
+                pool = "tank0";
+              };
+            };
+          };
+        };
+      };
+      two = {
+        type = "disk";
+        device = "/dev/disk/by-id/wwn-0x5000c500bca7d633";
+        content = {
+          type = "gpt";
+          partitions = {
+            # Support multiple disks to boot from
+            ESP = {
+              size = "512M";
+              type = "EF00";
+              content = {
+                type = "filesystem";
+                format = "vfat";
+                mountpoint = "/boot2";
+              };
+            };
+            zfs = {
+              size = "100%";
+              content = {
+                type = "zfs";
+                pool = "tank0";
+              };
+            };
+          };
+        };
+      };
+    };
+    zpool = {
+      tank0 = {
+        type = "zpool";
+        mode = "mirror";
+        # Workaround: cannot import 'tank0': I/O error in disko tests
+        options.cachefile = "none";
+        rootFsOptions = {
+          compression = "zstd";
+          "com.sun:auto-snapshot" = "true";
+          acltype = "posixacl";
+          xattr = "sa";
+          canmount = "off";
+          mountpoint = "none";
+        };
+        options = {
+          ashift = "12";
+          autotrim = "on";
+        };
+
+        datasets = {
+          "root" = {
+            type = "zfs_fs";
+            mountpoint = "/";
+            options.mountpoint = "legacy";
+          };
+          "home" = {
+            type = "zfs_fs";
+            mountpoint = "/home";
+            options.mountpoint = "legacy";
+          };
+          "nix" = {
+            type = "zfs_fs";
+            mountpoint = "/nix";
+            options.mountpoint = "legacy";
+          };
+          "persist" = {
+            type = "zfs_fs";
+            mountpoint = "/persist";
+            options.mountpoint = "legacy";
+          };
+        };
+      };
+    };
+  };
+}

--- a/nix/machines/devServer/hardware-configuration.nix
+++ b/nix/machines/devServer/hardware-configuration.nix
@@ -23,35 +23,6 @@
   boot.kernelModules = [ "kvm-intel" ];
   boot.extraModulePackages = [ ];
 
-  fileSystems."/" = {
-    device = "zroot/root";
-    fsType = "zfs";
-  };
-  fileSystems."/boot" = {
-    device = "/dev/disk/by-uuid/063A-73D6";
-    fsType = "vfat";
-    options = [ "nofail" ];
-  };
-  fileSystems."/boot2" = {
-    device = "/dev/disk/by-uuid/0655-58C2";
-    fsType = "vfat";
-    options = [ "nofail" ];
-  };
-  fileSystems."/nix" = {
-    device = "zroot/nix";
-    fsType = "zfs";
-  };
-
-  fileSystems."/home" = {
-    device = "zroot/home";
-    fsType = "zfs";
-  };
-
-  fileSystems."/persist" = {
-    device = "zroot/persist";
-    fsType = "zfs";
-  };
-
   swapDevices = [ ];
 
   nixpkgs.hostPlatform = lib.mkDefault "x86_64-linux";
@@ -74,5 +45,5 @@
   };
 
   # ZFS uniq system ID
-  networking.hostId = "74405d06";
+  networking.hostId = "713fdc74";
 }

--- a/nix/machines/devServer/hardware-configuration.nix
+++ b/nix/machines/devServer/hardware-configuration.nix
@@ -17,6 +17,7 @@
     "usbhid"
     "usb_storage"
     "sd_mod"
+    "megaraid_sas"
   ];
   boot.initrd.kernelModules = [ ];
   boot.kernelModules = [ "kvm-intel" ];

--- a/nix/machines/flake-module.nix
+++ b/nix/machines/flake-module.nix
@@ -34,6 +34,8 @@ in
     devServer = lib.nixosSystem {
       system = "x86_64-linux";
       modules = [
+        inputs.disko.nixosModules.disko
+        ./devServer/disko.nix
         ./_common/base.nix
         ./_common/users.nix
         ./devServer/default.nix


### PR DESCRIPTION
## Description of PR

Instead of leveraging something like https://github.com/socallinuxexpo/scale-network/blob/ef74408a99827005e7e36f5b2b5ab78784611f1e/nix/machines/bootstrap/bootstrap.sh this moves our provisioning of systems to disko.

This configuration was used to setup the devServer utilizing the 500GB disks in a mirror.

## Previous Behavior

- Previous disks were utilizing the 30 GB SSDs

## New Behavior

- Leverage 500 GB disks for devServer usage

## Tests

- `devServer` is online
