### PR TITLE
[READY] - openwrt build follow up and github actions

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,7 +1,11 @@
 ## Description
 
+<!--
 Brief description of the Issue
+-->
 
 ## Acceptance Criteria
 
+<!--
 What is the expected outcome that resolves this issue?
+-->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,15 +1,28 @@
 ## Description of PR
 
-Brief description of the PR
+<!--
+Brief description of the changes in PR
+-->
 
 ## Previous Behavior
 
+<!--
+What was the behavior before this PR?
+
 Remove this section if not relevant
+-->
 
 ## New Behavior
 
+<!--
+What is the new behavior being introduced in this PR?
+
 Remove this section if not relevant
+-->
 
 ## Tests
 
-How was this PR tested?
+<!--
+How was this PR tested? Please provide as much detail as possible
+so we can ensure this change is working as intended before being merged.
+-->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,6 +2,9 @@
 
 <!--
 Brief description of the changes in PR
+
+If change is related to an open issue template include at the top of your
+description.
 -->
 
 ## Previous Behavior

--- a/.github/workflows/openwrt-build.yml
+++ b/.github/workflows/openwrt-build.yml
@@ -36,6 +36,8 @@ jobs:
           path: |
             openwrt/build/artifacts/*.tar.gz
           retention-days: 30
+          # Since we cant turn off compression set to lowest level
+          compression-level: 0
       - name: 'Upload openwrt build log'
         uses: actions/upload-artifact@v4.6.0
         with:

--- a/.github/workflows/openwrt-build.yml
+++ b/.github/workflows/openwrt-build.yml
@@ -28,7 +28,7 @@ jobs:
           cd openwrt
           TARGET=${{ matrix.target }} make templates build-img package 2>&1 | tee ${{ matrix.target }}-build.log
       - name: 'Upload openwrt build artifact tarball'
-        uses: actions/upload-artifact@v3.1.1
+        uses: actions/upload-artifact@v4.6.0
         with:
           name: ${{ matrix.target }}-openwrt-build-artifacts
           # Cant use relative pathing .. or . for artifacts action
@@ -37,7 +37,7 @@ jobs:
             openwrt/build/artifacts/*.tar.gz
           retention-days: 30
       - name: 'Upload openwrt build log'
-        uses: actions/upload-artifact@v3.1.1
+        uses: actions/upload-artifact@v4.6.0
         with:
           name: ${{ matrix.target }}-openwrt-buildlog
           path: |

--- a/.github/workflows/openwrt-build.yml
+++ b/.github/workflows/openwrt-build.yml
@@ -42,6 +42,8 @@ jobs:
           # this was the default behavior in v3.x
           # ref: https://github.com/actions/upload-artifact/blob/v3.1.1/README.md?plain=1#L152
           overwrite: true
+          # if we dont have images, scream loudly
+          if-no-files-found: "error"
       - name: 'Upload openwrt build log'
         uses: actions/upload-artifact@v4.6.0
         with:
@@ -50,3 +52,4 @@ jobs:
             openwrt/*build.log
           retention-days: 30
           overwrite: true
+          if-no-files-found: "error"

--- a/.github/workflows/openwrt-build.yml
+++ b/.github/workflows/openwrt-build.yml
@@ -38,6 +38,10 @@ jobs:
           retention-days: 30
           # Since we cant turn off compression set to lowest level
           compression-level: 0
+          # rerunning jobs overwrites artifacts from previous runs
+          # this was the default behavior in v3.x
+          # ref: https://github.com/actions/upload-artifact/blob/v3.1.1/README.md?plain=1#L152
+          overwrite: true
       - name: 'Upload openwrt build log'
         uses: actions/upload-artifact@v4.6.0
         with:
@@ -45,3 +49,4 @@ jobs:
           path: |
             openwrt/*build.log
           retention-days: 30
+          overwrite: true

--- a/.github/workflows/openwrt-build.yml
+++ b/.github/workflows/openwrt-build.yml
@@ -14,8 +14,8 @@ jobs:
     container:
       # Ubuntu 24.04
       image: sarcasticadmin/openwrt-build@sha256:25ac9d0dd4eeaad1aaaa7c82c09e9ecc103c69224fc55eb9717c4cfb018a5281
-      # Since user is ubuntu and gets 1000 from inside container
-      options: --user 1000
+      # Since user is openwrt and gets 1001 from inside container
+      options: --user 1001
     steps:
       - uses: actions/checkout@v1
         with:

--- a/.github/workflows/trigger.yml
+++ b/.github/workflows/trigger.yml
@@ -29,7 +29,7 @@ jobs:
           # is not a PR event
           REF=$(curl -sSf \
             --url ${{ steps.pr-standardize-comment.outputs.url }} \
-            --header 'Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}' \
+            --header 'Authorization: Bearer ${{ secrets.SCALE_GITHUB_TOKEN }}' \
             --header 'Content-Type: application/json' | jq -r '.head.ref' \
           )
           echo "subcomm=$SUBCOMM" >> $GITHUB_OUTPUT


### PR DESCRIPTION
## Description of PR

Relates to: #808
Fixes: #818 


Follow up to: #814 #815 (since both merged prematurely) and fixing some things in github actions

## Old Behavior
- existing openwrt-build github action is failing due to incorrect user id
- github actions: uplaod-artifacts@v3.x
- templates had instructions that would render if not deleted before posting 
- github removed one of our tokens named: GITHUB_* (which is now unusable due to naming requirements of env vars)

## New Behavior
- github action for openwrt-build set back to 1001 for user id
- updating our env var for github action trigger to gitlab. Can completely confirm this functionality until merged to `master`
- github action: upload-artifacts needs to be bumped ahead of deprecation #818
- Updated our templates so the instructions dont have to be removed when filling them out, exactly how nixpkgs works: https://github.com/NixOS/nixpkgs/blob/d8a92f0cf1c9e4825bd71b7e614a6b4063dba39c/.github/PULL_REQUEST_TEMPLATE.md

## Tests

- github action builds are working: https://github.com/socallinuxexpo/scale-network/actions/runs/13064758530
- gitlab runner with autoflash of the above image on ath79 (netgear wndr3800ch) is working: https://gitlab.com/socallinuxexpo/scale-network/-/jobs/8968109863
  - ~There is a slight issue with 2 of the tests which appear to be problem with the SHELL (`/bin/sh`) that comes on this build. I suspect theres something either related to /bin/sh being symlinked to /bin/dash or busybox oddities.~ This actually might just be an issue with the version of serverspec and ruby gems since using the nix devshell seems to work on the same build:
```
$ rake spec TEST_TYPE=openwrt TARGET_HOST=192.168.254.113
/nix/store/xkmg185m7hv3c5dv6dsbmfs1c5vf92p6-ruby-3.1.6/bin/ruby -I/nix/store/7fl8vynr2x1vfi1d2slvhp07nmdhby35-serverspec/lib/ruby/gems/3.1.0/gems/rspec-core-3.12.2/lib:/nix/store/7fl8vynr2x1vfi1d2slvhp07nmdhby35-serverspec/lib/ruby/gems/3.1.0/gems/rspec-support-3.12.1/lib /nix/store/h751jn4jignpp48d60wlpq05ariv18r6-ruby3.1-rspec-core-3.12.2/lib/ruby/gems/3.1.0/gems/rspec-core-3.12.2/exe/rspec --pattern spec/openwrt/\*_spec.rb

Image info:
Linux OpenWrt 6.6.68 #0 Mon Jan 27 16:23:54 2025 mips GNU/Linux
SCALE_VER=fd9d58a6b451f6a2d5384f7c978cdad34046a810
OPENWRT_VER=c8ea1aa970bf5a0275e3b0b7da777e804821ddcd
BUILD_ID="r0-fd9d58a"
OPENWRT_BOARD="ath79/generic"
OPENWRT_ARCH="mips_24kc"

shared
  Command "which apinger 2> /dev/null"
    exit_status
      is expected to eq 0
  Command "which awk 2> /dev/null"
    exit_status
      is expected to eq 0
  Command "which bash 2> /dev/null"
    exit_status
      is expected to eq 0
  Command "which logrotate 2> /dev/null"
    exit_status
      is expected to eq 0
  Command "which rsyslogd 2> /dev/null"
    exit_status
      is expected to eq 0
  Command "which tcpdump 2> /dev/null"
    exit_status
      is expected to eq 0
  Command "which snmpd 2> /dev/null"
    exit_status
      is expected to eq 1
  Command "which dropbear 2> /dev/null"
    exit_status
      is expected to eq 1
  Command "which logd 2> /dev/null"
    exit_status
      is expected to eq 1
  Command "pgrep apinger"
    exit_status
      is expected to eq 0
  Command "pgrep crond"
    exit_status
      is expected to eq 0
  Command "pgrep rsyslogd"
    exit_status
      is expected to eq 0
  Command "pgrep lldpd"
    exit_status
      is expected to eq 0
  Command "pgrep ntpd"
    exit_status
      is expected to eq 0
  Port "80"
    is expected not to be listening
  Port "9100"
    is expected to be listening
  Command "rsyslogd -N1"
    exit_status
      is expected to eq 0
  Command "logger "serverspec test msg""
    exit_status
      is expected to eq 0
  File "/root/bin/wifi-details.sh"
    is expected to exist
    is expected to be mode 750
    is expected to be owned by "root"
    is expected to be grouped into "root"
  File "/root/bin/config-version.sh"
    is expected to exist
    is expected to be mode 750
    is expected to be owned by "root"
    is expected to be grouped into "root"
  Command "/root/bin/config-version.sh"
    exit_status
      is expected to eq 0
  Command "/root/bin/config-version.sh -c 9999"
    exit_status
      is expected to eq 1
  File "/etc/scale-release"
    is expected to exist
    is expected to be mode 644
    is expected to be owned by "root"
    is expected to be grouped into "root"
  Command "source /etc/scale-release && test -z $SCALE_VER"
    exit_status
      is expected to eq 1
  Command "source /etc/scale-release && test -z $OPENWRT_VER"
    exit_status
      is expected to eq 1
  File "/tmp/resolv.conf.d/resolv.conf.auto"
    is expected to exist
    is expected to be mode 644
    is expected to be owned by "root"
    is expected to be grouped into "root"
  File "/etc/resolv.conf"
    is expected to exist
    is expected to be symlink
    is expected to be owned by "root"
    is expected to be grouped into "root"
  File "/etc/config/network"
    is expected to exist
    is expected to be symlink
    is expected to be owned by "root"
    is expected to be grouped into "root"
  File "/etc/config/wireless"
    is expected to exist
    is expected to be symlink
    is expected to be owned by "root"
    is expected to be grouped into "root"
  correct_num_configs
    should always be equal
  ensure_dhcp_client_options
    should contain the following options
  Command "cat /etc/apinger.conf | grep "^target \"$(ip route | grep default | cut -d ' ' -f 3)\"""
    exit_status
      is expected to eq 0
  Command "wifi status | jq '.[] | select(.up == false )' | wc -l"
    stdout
      is expected to eq "0\n"
  Command "awk -F: -v user='root' '$1 == user {print $NF}' /etc/passwd"
    stdout
      is expected to match /\/bin\/bash/
  ensure_admin_ssh_key_present
    should match the following key fingerprint

Finished in 12.22 seconds (files took 2.07 seconds to load)
56 examples, 0 failures
```
  - Regardless these 2 failed tests are actually passing upon further inspection

