### PR TITLE
[READY] - gitlab-ci nix flake check on devServer

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -6,6 +6,15 @@ stages:
   - test
   - build
   - integ
+# Nix build all the things
+nix-checks:
+  tags:
+    - nix
+  stage: test
+  # Takes more than 1 hr to build on gitlab shared runners
+  timeout: 1 hour
+  script:
+    - nix flake check
 # This build takes a long time and should be done
 # outside of initial PR CI testing
 openwrt-ar71xx-build:


### PR DESCRIPTION
## Description of PR

Requires #789

Previous #https://github.com/socallinuxexpo/scale-network/pull/770 testing improvements have had to work around limitation of GHA (no nested VM capabilities) and limited resourcing (running existing nix GHA tests on PRs exhausts rate limits).

This enables tests to run on our own dev server self-hosted runner (PR to follow).

## Previous Behavior

- GHA and gitlab SaaS were to the only way to run CI jobs

## New Behavior

- Tag specific jobs and have them run on the dev server

## Tests

- https://gitlab.com/socallinuxexpo/scale-network/-/pipelines/1532846314
