### PR TITLE
[READY] - openwrt bump master -> 021420245

### DIFF
--- a/.github/workflows/openwrt-build.yml
+++ b/.github/workflows/openwrt-build.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        target: ["ath79", "mt7622"]
+        target: ["ath79", "mt7622", "mt798x"]
     container:
       # Ubuntu 24.04
       image: sarcasticadmin/openwrt-build@sha256:25ac9d0dd4eeaad1aaaa7c82c09e9ecc103c69224fc55eb9717c4cfb018a5281

--- a/openwrt/Makefile
+++ b/openwrt/Makefile
@@ -24,7 +24,7 @@ KEYPATH ?= ../facts/keys/
 GOMPLATE := $(shell command -v gomplate 2> /dev/null)
 CURL := $(shell command -v curl 2> /dev/null)
 
-OPENWRT_VER ?= fbe0bd5f6453a61fab871bee56883afc5c6308cf
+OPENWRT_VER ?= 3dfd1f69a769bd857061b4856270dfc78e30c610
 # If bumping opkg it needs to be a commit that exists in the fork
 # https://github.com/sarcasticadmin/opkgs
 OPENWRT_PKG_VERSION ?= 38e0f8c7d5c2f69f1603abb99e0fd3886c05f687

--- a/openwrt/files/etc/rc.local
+++ b/openwrt/files/etc/rc.local
@@ -16,4 +16,9 @@
 # the result is wifi is up but the wifi tool detects it as down
 (sleep 30 && /root/bin/apinger-pop.sh "8.8.8.8") &> /dev/null &
 
+# if the device crashes capture the pstore crashlog ring-buffer, then
+# ship that off to rsyslog and delete it. Need to wait for pstore to be
+# mounted so sleep a little before trying to check for /sys/fs/pstore
+(sleep 30 && logger -p kern.emerg -t pstore -f /sys/fs/pstore/dmesg-ramoops-0 && rm -f /sys/fs/pstore/dmesg-ramoops-0) &> /dev/null &
+
 exit 0

--- a/openwrt/files/etc/udhcpc.user
+++ b/openwrt/files/etc/udhcpc.user
@@ -42,7 +42,6 @@ case "$1" in
       if [ `echo "$HOSTNAME" | tr '[A-Z]' '[a-z]'` != `echo "$hostname" | tr '[A-Z]' '[a-z]'` ]; then
         # reload/restart whatever needs the hostname updated
         /etc/init.d/system reload
-        service zabbix_agentd restart
         service rsyslog restart
         service lldpd restart
       fi

--- a/openwrt/files/etc/udhcpc.user
+++ b/openwrt/files/etc/udhcpc.user
@@ -1,8 +1,7 @@
-#!/bin/bash
+#!/bin/sh
 
-# set case insensitive match. This only works if a comparison is made with
-# double brackets
-shopt -s nocasematch
+# Since this is called from other udhcpc scripts this cannot be changed to
+# use /bin/bash without also modifying the script that calls this.
 
 case "$1" in
   # Same actions for renew or bound for the time being
@@ -14,13 +13,13 @@ case "$1" in
 
     if [[ ! -z "$opt224" ]] && [[ ! -z "$opt225" ]]; then
       if [[ "$opt224" != "$radio0" ]] || [[ "$opt225" != "$radio1" ]]; then
-        if [[ "$opt224" != "off" ]]; then
+        if [[ "`echo $opt224 | tr '[A-Z]' '[a-z]'`" != "off" ]]; then
           uci set 'wireless.radio0.channel'=$(printf %d "0x$opt224")
           uci set 'wireless.radio0.disabled'=0
         else
           uci set 'wireless.radio0.disabled'=1
         fi
-        if [[ "$opt225" != "off" ]]; then
+        if [[ "`echo $opt225 | tr '[A-Z]' '[a-z]'`" != "off" ]]; then
           uci set 'wireless.radio1.channel'=$(printf %d "0x$opt225")
           uci set 'wireless.radio1.disabled'=0
         else

--- a/openwrt/files/etc/udhcpc.user
+++ b/openwrt/files/etc/udhcpc.user
@@ -44,6 +44,9 @@ case "$1" in
         /etc/init.d/system reload
         service rsyslog restart
         service lldpd restart
+        # prometheus doesnt understand restart
+        service prometheus-node-exporter-lua stop
+        service prometheus-node-exporter-lua start
       fi
     fi
     if [ ! -z "$opt226" ]; then

--- a/tests/serverspec/spec/shared/openwrt/init.rb
+++ b/tests/serverspec/spec/shared/openwrt/init.rb
@@ -150,6 +150,11 @@ RSpec.shared_examples "openwrt" do
     its(:stdout) { should eq "0\n" }
   end
 
+  # Make sure ap_isolate=1 (enabled) always on hostapd
+  describe command("cat /tmp/run/hostapd-phy*.conf | awk -F= '$1==\"ap_isolate\" && $2!=1 {print; err = 1} END {exit err}'") do
+    its(:exit_status) { should eq 0 }
+  end
+
   # Make sure bash is roots shell
   describe command("awk -F: -v user='root' '$1 == user {print $NF}' /etc/passwd") do
       its(:stdout) { should match /\/bin\/bash/ }

--- a/tests/unit/openwrt/golden/ath79/etc/rc.local
+++ b/tests/unit/openwrt/golden/ath79/etc/rc.local
@@ -16,4 +16,9 @@
 # the result is wifi is up but the wifi tool detects it as down
 (sleep 30 && /root/bin/apinger-pop.sh "8.8.8.8") &> /dev/null &
 
+# if the device crashes capture the pstore crashlog ring-buffer, then
+# ship that off to rsyslog and delete it. Need to wait for pstore to be
+# mounted so sleep a little before trying to check for /sys/fs/pstore
+(sleep 30 && logger -p kern.emerg -t pstore -f /sys/fs/pstore/dmesg-ramoops-0 && rm -f /sys/fs/pstore/dmesg-ramoops-0) &> /dev/null &
+
 exit 0

--- a/tests/unit/openwrt/golden/ath79/etc/udhcpc.user
+++ b/tests/unit/openwrt/golden/ath79/etc/udhcpc.user
@@ -42,7 +42,6 @@ case "$1" in
       if [ `echo "$HOSTNAME" | tr '[A-Z]' '[a-z]'` != `echo "$hostname" | tr '[A-Z]' '[a-z]'` ]; then
         # reload/restart whatever needs the hostname updated
         /etc/init.d/system reload
-        service zabbix_agentd restart
         service rsyslog restart
         service lldpd restart
       fi

--- a/tests/unit/openwrt/golden/ath79/etc/udhcpc.user
+++ b/tests/unit/openwrt/golden/ath79/etc/udhcpc.user
@@ -1,8 +1,7 @@
-#!/bin/bash
+#!/bin/sh
 
-# set case insensitive match. This only works if a comparison is made with
-# double brackets
-shopt -s nocasematch
+# Since this is called from other udhcpc scripts this cannot be changed to
+# use /bin/bash without also modifying the script that calls this.
 
 case "$1" in
   # Same actions for renew or bound for the time being
@@ -14,13 +13,13 @@ case "$1" in
 
     if [[ ! -z "$opt224" ]] && [[ ! -z "$opt225" ]]; then
       if [[ "$opt224" != "$radio0" ]] || [[ "$opt225" != "$radio1" ]]; then
-        if [[ "$opt224" != "off" ]]; then
+        if [[ "`echo $opt224 | tr '[A-Z]' '[a-z]'`" != "off" ]]; then
           uci set 'wireless.radio0.channel'=$(printf %d "0x$opt224")
           uci set 'wireless.radio0.disabled'=0
         else
           uci set 'wireless.radio0.disabled'=1
         fi
-        if [[ "$opt225" != "off" ]]; then
+        if [[ "`echo $opt225 | tr '[A-Z]' '[a-z]'`" != "off" ]]; then
           uci set 'wireless.radio1.channel'=$(printf %d "0x$opt225")
           uci set 'wireless.radio1.disabled'=0
         else

--- a/tests/unit/openwrt/golden/ath79/etc/udhcpc.user
+++ b/tests/unit/openwrt/golden/ath79/etc/udhcpc.user
@@ -44,6 +44,9 @@ case "$1" in
         /etc/init.d/system reload
         service rsyslog restart
         service lldpd restart
+        # prometheus doesnt understand restart
+        service prometheus-node-exporter-lua stop
+        service prometheus-node-exporter-lua start
       fi
     fi
     if [ ! -z "$opt226" ]; then

--- a/tests/unit/openwrt/test_udhcpc.sh
+++ b/tests/unit/openwrt/test_udhcpc.sh
@@ -16,7 +16,7 @@ test_dhcp(){
 	export opt225=$3 	# radio1 channel | off
 
 	echo "" > $UCILOG
-	bash $TOPDIR/openwrt/files/etc/udhcpc.user renew
+	sh $TOPDIR/openwrt/files/etc/udhcpc.user renew
 
 	if ! diff "$testname"_uci.log "$testname"_expected.log; then
 		echo "FAILED: $testname"


### PR DESCRIPTION
## Description of PR

<!--
Brief description of the changes in PR

If change is related to an open issue template include at the top of your
description.
-->

Follow up to: https://github.com/socallinuxexpo/scale-network/issues/808

Recommendations from the OpenWrt team to leverage the latest Mediatek drivers: https://github.com/openwrt/mt76/commit/e5fef138524e63314cb96ff8314048d175294e95
which landed in the following version on upstream OpenWrt: 3dfd1f69a769bd857061b4856270dfc78e30c610

Also seeing the following shopt issue with dhcpc.user after https://github.com/socallinuxexpo/scale-network/pull/823:

```
Feb 20 17:49:44 OpenWrt netifd: mgmt (2585): /lib/netifd/dhcp.script: /etc/udhcpc.user: line 5: shopt: not found
Feb 20 17:49:44 OpenWrt netifd: mgmt (2585): udhcpc: sending renew to server 192.168.44.1
Feb 20 17:49:44 OpenWrt netifd: mgmt (2585): udhcpc: lease of 192.168.44.140 obtained from 192.168.44.1, lease time 43200
Feb 20 17:49:44 OpenWrt netifd: radio0 (3514): WARNING: Variable 'data' does not exist or is not an array/object
Feb 20 17:49:44 OpenWrt netifd: mgmt (2585): /lib/netifd/dhcp.script: /etc/udhcpc.user: line 5: shopt: not found
Feb 20 17:49:44 OpenWrt netifd: mgmt (2585): udhcpc: sending renew to server 192.168.44.1
Feb 20 17:49:44 OpenWrt netifd: mgmt (2585): udhcpc: lease of 192.168.44.140 obtained from 192.168.44.1, lease time 43200
Feb 20 17:49:44 OpenWrt netifd: mgmt (2585): /lib/netifd/dhcp.script: /etc/udhcpc.user: line 5: shopt: not found
```

## Previous Behavior

<!--
What was the behavior before this PR?

Remove this section if not relevant
-->
- We were running on a previous version of master from 01282025
- Left old restart of a service (zabbix) that no longer exists on the image
- udhcpc.user was set to `/bin/bash` https://github.com/socallinuxexpo/scale-network/pull/823

## New Behavior

<!--
What is the new behavior being introduced in this PR?

Remove this section if not relevant
-->
- Using openwrt version of master from 02142025
- enable pstore -> logger to get crash data (recommended by OpenWrt team: https://www.open-mesh.org/projects/devtools/wiki/Crashlog_with_pstore)
- restart node exporter when hostname changes
- udhcpc.user was moved back to `/bin/sh` and case-sensitivity done with `tr` @cjmakes FYI

## Tests

<!--
How was this PR tested? Please provide as much detail as possible
so we can ensure this change is working as intended before being merged.
-->

- `serverspec` passes on `mt798x`:

```
/nix/store/xkmg185m7hv3c5dv6dsbmfs1c5vf92p6-ruby-3.1.6/bin/ruby -I/nix/store/7fl8vynr2x1vfi1d2slvhp07nmdhby35-serverspec/lib/ruby/gems/3.1.0/gems/rspec-core-3.12.2/lib:/nix/store/7fl8vynr2x1vfi1d2slvhp07nmdhby35-serverspec/lib/ruby/gems/3.1.0/gems/rspec-support-3.12.1/lib /nix/store/h751jn4jignpp48d60wlpq05ariv18r6-ruby3.1-rspec-core-3.12.2/lib/ruby/gems/3.1.0/gems/rspec-core-3.12.2/exe/rspec --pattern spec/openwrt/\*_spec.rb

Image info:
Linux OpenWrt 6.6.77 #0 SMP Sun Feb 23 06:30:49 2025 aarch64 GNU/Linux
SCALE_VER=fed56766ab00f6c2d1ccf88bdbdb7715067aeda3
OPENWRT_VER=3dfd1f69a769bd857061b4856270dfc78e30c610
BUILD_ID="r0-fed5676"
OPENWRT_BOARD="mediatek/filogic"
OPENWRT_ARCH="aarch64_cortex-a53"

shared
  Command "which apinger 2> /dev/null"
    exit_status
      is expected to eq 0
  Command "which awk 2> /dev/null"
    exit_status
      is expected to eq 0
  Command "which bash 2> /dev/null"
    exit_status
      is expected to eq 0
  Command "which logrotate 2> /dev/null"
    exit_status
      is expected to eq 0
  Command "which rsyslogd 2> /dev/null"
    exit_status
      is expected to eq 0
  Command "which tcpdump 2> /dev/null"
    exit_status
      is expected to eq 0
  Command "which snmpd 2> /dev/null"
    exit_status
      is expected to eq 1
  Command "which dropbear 2> /dev/null"
    exit_status
      is expected to eq 1
  Command "which logd 2> /dev/null"
    exit_status
      is expected to eq 1
  Command "pgrep apinger"
    exit_status
      is expected to eq 0
  Command "pgrep crond"
    exit_status
      is expected to eq 0
  Command "pgrep rsyslogd"
    exit_status
      is expected to eq 0
  Command "pgrep lldpd"
    exit_status
      is expected to eq 0
  Command "pgrep ntpd"
    exit_status
      is expected to eq 0
  Port "80"
    is expected not to be listening
  Port "9100"
    is expected to be listening
  Command "rsyslogd -N1"
    exit_status
      is expected to eq 0
  Command "logger "serverspec test msg""
    exit_status
      is expected to eq 0
  File "/root/bin/wifi-details.sh"
    is expected to exist
    is expected to be mode 750
    is expected to be owned by "root"
    is expected to be grouped into "root"
  File "/root/bin/config-version.sh"
    is expected to exist
    is expected to be mode 750
    is expected to be owned by "root"
    is expected to be grouped into "root"
  Command "/root/bin/config-version.sh"
    exit_status
      is expected to eq 0
  Command "/root/bin/config-version.sh -c 9999"
    exit_status
      is expected to eq 1
  File "/etc/scale-release"
    is expected to exist
    is expected to be mode 644
    is expected to be owned by "root"
    is expected to be grouped into "root"
  Command "source /etc/scale-release && test -z $SCALE_VER"
    exit_status
      is expected to eq 1
  Command "source /etc/scale-release && test -z $OPENWRT_VER"
    exit_status
      is expected to eq 1
  File "/tmp/resolv.conf.d/resolv.conf.auto"
    is expected to exist
    is expected to be mode 644
    is expected to be owned by "root"
    is expected to be grouped into "root"
  File "/etc/resolv.conf"
    is expected to exist
    is expected to be symlink
    is expected to be owned by "root"
    is expected to be grouped into "root"
  File "/etc/config/network"
    is expected to exist
    is expected to be symlink
    is expected to be owned by "root"
    is expected to be grouped into "root"
  File "/etc/config/wireless"
    is expected to exist
    is expected to be symlink
    is expected to be owned by "root"
    is expected to be grouped into "root"
  correct_num_configs
    should always be equal
  ensure_dhcp_client_options
    should contain the following options
  Command "cat /etc/apinger.conf | grep "^target \"$(ip route | grep default | cut -d ' ' -f 3)\"""
    exit_status
      is expected to eq 0
  Command "wifi status | jq '.[] | select(.up == false )' | wc -l"
    stdout
      is expected to eq "0\n"
  Command "cat /tmp/run/hostapd-phy*.conf | awk -F= '$1=="ap_isolate" && $2!=1 {print; err = 1} END {exit err}'"
    exit_status
      is expected to eq 0
  Command "awk -F: -v user='root' '$1 == user {print $NF}' /etc/passwd"
    stdout
      is expected to match /\/bin\/bash/
  ensure_admin_ssh_key_present
    should match the following key fingerprint

Finished in 8.83 seconds (files took 0.90768 seconds to load)
57 examples, 0 failures
```

- pstore enabled on `mt798x`:

```
root@OpenWrt:~# dmesg|grep -e ramoops -e pstore
[    0.000000] OF: reserved mem: 0x0000000042ff0000..0x0000000042ffffff (64 KiB) map non-reusable ramoops@42ff0000
[    0.015315] pstore: Using crash dump compression: deflate
[    0.015321] pstore: Registered ramoops as persistent store backend
[    0.015324] ramoops: using 0x10000@0x42ff0000, ecc: 0

root@OpenWrt:~# ls -ltr /sys/fs/
dr-xr-xr-x    3 root     root             0 Jan  1  1970 cgroup
drwxr-x---    2 root     root             0 Feb 18 21:14 pstore
drwx-----T    2 root     root             0 Feb 18 21:14 bpf
drwxr-xr-x    3 root     root             0 Feb 18 21:22 ubifs
drwxr-xr-x    3 root     root             0 Feb 18 21:22 f2fs
drwxr-xr-x    3 root     root             0 Feb 18 21:22 ext4
```

Confirm tests pass of udhcpc.user:

```
$ bash test_udhcpc.sh
Running both_off
Running enable_0
Running enable_1
PASS
```

No longer seeing errors for udhcpc.user:
```
root@OpenWrt:~# cat /var/log/messages | grep udhcpc
Feb 23 06:32:55 OpenWrt netifd: mgmt (3083): udhcpc: started, v1.37.0
Feb 23 06:32:55 OpenWrt netifd: mgmt (3083): udhcpc: broadcasting discover
Feb 23 06:32:55 OpenWrt netifd: mgmt (3083): udhcpc: broadcasting select for 192.168.254.114, server 192.168.254.1
Feb 23 06:32:55 OpenWrt netifd: mgmt (3083): udhcpc: lease of 192.168.254.114 obtained from 192.168.254.1, lease time 120
Feb 23 06:33:55 OpenWrt netifd: mgmt (3083): udhcpc: sending renew to server 192.168.254.1
Feb 23 06:33:55 OpenWrt netifd: mgmt (3083): udhcpc: lease of 192.168.254.114 obtained from 192.168.254.1, lease time 120
Feb 23 06:34:56 OpenWrt netifd: mgmt (3083): udhcpc: sending renew to server 192.168.254.1
Feb 23 06:34:56 OpenWrt netifd: mgmt (3083): udhcpc: lease of 192.168.254.114 obtained from 192.168.254.1, lease time 120
```

- `pstore` logging entry after a deliberate crash triggered via `echo c > /proc/sysrq-trigger`:

```
Feb 23 06:32:50 OpenWrt pstore: Panic#1 Part1
Feb 23 06:32:50 OpenWrt pstore: <6>[   20.938949] scalefast-br: port 3(phy1-ap0) entered blocking state
Feb 23 06:32:50 OpenWrt pstore: <6>[   20.945065] scalefast-br: port 3(phy1-ap0) entered listening state
Feb 23 06:32:50 OpenWrt pstore: <6>[   27.990143] scaleslow-br: port 3(phy0-ap0) entered learning state
Feb 23 06:32:50 OpenWrt pstore: <6>[   28.630141] br-lan: port 1(eth0) entered learning state
Feb 23 06:32:50 OpenWrt pstore: <6>[   29.270147] scalefast-br: port 3(phy1-ap0) entered learning state
Feb 23 06:32:50 OpenWrt pstore: <6>[   36.310142] scaleslow-br: port 3(phy0-ap0) entered forwarding state
Feb 23 06:32:50 OpenWrt pstore: <6>[   36.316415] scaleslow-br: topology change detected, propagating
Feb 23 06:32:50 OpenWrt pstore: <6>[   36.950139] br-lan: port 1(eth0) entered forwarding state
Feb 23 06:32:50 OpenWrt pstore: <6>[   36.955547] br-lan: topology change detected, propagating
Feb 23 06:32:50 OpenWrt pstore: <6>[   36.961326] scaleslow-br: port 1(br-lan.100) entered blocking state
Feb 23 06:32:50 OpenWrt pstore: <6>[   36.967619] scaleslow-br: port 1(br-lan.100) entered listening state
Feb 23 06:32:50 OpenWrt pstore: <6>[   36.974211] scalefast-br: port 1(br-lan.101) entered blocking state
Feb 23 06:32:50 OpenWrt pstore: <6>[   36.980512] scalefast-br: port 1(br-lan.101) entered listening state
Feb 23 06:32:50 OpenWrt pstore: <6>[   36.987067] mgmt-br: port 1(br-lan.103) entered blocking state
Feb 23 06:32:50 OpenWrt pstore: <6>[   36.992932] mgmt-br: port 1(br-lan.103) entered listening state
Feb 23 06:32:50 OpenWrt pstore: <6>[   36.999051] scaleslow-br: port 2(br-lan.500) entered blocking state
Feb 23 06:32:50 OpenWrt pstore: <6>[   37.005339] scaleslow-br: port 2(br-lan.500) entered listening state
Feb 23 06:32:50 OpenWrt pstore: <6>[   37.011901] scalefast-br: port 2(br-lan.501) entered blocking state
Feb 23 06:32:50 OpenWrt pstore: <6>[   37.018187] scalefast-br: port 2(br-lan.501) entered listening state
Feb 23 06:32:50 OpenWrt pstore: <6>[   37.024763] mgmt-br: port 2(br-lan.503) entered blocking state
Feb 23 06:32:50 OpenWrt pstore: <6>[   37.030610] mgmt-br: port 2(br-lan.503) entered listening state
Feb 23 06:32:50 OpenWrt pstore: <6>[   37.590164] scalefast-br: port 3(phy1-ap0) entered forwarding state
Feb 23 06:32:50 OpenWrt pstore: <6>[   37.596442] scalefast-br: topology change detected, propagating
Feb 23 06:32:50 OpenWrt pstore: <6>[   45.270153] mgmt-br: port 2(br-lan.503) entered learning state
Feb 23 06:32:50 OpenWrt pstore: <6>[   45.276058] scalefast-br: port 2(br-lan.501) entered learning state
Feb 23 06:32:50 OpenWrt pstore: <6>[   45.282384] scaleslow-br: port 2(br-lan.500) entered learning state
Feb 23 06:32:50 OpenWrt pstore: <6>[   45.288709] mgmt-br: port 1(br-lan.103) entered learning state
Feb 23 06:32:50 OpenWrt pstore: <6>[   45.294609] scalefast-br: port 1(br-lan.101) entered learning state
Feb 23 06:32:50 OpenWrt pstore: <6>[   45.300931] scaleslow-br: port 1(br-lan.100) entered learning state
Feb 23 06:32:50 OpenWrt pstore: <6>[   53.590145] scaleslow-br: port 1(br-lan.100) entered forwarding state
Feb 23 06:32:50 OpenWrt pstore: <6>[   53.596595] scaleslow-br: topology change detected, propagating
Feb 23 06:32:50 OpenWrt pstore: <6>[   53.602572] scalefast-br: port 1(br-lan.101) entered forwarding state
Feb 23 06:32:50 OpenWrt pstore: <6>[   53.609004] scalefast-br: topology change detected, propagating
Feb 23 06:32:50 OpenWrt pstore: <6>[   53.614972] mgmt-br: port 1(br-lan.103) entered forwarding state
Feb 23 06:32:50 OpenWrt pstore: <6>[   53.620982] mgmt-br: topology change detected, propagating
Feb 23 06:32:50 OpenWrt pstore: <6>[   53.626520] scaleslow-br: port 2(br-lan.500) entered forwarding state
Feb 23 06:32:50 OpenWrt pstore: <6>[   53.632991] scaleslow-br: topology change detected, propagating
Feb 23 06:32:50 OpenWrt pstore: <6>[   53.638970] scalefast-br: port 2(br-lan.501) entered forwarding state
Feb 23 06:32:50 OpenWrt pstore: <6>[   53.645429] scalefast-br: topology change detected, propagating
Feb 23 06:32:50 OpenWrt pstore: <6>[   53.651432] mgmt-br: port 2(br-lan.503) entered forwarding state
Feb 23 06:32:50 OpenWrt pstore: <6>[   53.657442] mgmt-br: topology change detected, propagating
Feb 23 06:32:50 OpenWrt pstore: <6>[   59.311707] mt798x-wmac 18000000.wifi phy0-ap0: left allmulticast mode
Feb 23 06:32:50 OpenWrt pstore: <6>[   59.318300] mt798x-wmac 18000000.wifi phy0-ap0: left promiscuous mode
Feb 23 06:32:50 OpenWrt pstore: <6>[   59.324928] scaleslow-br: port 3(phy0-ap0) entered disabled state
Feb 23 06:32:50 OpenWrt pstore: <6>[   59.536348] mt798x-wmac 18000000.wifi phy1-ap0: left allmulticast mode
Feb 23 06:32:50 OpenWrt pstore: <6>[   59.542976] mt798x-wmac 18000000.wifi phy1-ap0: left promiscuous mode
Feb 23 06:32:50 OpenWrt pstore: <6>[   59.549523] scalefast-br: port 3(phy1-ap0) entered disabled state
Feb 23 06:32:50 OpenWrt pstore: <6>[   60.458760] scaleslow-br: port 3(phy0-ap0) entered blocking state
Feb 23 06:32:50 OpenWrt pstore: <6>[   60.464968] scaleslow-br: port 3(phy0-ap0) entered disabled state
Feb 23 06:32:50 OpenWrt pstore: <6>[   60.471180] mt798x-wmac 18000000.wifi phy0-ap0: entered allmulticast mode
Feb 23 06:32:50 OpenWrt pstore: <6>[   60.478253] mt798x-wmac 18000000.wifi phy0-ap0: entered promiscuous mode
Feb 23 06:32:50 OpenWrt pstore: <6>[   60.485200] scaleslow-br: port 3(phy0-ap0) entered blocking state
Feb 23 06:32:50 OpenWrt pstore: <6>[   60.491320] scaleslow-br: port 3(phy0-ap0) entered listening state
Feb 23 06:32:50 OpenWrt pstore: <6>[   60.862491] scalefast-br: port 3(phy1-ap0) entered blocking state
Feb 23 06:32:50 OpenWrt pstore: <6>[   60.868591] scalefast-br: port 3(phy1-ap0) entered disabled state
Feb 23 06:32:50 OpenWrt pstore: <6>[   60.874790] mt798x-wmac 18000000.wifi phy1-ap0: entered allmulticast mode
Feb 23 06:32:50 OpenWrt pstore: <6>[   60.881843] mt798x-wmac 18000000.wifi phy1-ap0: entered promiscuous mode
Feb 23 06:32:50 OpenWrt pstore: <6>[   60.888720] scalefast-br: port 3(phy1-ap0) entered blocking state
Feb 23 06:32:50 OpenWrt pstore: <6>[   60.894836] scalefast-br: port 3(phy1-ap0) entered listening state
Feb 23 06:32:50 OpenWrt pstore: <6>[   61.410208] scalefast-br: port 3(phy1-ap0) entered disabled state
Feb 23 06:32:50 OpenWrt pstore: <6>[   61.458998] scalefast-br: port 3(phy1-ap0) entered blocking state
Feb 23 06:32:50 OpenWrt pstore: <6>[   61.465115] scalefast-br: port 3(phy1-ap0) entered listening state
Feb 23 06:32:50 OpenWrt pstore: <6>[   62.268991] mt798x-wmac 18000000.wifi phy0-ap0: left allmulticast mode
Feb 23 06:32:50 OpenWrt pstore: <6>[   62.275624] mt798x-wmac 18000000.wifi phy0-ap0: left promiscuous mode
Feb 23 06:32:50 OpenWrt pstore: <6>[   62.282276] scaleslow-br: port 3(phy0-ap0) entered disabled state
Feb 23 06:32:50 OpenWrt pstore: <6>[   62.436142] mt798x-wmac 18000000.wifi phy1-ap0: left allmulticast mode
Feb 23 06:32:50 OpenWrt pstore: <6>[   62.442821] mt798x-wmac 18000000.wifi phy1-ap0: left promiscuous mode
Feb 23 06:32:50 OpenWrt pstore: <6>[   62.449355] scalefast-br: port 3(phy1-ap0) entered disabled state
Feb 23 06:32:50 OpenWrt pstore: <6>[   63.363185] scaleslow-br: port 3(phy0-ap0) entered blocking state
Feb 23 06:32:50 OpenWrt pstore: <6>[   63.369331] scaleslow-br: port 3(phy0-ap0) entered disabled state
Feb 23 06:32:50 OpenWrt pstore: <6>[   63.375558] mt798x-wmac 18000000.wifi phy0-ap0: entered allmulticast mode
Feb 23 06:32:50 OpenWrt pstore: <6>[   63.382658] mt798x-wmac 18000000.wifi phy0-ap0: entered promiscuous mode
Feb 23 06:32:50 OpenWrt pstore: <6>[   63.389607] scaleslow-br: port 3(phy0-ap0) entered blocking state
Feb 23 06:32:50 OpenWrt pstore: <6>[   63.395766] scaleslow-br: port 3(phy0-ap0) entered listening state
Feb 23 06:32:50 OpenWrt pstore: <6>[   63.430253] scaleslow-br: port 3(phy0-ap0) entered disabled state
Feb 23 06:32:50 OpenWrt pstore: <6>[   63.562255] scaleslow-br: port 3(phy0-ap0) entered blocking state
Feb 23 06:32:50 OpenWrt pstore: <6>[   63.568375] scaleslow-br: port 3(phy0-ap0) entered listening state
Feb 23 06:32:50 OpenWrt pstore: <6>[   63.782394] scalefast-br: port 3(phy1-ap0) entered blocking state
Feb 23 06:32:50 OpenWrt pstore: <6>[   63.788502] scalefast-br: port 3(phy1-ap0) entered disabled state
Feb 23 06:32:50 OpenWrt pstore: <6>[   63.794718] mt798x-wmac 18000000.wifi phy1-ap0: entered allmulticast mode
Feb 23 06:32:50 OpenWrt pstore: <6>[   63.801735] mt798x-wmac 18000000.wifi phy1-ap0: entered promiscuous mode
Feb 23 06:32:50 OpenWrt pstore: <6>[   63.808572] scalefast-br: port 3(phy1-ap0) entered blocking state
Feb 23 06:32:50 OpenWrt pstore: <6>[   63.814688] scalefast-br: port 3(phy1-ap0) entered listening state
Feb 23 06:32:50 OpenWrt pstore: <6>[   72.150134] scaleslow-br: port 3(phy0-ap0) entered learning state
Feb 23 06:32:50 OpenWrt pstore: <6>[   72.150138] scalefast-br: port 3(phy1-ap0) entered learning state
Feb 23 06:32:50 OpenWrt pstore: <6>[   80.470135] scaleslow-br: port 3(phy0-ap0) entered forwarding state
Feb 23 06:32:50 OpenWrt pstore: <6>[   80.470141] scalefast-br: port 3(phy1-ap0) entered forwarding state
Feb 23 06:32:50 OpenWrt pstore: <6>[   80.470151] scalefast-br: topology change detected, propagating
Feb 23 06:32:50 OpenWrt pstore: <6>[   80.488594] scaleslow-br: topology change detected, propagating
Feb 23 06:32:50 OpenWrt pstore: <6>[  149.174928] sysrq: Trigger a crash
Feb 23 06:32:50 OpenWrt pstore: <0>[  149.178355] Kernel panic - not syncing: sysrq triggered crash
Feb 23 06:32:50 OpenWrt pstore: <2>[  149.184087] SMP: stopping secondary CPUs
Feb 23 06:32:50 OpenWrt pstore: <0>[  149.188007] Kernel Offset: disabled
Feb 23 06:32:50 OpenWrt pstore: <0>[  149.191482] CPU features: 0x0,00000000,00000000,1000400b
Feb 23 06:32:50 OpenWrt pstore: <0>[  149.196783] Memory Limit: none
```
- TDB testing on existing hardware (ath79 and mt798x)
