### PR TITLE
[READY] - init devServer gitlab runner

### DIFF
--- a/CI.md
+++ b/CI.md
@@ -37,10 +37,3 @@ Wormhole code is: 8-amusement-drumbeat
 ```
 
 4. This will kickoff the flash and reply with a gitlab pipeline URL.
-
-## Gitlab CI
-
-See the pipelines defined: https://github.com/socallinuxexpo/scale-network/blob/master/.gitlab-ci.yml
-
-Our [autoflash process](./openwrt/docs/AUTOFLASH.md) leverages `gitlab-runners` to be able to interact with real hardware so that
-we can automate the flashing process to test our openwrt images.

--- a/README.md
+++ b/README.md
@@ -11,7 +11,8 @@
 ## Table of Contents
 
 - [CONTRIBUTING](./CONTRIBUTING.md)
-- [CI](./CI.md)
+- [GitHub Actions CI](./CI.md)
+- [Gitlab CI](./docs/gitlab-ci.md)
 - [MAPS](./MAPS.md)
 - [SWITCH CONFIG](./switch-configuration/README.md)
 - [OPENWRT](./openwrt/README.md)

--- a/docs/gitlab-ci.md
+++ b/docs/gitlab-ci.md
@@ -1,0 +1,21 @@
+# Gitlab
+
+See the pipelines defined: https://github.com/socallinuxexpo/scale-network/blob/master/.gitlab-ci.yml
+
+Our [autoflash process](./openwrt/docs/AUTOFLASH.md) leverages `gitlab-runners` to be able to interact with real hardware so that
+we can automate the flashing process to test our openwrt images.
+
+## Generate token for runner
+
+1. Navigate to the [runner page](https://gitlab.com/groups/socallinuxexpo/-/runners)
+
+1. Click the `New Group Runner`
+
+1. Ensure that you have the right tags for the runner. These should match the `.gitlab-ci` jobs you expect to run.
+
+1. Add a description and set an appropriate timeout if different from the default.
+
+1. Take the token and place it on the runner.
+
+> NOTE: Runners cannot be configured with additional tags or config. These are encoded into the token. Should these
+> config need to change you'll need a new token.

--- a/flake.lock
+++ b/flake.lock
@@ -84,16 +84,16 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1695830400,
-        "narHash": "sha256-gToZXQVr0G/1WriO83olnqrLSHF2Jb8BPcmCt497ro0=",
+        "lastModified": 1728500571,
+        "narHash": "sha256-dOymOQ3AfNI4Z337yEwHGohrVQb4yPODCW9MDUyAc4w=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "8a86b98f0ba1c405358f1b71ff8b5e1d317f5db2",
+        "rev": "d51c28603def282a24fa034bcb007e2bcb5b5dd0",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixos-unstable",
+        "ref": "nixos-24.05",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -11,7 +11,7 @@
       inputs.nixpkgs.follows = "nixpkgs";
       inputs.spectrum.follows = "";
     }; # Currently using this fork since the upstream seems to be causing an issue
-    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-24.05";
     nixpkgs-unstable.url = "github:NixOS/nixpkgs/nixos-unstable";
     treefmt-nix = {
       url = "github:numtide/treefmt-nix";

--- a/nix/machines/devServer/default.nix
+++ b/nix/machines/devServer/default.nix
@@ -3,6 +3,7 @@
 {
   imports = [
     ./libvirt.nix
+    ./gitlab.nix
   ];
   # remove the annoying experimental warnings
   nix.extraOptions = ''

--- a/nix/machines/devServer/gitlab.nix
+++ b/nix/machines/devServer/gitlab.nix
@@ -1,0 +1,17 @@
+{ pkgs, ... }:
+{
+  services.gitlab-runner = {
+    enable = true;
+    gracefulTermination = true;
+    services = {
+      shell = {
+        # make sure this is a quote path so it doesnt end up in /nix/store
+        authenticationTokenConfigFile = "/persist/etc/gitlab/shellAuthToken.env";
+        executor = "shell";
+      };
+    };
+  };
+
+  # include for gl-runner cli
+  environment.systemPackages = [ pkgs.gitlab-runner ];
+}

--- a/nix/machines/flake-module.nix
+++ b/nix/machines/flake-module.nix
@@ -40,7 +40,6 @@ in
         ./_common/users.nix
         ./devServer/default.nix
         ./devServer/hardware-configuration.nix
-        inputs.microvm.nixosModules.host
       ];
     };
     loghost = lib.nixosSystem {


### PR DESCRIPTION
## Description of PR

Putting the devServer to work and adding a hosted gitlab-runner. Currently trigger on the `nix` tag.

This will allow us to run `nix flake check` (includes vm tests)

Had to bump to nixos-24.05 since we were pretty behind (~2023) for our flake input `nixpkgs`. Will probably move to unstable after getting more time to test.

## Previous Behavior

- no runner on `devServer`

## New Behavior

- gitlab-runner on `devServer`

## Tests

- `nix flake check` passes for this branch to ensure out vmTests work with new nixpkgs
- Tested using https://github.com/socallinuxexpo/scale-network/pull/788 for actual ci runs
