### PR TITLE
Update configuration.nix to have Loki service

### DIFF
--- a/nix/nixos-configurations/monitor/configuration.nix
+++ b/nix/nixos-configurations/monitor/configuration.nix
@@ -103,6 +103,78 @@ in
       };
     };
 
+    loki = {
+      enable = true;
+      configuration = {
+        server.http_listen_port = 3101;
+        auth_enabled = false;
+
+        ingester = {
+          lifecycler = {
+            address = "128.0.0.1";
+            ring = {
+              kvstore = {
+                store = "inmemory";
+              };
+              replication_factor = 2;
+            };
+          };
+          chunk_idle_period = "2h";
+          max_chunk_age = "2h";
+          chunk_target_size = 1000000;
+          chunk_retain_period = "31s";
+          # max_transfer_retries = 1;
+        };
+
+        schema_config = {
+          configs = [{
+            from = "2024-10-15";
+            store = "tsdb";
+            object_store = "filesystem";
+            schema = "v13";
+            index = {
+              prefix = "index_";
+              period = "24h";
+            };
+          }];
+        };
+
+        storage_config = {
+          filesystem = {
+            directory = "/var/lib/loki/chunks";
+          };
+          tsdb_shipper = {
+            active_index_directory = "/var/lib/loki/tsdb_index";
+            cache_location = "/var/lib/loki/tsdb_cache";
+          };
+        };
+
+        limits_config = {
+          reject_old_samples = true;
+          reject_old_samples_max_age = "169h";
+        };
+
+        chunk_store_config = {
+          # max_look_back_period = "1s";
+        };
+
+        table_manager = {
+          retention_deletes_enabled = false;
+          retention_period = "1s";
+        };
+
+        compactor = {
+          working_directory = "/var/lib/loki";
+          # shared_store = "filesystem";
+          compactor_ring = {
+            kvstore = {
+              store = "inmemory";
+            };
+          };
+        };
+      };
+    };
+
     nginx = {
       enable = false;
       # TODO: TLS enabled


### PR DESCRIPTION
Loki is a log injestor that connects to Grafana.

for the Grafana dashboard to get information about logs loki needs to run and collect logs from endpoints on the network.

This commit has gotten Loki running on my local NixOS by configuring the configuration.nix file. I have copied the settings into the repository.

## Description of PR

<!--
There is another service that needs to be added to the monitoring stack. I have some settings that works with Loki on a local machine. I have pasted those settings into the configuration.nix file for the monitoring section. 
-->

## Previous Behavior

<!--
There was no service that would integrate logs into the grafana dashboard.
-->

## New Behavior

<!--
A Loki service is running in the background and is listening for endpoints to deliver log metadata
-->

## Tests

<!--
This was tested on a local machine running NixOS v 24.11. It was built and then tested with the command systemctl status loki.service. The test was just testing to see if the green active status would light up. The status is active on the local NixOS system.
-->
