### PR TITLE
nixosModules.monitoring: enable nginx and add tests

### DIFF
--- a/nix/checks/monitor.nix
+++ b/nix/checks/monitor.nix
@@ -13,13 +13,30 @@
     virtualisation.graphics = true;
   };
 
-  testScript = ''
-    start_all()
-    coremaster.succeed("sleep 2")
-    coremaster.wait_for_unit("grafana.service", None, 30)
-    coremaster.wait_for_unit("prometheus.service", None, 30)
-    coremaster.wait_until_succeeds("nc -vz localhost 3000")
-  '';
+  nodes.client1 =
+    { pkgs, ... }:
+    {
+      systemd.services.systemd-networkd.environment.SYSTEMD_LOG_LEVEL = "debug";
+      #networking.extraHosts = "IP monitoring.scale.lan";
+      environment = {
+        systemPackages = with pkgs; [
+          curl
+        ];
+      };
+    };
+
+  testScript =
+    { nodes, ... }:
+    ''
+      start_all()
+      coremaster.succeed("sleep 2")
+      coremaster.wait_for_unit("grafana.service", None, 30)
+      coremaster.wait_for_unit("prometheus.service", None, 30)
+      coremaster.wait_until_succeeds("nc -vz localhost 3000")
+
+      client1.wait_until_succeeds("ping -c 5 ${nodes.coremaster.networking.hostName}")
+      client1.wait_until_succeeds("curl -v -L -H \"Host: monitoring.scale.lan\" http://${nodes.coremaster.networking.hostName}")
+    '';
 
   # TODO:
   # - Create machine that replays AP data

--- a/nix/nixos-modules/services/monitoring.nix
+++ b/nix/nixos-modules/services/monitoring.nix
@@ -23,11 +23,6 @@ let
 in
 {
   options.scale-network.services.monitoring.enable = mkEnableOption "SCaLE network monitoring server";
-  options.scale-network.services.monitoring.grafanaDomain = mkOption {
-    type = types.str;
-    default = "localhost";
-    description = "Publicly facing domain name used to access grafana from a browser";
-  };
 
   config = mkIf cfg.enable {
     networking.firewall.allowedTCPPorts = [
@@ -63,7 +58,7 @@ in
         server = {
           http_addr = "127.0.0.1";
           http_port = 3000;
-          domain = cfg.grafanaDomain;
+          domain = "localhost";
         };
         analytics.reporting_Enabled = false;
       };

--- a/nix/nixos-modules/services/monitoring.nix
+++ b/nix/nixos-modules/services/monitoring.nix
@@ -12,6 +12,7 @@ let
     ;
 
   inherit (lib.modules)
+    mkDefault
     mkIf
     ;
 
@@ -35,7 +36,7 @@ in
     ];
 
     services = {
-      prometheus.enable = true;
+      prometheus.enable = mkDefault true;
       prometheus.enableReload = true;
       prometheus.scrapeConfigs = [
         {
@@ -57,7 +58,7 @@ in
         }
       ];
 
-      grafana.enable = true;
+      grafana.enable = mkDefault true;
       grafana.settings = {
         server = {
           http_addr = "127.0.0.1";


### PR DESCRIPTION
## Description of PR

Use `mkDefault` for enable flags for easier toggling.
Remove `grafanaDomain` option and inline `localhost`.
Enable nginx routing and fix module definition.
Add test to check routing for grafana.

## Previous Behavior

We didn't enable nginx for monitoring.

## New Behavior

We enabled nginx for monitoring.

## Tests

`nix build .#checks.x86_64-linux.monitor`
