### PR TITLE
[READY] Fix syntax in switch_config_loader

### DIFF
--- a/switch-configuration/config/scripts/switch_config_loader
+++ b/switch-configuration/config/scripts/switch_config_loader
@@ -123,7 +123,10 @@ $opt_l = 1 if ($opt_t);
 
 die "Error: -b and -k are incompatible.\n" if ($opt_b && $opt_k);
 die "Error: -l and -t are incompatible.\n" if ($opt_t && $opt_l);
-warn "Warning: -x only meaningful if used with -b.\n" if ($opt_x) unless($opt_b);
+if ($opt_x)
+{
+  warn "Warning: -x only meaningful if used with -b.\n" unless($opt_b);
+}
 
 my @list = @ARGV;
 
@@ -227,8 +230,8 @@ unless($opt_b)
 }
 
 # Power off switches if in bulk mode.
-$Loader->{'power_off'} = 1;
-$Loader->{'power_off'} = 0 if ($opt_x);
+$LOADER->{'power_off'} = 1;
+$LOADER->{'power_off'} = 0 if ($opt_x);
 
 while (1)
 {


### PR DESCRIPTION
## Description of PR

Fixes regression introduced in: https://github.com/socallinuxexpo/scale-network/pull/825

Fix stupid in switch_config_loader:126 

And later in
```
$ ./scripts/switch_config_loader -l -b
Global symbol "$Loader" requires explicit package name (did you forget to declare "my $Loader"?) at ./scripts/switch_config_loader line 233.
Global symbol "$Loader" requires explicit package name (did you forget to declare "my $Loader"?) at ./scripts/switch_config_loader line 234.
Execution of ./scripts/switch_config_loader aborted due to compilation errors.
```

## Previous Behavior

Owen must have suffered from a bout of python brain and wrote syntactically (and grammatically) terrible code.

## New Behavior

PERL will digest it and do what was intended.

## Tests

Testing is for people who don't write perfect code.
