### PR TITLE
Update configuration.nix with Loki Service

### DIFF
--- a/nix/nixos-configurations/monitor/configuration.nix
+++ b/nix/nixos-configurations/monitor/configuration.nix
@@ -128,7 +128,7 @@ in
               prefix: index_
               period: 24h
       storage_config:
-        filesyste:
+        filesystem:
           directory: /tmp/loki/chunks
       '';
     };

--- a/nix/nixos-configurations/monitor/configuration.nix
+++ b/nix/nixos-configurations/monitor/configuration.nix
@@ -102,7 +102,36 @@ in
         ];
       };
     };
+    
+    loki = {
+      enable = true;
+      configFile = pkgs.writeText "loki-config.yaml" ''
+        auth_enabled: false
+      server:
+        http_listen_port: 3100
 
+      common:
+        ring:
+          instance_addr: 127.0.0.1
+          kvstore:
+            store: inmemory
+        replication_factor: 1
+        path_prefix: /tmp/loki
+
+      schema_config:
+        configs:
+          - from: 2020-05-15
+            store: tsdb
+            object_store: filesystem
+            schema: v13
+            index:
+              prefix: index_
+              period: 24h
+      storage_config:
+        filesyste:
+          directory: /tmp/loki/chunks
+      '';
+    };
     nginx = {
       enable = false;
       # TODO: TLS enabled


### PR DESCRIPTION
This is the Loki service for ingesting logs for the monitoring section of the infrastrucutre.

This change adds a loki-config.yaml file.

The commit does not have Loki fully functioning.

## Description of PR

<!--
Brief description of the changes in PR

addition of service in configuration.nix file
-->

## Previous Behavior

<!--
What was the behavior before this PR?

There was no service to injest logs in the infrastructure. Loki is the injestor of logs
-->

## New Behavior

<!--
What is the new behavior being introduced in this PR?

There is now a log injesting service
-->

## Tests

<!--
The PR was tested on a 24.11 version of nixos. 
The configuration file was built
systemctl status was used to look at what loki was doing
journalctl -u loki -f was used to monitor the error messages
The error messages have something to do with git
Here is what the error message was giving:

github.com/grafana/loki/v3/pkg/loki.(*Config).Validate(0xc000c0e008)
Feb 16 21:40:39 kraken loki[5756]:         github.com/grafana/loki/v3/pkg/loki/loki.go:312 +0x13b2
Feb 16 21:40:39 kraken loki[5756]: main.main()
Feb 16 21:40:39 kraken loki[5756]:         github.com/grafana/loki/v3/cmd/loki/main.go:69 +0x645
Feb 16 21:40:39 kraken systemd[1]: loki.service: Main process exited, code=exited, status=2/INVALIDARGUMENT
Feb 16 21:40:39 kraken systemd[1]: loki.service: Failed with result 'exit-code'.
Feb 16 21:40:39 kraken systemd[1]: loki.service: Scheduled restart job, restart counter is at 5.
Feb 16 21:40:39 kraken systemd[1]: loki.service: Start request repeated too quickly.
Feb 16 21:40:39 kraken systemd[1]: loki.service: Failed with result 'exit-code'.

-->
