### PR TITLE
openwrt: enable/disables radios via dhcp options

### DIFF
--- a/openwrt/files/etc/udhcpc.user
+++ b/openwrt/files/etc/udhcpc.user
@@ -1,4 +1,8 @@
-#!/bin/sh
+#!/bin/bash
+
+# set case insensitive match. This only works if a comparison is made with
+# double brackets
+shopt -s nocasematch
 
 case "$1" in
   # Same actions for renew or bound for the time being
@@ -7,10 +11,21 @@ case "$1" in
     set > /tmp/dhcp.params
     radio0=`uci show 'wireless.radio0.channel'|cut -f 2 -d "'"`
     radio1=`uci show 'wireless.radio1.channel'|cut -f 2 -d "'"`
-    if [ ! -z "$opt224" ] || [ ! -z "$opt225" ]; then
-      if [ "$opt224" != "$radio0" ] || [ "$opt225" != "$radio1" ]; then
-        uci set 'wireless.radio0.channel'=$(printf %d "0x$opt224")
-        uci set 'wireless.radio1.channel'=$(printf %d "0x$opt225")
+
+    if [[ ! -z "$opt224" ]] && [[ ! -z "$opt225" ]]; then
+      if [[ "$opt224" != "$radio0" ]] || [[ "$opt225" != "$radio1" ]]; then
+        if [[ "$opt224" != "off" ]]; then
+          uci set 'wireless.radio0.channel'=$(printf %d "0x$opt224")
+          uci set 'wireless.radio0.disabled'=0
+        else
+          uci set 'wireless.radio0.disabled'=1
+        fi
+        if [[ "$opt225" != "off" ]]; then
+          uci set 'wireless.radio1.channel'=$(printf %d "0x$opt225")
+          uci set 'wireless.radio1.disabled'=0
+        else
+          uci set 'wireless.radio1.disabled'=1
+        fi
         uci commit
         wifi reload
       fi

--- a/tests/unit/openwrt/golden/ath79/etc/udhcpc.user
+++ b/tests/unit/openwrt/golden/ath79/etc/udhcpc.user
@@ -1,4 +1,8 @@
-#!/bin/sh
+#!/bin/bash
+
+# set case insensitive match. This only works if a comparison is made with
+# double brackets
+shopt -s nocasematch
 
 case "$1" in
   # Same actions for renew or bound for the time being
@@ -7,10 +11,21 @@ case "$1" in
     set > /tmp/dhcp.params
     radio0=`uci show 'wireless.radio0.channel'|cut -f 2 -d "'"`
     radio1=`uci show 'wireless.radio1.channel'|cut -f 2 -d "'"`
-    if [ ! -z "$opt224" ] || [ ! -z "$opt225" ]; then
-      if [ "$opt224" != "$radio0" ] || [ "$opt225" != "$radio1" ]; then
-        uci set 'wireless.radio0.channel'=$(printf %d "0x$opt224")
-        uci set 'wireless.radio1.channel'=$(printf %d "0x$opt225")
+
+    if [[ ! -z "$opt224" ]] && [[ ! -z "$opt225" ]]; then
+      if [[ "$opt224" != "$radio0" ]] || [[ "$opt225" != "$radio1" ]]; then
+        if [[ "$opt224" != "off" ]]; then
+          uci set 'wireless.radio0.channel'=$(printf %d "0x$opt224")
+          uci set 'wireless.radio0.disabled'=0
+        else
+          uci set 'wireless.radio0.disabled'=1
+        fi
+        if [[ "$opt225" != "off" ]]; then
+          uci set 'wireless.radio1.channel'=$(printf %d "0x$opt225")
+          uci set 'wireless.radio1.disabled'=0
+        else
+          uci set 'wireless.radio1.disabled'=1
+        fi
         uci commit
         wifi reload
       fi

--- a/tests/unit/openwrt/test_udhcpc.sh
+++ b/tests/unit/openwrt/test_udhcpc.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+#
+# Tests some scenarios of the udhcpc.user script. There is room for improvement
+# here to mock out uci to return radio status as part of the test. There is
+# also room to cover more of the udhcpcp.user script like setting the hostname
+# and chaning the config version.
+#
+TOPDIR=$(git rev-parse --show-toplevel)
+export PATH="$TOPDIR/tests/unit/openwrt:$PATH"
+
+test_dhcp(){
+	testname=$1
+	echo "Running $testname"
+	export UCILOG="$testname"_uci.log
+	export opt224=$2 	# radio0 channel | off
+	export opt225=$3 	# radio1 channel | off
+
+	echo "" > $UCILOG
+	bash $TOPDIR/openwrt/files/etc/udhcpc.user renew
+
+	if ! diff "$testname"_uci.log "$testname"_expected.log; then
+		echo "FAILED: $testname"
+		exit 1
+	fi
+}
+
+
+cat > both_off_expected.log << EOF
+
+show wireless.radio0.channel
+show wireless.radio1.channel
+set wireless.radio0.disabled=1
+set wireless.radio1.disabled=1
+commit
+EOF
+test_dhcp "both_off" off OFF
+
+cat > enable_0_expected.log << EOF
+
+show wireless.radio0.channel
+show wireless.radio1.channel
+set wireless.radio0.channel=3
+set wireless.radio0.disabled=0
+set wireless.radio1.disabled=1
+commit
+EOF
+test_dhcp "enable_0" 3 OFF
+
+cat > enable_1_expected.log << EOF
+
+show wireless.radio0.channel
+show wireless.radio1.channel
+set wireless.radio0.channel=3
+set wireless.radio0.disabled=0
+set wireless.radio1.channel=4
+set wireless.radio1.disabled=0
+commit
+EOF
+test_dhcp "enable_1" 3 4
+
+echo "PASS"

--- a/tests/unit/openwrt/uci
+++ b/tests/unit/openwrt/uci
@@ -1,0 +1,2 @@
+#!/bin/sh
+echo $@ >> $UCILOG


### PR DESCRIPTION
## Description of PR

Adds logic to enable / disable radios if the channel dhcp option is set to "off" 

## Previous Behavior

radio enable/disable is not controlled via dhcp option

## Tests

confirmed on a physical ap by running the script with minimal env vars set.

Assuming physical AP is at 192.168.68. create the below script at `test_udhcpc.sh`. Then follow

```
$ cat ./openwrt/files/etc/udhcpc.user | ssh root@192.168.68.1 "c
at >  udhcpc.user"
$ cat test_udchpc.user | wl-copy
$ ssh root@192.168.68.1 "sh ./test_udhcpc.sh"
PASS
```


```
#!/bin/sh

set -euxo

# Test that radios are disabled when option is set
export opt224="off"
export opt225="OFF"

./udhcpc.user renew

if [ "$(uci get 'wireless.radio0.disabled')" != 1 ]; then
	echo "radio0 should have been disabled but was not"
        exit 1
fi
if [ "$(uci get 'wireless.radio1.disabled')" != 1 ]; then
        echo "radio1 should have been disabled but was not"
        exit 1
fi


# Test that radios are brought up when option is set
export opt224=1
export opt225=2

./udhcpc.user renew

if [ "$(uci get 'wireless.radio0.disabled')" != 0 ]; then
	echo "radio0 should have been disabled but was not"
        exit 1
fi
if [ "$(uci get 'wireless.radio0.channel')" != 1 ]; then
	echo "radio0 should channel 1 but was not"
        exit 1
fi
if [ "$(uci get 'wireless.radio1.disabled')" != 0 ]; then
	echo "radio1 should have been disabled but was not"
        exit 1
fi
if [ "$(uci get 'wireless.radio1.channel')" != 2 ]; then
	echo "radio1 should channel 2 but was not"
        exit 1
fi

echo "PASS"
```
