### PR TITLE
Add Juniper root passwd SHA-256 Hash

### DIFF
--- a/facts/secrets/jroot_pw
+++ b/facts/secrets/jroot_pw
@@ -1,0 +1,1 @@
+$5$4aLYtrAyHVFjo1ZQ$lKFOTeeNqop9U3ggCdwOVUF4qJaHEgj23tnuqyOQ7e9


### PR DESCRIPTION
## Description of PR

Add Juniper root passwd SHA-256 Hash, to simplify switch config builds.

## Previous Behavior

The file had to be created before generating switch configs.

## New Behavior

This will help in automatically generating switch configs, to leverage Juniper's event handling and ZTP (zero touch provisioning mechanisms), to push configs and firmware to devices.