### PR TITLE
Update configuration.nix with promtail

### DIFF
--- a/nix/nixos-configurations/monitor/configuration.nix
+++ b/nix/nixos-configurations/monitor/configuration.nix
@@ -102,7 +102,37 @@ in
         ];
       };
     };
-
+    
+    services.promtail = {
+      enable = true;
+      configuration = {
+        server = {
+          http_listen_port = 3300;
+          grpc_listen_port = 0;
+        };
+        positions = {
+          filename = "/tmp/positions.yaml";
+        };
+        clients = [{
+          url = "http://127.0.0.1:3200/loki/api/v1/push";
+        }];
+        scrape_configs = [{
+          job_name = "journal";
+          journal = {
+            max_age = "12h";
+            labels = {
+              job = "systemd-journal";
+              host = "pihole";
+            };
+          };
+          relabel_configs = [{
+            source_labels = [ "__journal__systemd_unit" ];
+            target_label = "unit";
+          }];
+        }];
+      };
+    };
+    
     nginx = {
       enable = false;
       # TODO: TLS enabled


### PR DESCRIPTION
Promtail is a part of the monitoring stack because it is the processor for logs. 

Promtail will send logs to a Loki service which is what injests the logs. Both services are needed, but promtail goes in front of Loki. It is the point where all of the rsyslog services that are running on the access points will send their logs. Basically, send logs to Promtail’s port, not directly to Loki. It is important to note that promtail only accepts newer RFC 5424 ("IETF") formatted syslog messages.

The Grafana dashboard will then be able to have Loki presets loaded into modules.

This push is just a build that puts the promtail servicee on the local NixOS host.

## Description of PR

<!--
addition of another section for promtail in the services section of the configuration.nix file. This code will get the promtail.service to active (running).
-->

## Previous Behavior

<!--
Loki was running, but there was no part of the monitoring stack where an AP can send it's logs to.
-->

## New Behavior

<!--
The promtail service runs on a port. An AP can point it's rsyslog service to send the log to that port that promtail is running on.
-->

## Tests

<!--
This was tested on a local version of NixOS v 24.11. 

The configuration.nix file would build. A systemctl status of promtail gave back a sucessful active (running) designation.

No tests were done to send logs to the service and see how the service processes the logs. Also no tests have been done on if the Loki service can receive data from the promtail service. Those configurations still need to be tweaked.
-->
