### PR TITLE
Update configuration.nix

### DIFF
--- a/nix/nixos-configurations/monitor/configuration.nix
+++ b/nix/nixos-configurations/monitor/configuration.nix
@@ -103,6 +103,12 @@ in
       };
     };
 
+    loki = {
+      enable = true;
+      configuration ={
+        configFile = ./loki-local-config.yaml
+      }
+    };
     nginx = {
       enable = false;
       # TODO: TLS enabled


### PR DESCRIPTION
Loki needed to be installed on the nix server.

edited the configuration.nix file in the services section

Loki was enabled with a location of the location of the .yaml file

## Description of PR

<!--
The configuration file for NixOS needed to have a Loki service added
-->

## New Behavior

<!--
A Loki service will start to listen for messages and aggregate them.
-->

## Tests

<!--
Tested on VM
-->
