### PR TITLE
[READY] - perl packages for devShell.networkSub to run switch_config_loader

### DIFF
--- a/nix/dev-shells/default.nix
+++ b/nix/dev-shells/default.nix
@@ -54,6 +54,7 @@ inputs.nixpkgs.lib.genAttrs
         perlPackages.NetSFTPForeign
         scale-network.perlNetArp
         scale-network.perlNetInterface
+        scale-network.perlNetPing
         ghostscript
       ];
     in

--- a/nix/dev-shells/default.nix
+++ b/nix/dev-shells/default.nix
@@ -48,6 +48,12 @@ inputs.nixpkgs.lib.genAttrs
 
       networkSub = with pkgs; [
         perl
+        perlPackages.libnet
+        perlPackages.Expect
+        perlPackages.TermReadKey
+        perlPackages.NetSFTPForeign
+        scale-network.perlNetArp
+        scale-network.perlNetInterface
         ghostscript
       ];
     in

--- a/nix/packages/default.nix
+++ b/nix/packages/default.nix
@@ -11,5 +11,6 @@ inputs.nixpkgs.lib.genAttrs
       serverspec
       perlNetArp
       perlNetInterface
+      perlNetPing
       ;
   })

--- a/nix/packages/default.nix
+++ b/nix/packages/default.nix
@@ -10,5 +10,6 @@ inputs.nixpkgs.lib.genAttrs
       scaleInventory
       serverspec
       perlNetArp
+      perlNetInterface
       ;
   })

--- a/nix/packages/default.nix
+++ b/nix/packages/default.nix
@@ -9,5 +9,6 @@ inputs.nixpkgs.lib.genAttrs
       massflash
       scaleInventory
       serverspec
+      perlNetArp
       ;
   })

--- a/nix/packages/perl-net-arp/package.nix
+++ b/nix/packages/perl-net-arp/package.nix
@@ -1,0 +1,13 @@
+{
+  perlPackages,
+  fetchurl,
+}:
+
+perlPackages.buildPerlPackage {
+  pname = "NetArp";
+  version = "1.0.12";
+  src = fetchurl {
+    url = "mirror://cpan/authors/id/C/CR/CRAZYDJ/Net-ARP-1.0.12.tar.gz";
+    hash = "sha256-KK2GBaOh4PhoqYmIJvVGHYCSPm66GtXgRzfmDoug7HA=";
+  };
+}

--- a/nix/packages/perl-net-interface/net-interface-remove-grep-af-inet.patch
+++ b/nix/packages/perl-net-interface/net-interface-remove-grep-af-inet.patch
@@ -1,0 +1,16 @@
+diff --git a/Makefile.PL b/Makefile.PL
+index 973e65e..6ad0d51 100644
+--- a/Makefile.PL
++++ b/Makefile.PL
+@@ -176,11 +176,6 @@ unless (open(F,'./netsymbolC.inc')) {
+   exit;
+ }
+ 
+-unless (scalar grep {/# define\s+_NI_AF_INET/} (<F>)) {
+-  close F;
+-  die "AF_INET not found in netsymbolsC.inc,\nprerequisite development library header files missing from /usr/include/sys\n";
+-  exit 0;
+-}
+ close F;
+ 
+ WriteMakefile(%makeparms);

--- a/nix/packages/perl-net-interface/package.nix
+++ b/nix/packages/perl-net-interface/package.nix
@@ -2,12 +2,13 @@
   perlPackages,
   fetchurl,
   linuxHeaders,
+  which
 }:
 
 perlPackages.buildPerlPackage {
   pname = "NetInterface";
   version = "1.016";
-  buildInputs = [ linuxHeaders ];
+  buildInputs = [ linuxHeaders which ];
   doCheck = false;
   src = fetchurl {
     url = "mirror://cpan/authors/id/M/MI/MIKER/Net-Interface-1.016.tar.gz";

--- a/nix/packages/perl-net-interface/package.nix
+++ b/nix/packages/perl-net-interface/package.nix
@@ -1,29 +1,17 @@
 {
   perlPackages,
   fetchurl,
-  linuxHeaders,
-  which
 }:
-
 perlPackages.buildPerlPackage {
   pname = "NetInterface";
   version = "1.016";
-  buildInputs = [ linuxHeaders which ];
-  doCheck = false;
-
-  CPPFLAGS="-Iusr/include";
-
-  postPatch = ''
-    mkdir -p usr/include/sys/
-    cp -pr ${linuxHeaders}/include usr/
-    ln -s ${linuxHeaders}/include/linux/socket.h usr/include/sys/socket.h
-    ls -lahR usr/
-    echo "aaaaaaaa"
-    echo $CPPFLAGS
-  '';
 
   src = fetchurl {
     url = "mirror://cpan/authors/id/M/MI/MIKER/Net-Interface-1.016.tar.gz";
     hash = "sha256-e+RGk14BPQ7dPTcfkvuQo7s4q+mVYoidgXiVMSnlNQg=";
   };
+
+  patches = [ ./net-interface-remove-grep-af-inet.patch ];
+
+  doCheck = false;
 }

--- a/nix/packages/perl-net-interface/package.nix
+++ b/nix/packages/perl-net-interface/package.nix
@@ -1,0 +1,16 @@
+{
+  perlPackages,
+  fetchurl,
+  linuxHeaders,
+}:
+
+perlPackages.buildPerlPackage {
+  pname = "NetInterface";
+  version = "1.015";
+  buildInputs = [ linuxHeaders ];
+  doCheck = false;
+  src = fetchurl {
+    url = "mirror://cpan/authors/id/M/MI/MIKER/Net-Interface-1.015.tar.gz";
+    hash = "sha256-x6MFjTGh73k+eAtqTJCQEI/SxMNFeQ774AeFKgIvf4E=";
+  };
+}

--- a/nix/packages/perl-net-interface/package.nix
+++ b/nix/packages/perl-net-interface/package.nix
@@ -6,11 +6,11 @@
 
 perlPackages.buildPerlPackage {
   pname = "NetInterface";
-  version = "1.015";
+  version = "1.016";
   buildInputs = [ linuxHeaders ];
   doCheck = false;
   src = fetchurl {
-    url = "mirror://cpan/authors/id/M/MI/MIKER/Net-Interface-1.015.tar.gz";
-    hash = "sha256-x6MFjTGh73k+eAtqTJCQEI/SxMNFeQ774AeFKgIvf4E=";
+    url = "mirror://cpan/authors/id/M/MI/MIKER/Net-Interface-1.016.tar.gz";
+    hash = "sha256-e+RGk14BPQ7dPTcfkvuQo7s4q+mVYoidgXiVMSnlNQg=";
   };
 }

--- a/nix/packages/perl-net-interface/package.nix
+++ b/nix/packages/perl-net-interface/package.nix
@@ -10,6 +10,18 @@ perlPackages.buildPerlPackage {
   version = "1.016";
   buildInputs = [ linuxHeaders which ];
   doCheck = false;
+
+  CPPFLAGS="-Iusr/include";
+
+  postPatch = ''
+    mkdir -p usr/include/sys/
+    cp -pr ${linuxHeaders}/include usr/
+    ln -s ${linuxHeaders}/include/linux/socket.h usr/include/sys/socket.h
+    ls -lahR usr/
+    echo "aaaaaaaa"
+    echo $CPPFLAGS
+  '';
+
   src = fetchurl {
     url = "mirror://cpan/authors/id/M/MI/MIKER/Net-Interface-1.016.tar.gz";
     hash = "sha256-e+RGk14BPQ7dPTcfkvuQo7s4q+mVYoidgXiVMSnlNQg=";

--- a/nix/packages/perl-net-ping/linux-isroot-capability.patch
+++ b/nix/packages/perl-net-ping/linux-isroot-capability.patch
@@ -1,0 +1,48 @@
+diff --git a/lib/Net/Ping.pm b/lib/Net/Ping.pm
+index 0b7be8c..60aca57 100644
+--- a/lib/Net/Ping.pm
++++ b/lib/Net/Ping.pm
+@@ -227,13 +227,21 @@ sub new
+   }
+   elsif ($self->{proto} eq "icmp")
+   {
+-    croak("icmp ping requires root privilege") if !_isroot();
++    croak("icmp ping requires root privilege") if !_isroot() && ($^O ne "linux");
+     $self->{proto_num} = eval { (getprotobyname('icmp'))[2] } ||
+       croak("Can't get icmp protocol by name");
+     $self->{pid} = $$ & 0xffff;           # Save lower 16 bits of pid
+     $self->{fh} = FileHandle->new();
+-    socket($self->{fh}, PF_INET, SOCK_RAW, $self->{proto_num}) ||
+-      croak("icmp socket error - $!");
++    if ($^O eq "linux")
++    {
++	    socket($self->{fh}, PF_INET, SOCK_DGRAM, $self->{proto_num}) ||
++	      croak("icmp socket error - $!");
++    }
++    else
++    {
++	    socket($self->{fh}, PF_INET, SOCK_RAW, $self->{proto_num}) ||
++	      croak("icmp socket error - $!");
++    }
+     $self->_setopts();
+     if ($self->{'ttl'}) {
+       setsockopt($self->{fh}, IPPROTO_IP, IP_TTL, pack("I*", $self->{'ttl'}))
+@@ -250,8 +258,16 @@ sub new
+       croak("Can't get ipv6-icmp protocol by name"); # 58
+     $self->{pid} = $$ & 0xffff;           # Save lower 16 bits of pid
+     $self->{fh} = FileHandle->new();
+-    socket($self->{fh}, $AF_INET6, SOCK_RAW, $self->{proto_num}) ||
+-      croak("icmp socket error - $!");
++    if ($^O eq "linux")
++    {
++	    socket($self->{fh}, $AF_INET6, SOCK_DGRAM, $self->{proto_num}) ||
++	      croak("icmp socket error - $!");
++    }
++    else
++    {
++	    socket($self->{fh}, $AF_INET6, SOCK_RAW, $self->{proto_num}) ||
++	      croak("icmp socket error - $!");
++    }
+     $self->_setopts();
+     if ($self->{'gateway'}) {
+       my $g = $self->{gateway};

--- a/nix/packages/perl-net-ping/package.nix
+++ b/nix/packages/perl-net-ping/package.nix
@@ -1,0 +1,9 @@
+{
+  perlPackages,
+}:
+
+perlPackages.NetPing.overrideAttrs {
+  # Owen's patch for _isroot should consider CAP_NET_RAW capability on Linux
+  # related to: https://rt.cpan.org/Public/Bug/Display.html?id=139820
+  patches = [ ./linux-isroot-capability.patch ];
+}


### PR DESCRIPTION
## Description of PR

Fixes: #801

This requires all of the perl libs to be able to run `switch_config_loader` from inside the devShell.networkSub

## Previous Behavior

- No perl lib deps existed in devShell.networkSub

## New Behavior

- perl lib deps exist in devShell.networkSub
- perl lib Net::Ping patch included in scale-network overlay

## Tests

- TBD
