### PR TITLE
bump flake inputs & add wasgeht [DO NOT MERGE]

### DIFF
--- a/facts/inventory.py
+++ b/facts/inventory.py
@@ -703,6 +703,11 @@ def generatewasgehtconfig(switches, routers, pis, aps, servers, outputdir):
         wasgehtconfig[ap["name"]] = {"address": ap["ipv4"]}
     for server in servers:
         wasgehtconfig[server["name"]] = {"address": server["ipv6"]}
+    wasgehtconfig["google88v6"] = {"address": "2001:4860:4860::8888"}
+    wasgehtconfig["google88v4"] = {"address": "8.8.8.8"}
+    wasgehtconfig["google44v6"] = {"address": "2001:4860:4860::8844"}
+    wasgehtconfig["google44v4"] = {"address": "8.8.4.4"}
+    wasgehtconfig["localhost"] = {"address": "::1"}
     with open(f"{outputdir}/scale-wasgeht-config.json", "w") as f:
         json.dump(wasgehtconfig, f)
 

--- a/flake.lock
+++ b/flake.lock
@@ -7,17 +7,16 @@
         ]
       },
       "locked": {
-        "lastModified": 1725377834,
-        "narHash": "sha256-tqoAO8oT6zEUDXte98cvA1saU9+1dLJQe3pMKLXv8ps=",
+        "lastModified": 1740485968,
+        "narHash": "sha256-WK+PZHbfDjLyveXAxpnrfagiFgZWaTJglewBWniTn2Y=",
         "owner": "nix-community",
         "repo": "disko",
-        "rev": "e55f9a8678adc02024a4877c2a403e3f6daf24fe",
+        "rev": "19c1140419c4f1cdf88ad4c1cfb6605597628940",
         "type": "github"
       },
       "original": {
         "owner": "nix-community",
         "repo": "disko",
-        "rev": "e55f9a8678adc02024a4877c2a403e3f6daf24fe",
         "type": "github"
       }
     },

--- a/flake.lock
+++ b/flake.lock
@@ -39,11 +39,11 @@
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1726755586,
-        "narHash": "sha256-PmUr/2GQGvFTIJ6/Tvsins7Q43KTMvMFhvG6oaYK+Wk=",
+        "lastModified": 1740367490,
+        "narHash": "sha256-WGaHVAjcrv+Cun7zPlI41SerRtfknGQap281+AakSAw=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "c04d5652cfa9742b1d519688f65d1bbccea9eb7e",
+        "rev": "0196c0175e9191c474c26ab5548db27ef5d34b05",
         "type": "github"
       },
       "original": {
@@ -57,7 +57,7 @@
       "inputs": {
         "disko": "disko",
         "nixpkgs": [
-          "nixpkgs-2405"
+          "nixpkgs-unstable"
         ],
         "nixpkgs-2405": "nixpkgs-2405",
         "nixpkgs-unstable": "nixpkgs-unstable",

--- a/flake.nix
+++ b/flake.nix
@@ -6,7 +6,7 @@
     disko.url = "github:nix-community/disko/e55f9a8678adc02024a4877c2a403e3f6daf24fe";
     nixpkgs-2405.url = "github:NixOS/nixpkgs?rev=d51c28603def282a24fa034bcb007e2bcb5b5dd0";
     nixpkgs-unstable.url = "github:NixOS/nixpkgs/nixos-unstable";
-    nixpkgs.follows = "nixpkgs-2405";
+    nixpkgs.follows = "nixpkgs-unstable";
     treefmt-nix.inputs.nixpkgs.follows = "nixpkgs-unstable";
     treefmt-nix.url = "github:numtide/treefmt-nix";
   };

--- a/flake.nix
+++ b/flake.nix
@@ -3,7 +3,7 @@
 
   inputs = {
     disko.inputs.nixpkgs.follows = "nixpkgs-unstable";
-    disko.url = "github:nix-community/disko/e55f9a8678adc02024a4877c2a403e3f6daf24fe";
+    disko.url = "github:nix-community/disko";
     nixpkgs-2405.url = "github:NixOS/nixpkgs?rev=d51c28603def282a24fa034bcb007e2bcb5b5dd0";
     nixpkgs-unstable.url = "github:NixOS/nixpkgs/nixos-unstable";
     nixpkgs.follows = "nixpkgs-unstable";

--- a/nix/checks/core.nix
+++ b/nix/checks/core.nix
@@ -1,4 +1,4 @@
-{ inputs }:
+{ inputs, lib }:
 let
   chomp = "103";
   prefix = "2001:470:f026:${chomp}";
@@ -11,6 +11,9 @@ let
     ipv4 = "10.0.3.20";
   };
 
+  inherit (lib.modules)
+    mkForce
+    ;
 in
 {
   name = "core";
@@ -174,7 +177,7 @@ in
     let
       interactiveDefaults = hostPort: {
         services.openssh.enable = true;
-        services.openssh.settings.PermitRootLogin = "yes";
+        services.openssh.settings.PermitRootLogin = mkForce "yes";
         users.extraUsers.root.initialPassword = "";
         systemd.network.networks."01-eth0" = {
           name = "eth0";

--- a/nix/checks/core.nix
+++ b/nix/checks/core.nix
@@ -153,14 +153,11 @@ in
     in
     ''
       start_all()
-      router.wait_for_unit("systemd-networkd-wait-online.service")
       router.wait_for_unit("radvd.service")
-      coremaster.wait_for_unit("systemd-networkd-wait-online.service")
       coremaster.wait_for_unit("ntpd.service")
       coremaster.succeed("kea-dhcp4 -t /etc/kea/dhcp4-server.conf")
       coremaster.succeed("kea-dhcp6 -t /etc/kea/dhcp6-server.conf")
       coremaster.succeed("named-checkzone scale.lan ${scaleZone}")
-      client1.wait_for_unit("systemd-networkd-wait-online.service")
       client1.wait_until_succeeds("ping -c 5 ${coremasterAddr.ipv4}")
       client1.wait_until_succeeds("ping -c 5 -6 ${coremasterAddr.ipv6}")
       client1.wait_until_succeeds("ip route show | grep default | grep -w ${routerAddr.ipv4}")

--- a/nix/checks/default.nix
+++ b/nix/checks/default.nix
@@ -58,6 +58,7 @@ genAttrs
       core = pkgs.testers.runNixOSTest (import ./core.nix { inherit inputs lib; });
       loghost = pkgs.testers.runNixOSTest (import ./loghost.nix { inherit inputs; });
       monitor = pkgs.testers.runNixOSTest (import ./monitor.nix { inherit inputs; });
+      wasgeht = pkgs.testers.runNixOSTest (import ./wasgeht.nix { inherit inputs; });
 
       pytest-facts =
         let

--- a/nix/checks/default.nix
+++ b/nix/checks/default.nix
@@ -55,7 +55,7 @@ genAttrs
       pkgs = inputs.self.legacyPackages.${system};
     in
     {
-      core = pkgs.testers.runNixOSTest (import ./core.nix { inherit inputs; });
+      core = pkgs.testers.runNixOSTest (import ./core.nix { inherit inputs lib; });
       loghost = pkgs.testers.runNixOSTest (import ./loghost.nix { inherit inputs; });
       monitor = pkgs.testers.runNixOSTest (import ./monitor.nix { inherit inputs; });
 

--- a/nix/checks/wasgeht.nix
+++ b/nix/checks/wasgeht.nix
@@ -1,0 +1,38 @@
+{ inputs }:
+{
+  name = "wasgeht";
+
+  nodes.coremaster = {
+    _module.args = {
+      inherit inputs;
+    };
+    imports = [
+      inputs.self.nixosModules.default
+    ];
+    virtualisation.graphics = true;
+    scale-network.services.wasgeht.enable = true;
+  };
+
+  nodes.client1 =
+    { pkgs, ... }:
+    {
+      systemd.services.systemd-networkd.environment.SYSTEMD_LOG_LEVEL = "debug";
+      environment = {
+        systemPackages = with pkgs; [
+          curl
+        ];
+      };
+    };
+
+  testScript =
+    { nodes, ... }:
+    ''
+      start_all()
+      coremaster.succeed("sleep 2")
+      coremaster.wait_for_unit("wasgeht.service", None, 30)
+      coremaster.wait_until_succeeds("nc -vz localhost 1982")
+
+      client1.wait_until_succeeds("curl -v http://${nodes.coremaster.networking.hostName}:1982")
+    '';
+
+}

--- a/nix/checks/wasgeht.nix
+++ b/nix/checks/wasgeht.nix
@@ -28,11 +28,17 @@
     { nodes, ... }:
     ''
       start_all()
-      coremaster.succeed("sleep 2")
       coremaster.wait_for_unit("wasgeht.service", None, 30)
-      coremaster.wait_until_succeeds("nc -vz localhost 1982")
+      coremaster.succeed("nc -vz localhost 1982")
+      coremaster.succeed("curl -v http://localhost:1982")
+      coremaster.succeed("curl -v http://localhost:1982/imgs")
+      coremaster.succeed("curl -v http://localhost:1982/api")
+      coremaster.wait_until_succeeds("test -f /persist/var/lib/wasgeht/rrds/localhost_latency.rrd")
+      coremaster.wait_until_succeeds("journalctl -u wasgeht --no-pager | grep localhost | grep 'Ping successful'")
+      coremaster.wait_until_succeeds("test -f /persist/var/lib/wasgeht/graphs/imgs/localhost/localhost_latency_15m.png")
 
-      client1.wait_until_succeeds("curl -v http://${nodes.coremaster.networking.hostName}:1982")
+      client1.succeed("curl -v http://${nodes.coremaster.networking.hostName}:1982")
+      client1.succeed("curl -q http://${nodes.coremaster.networking.hostName}:1982/api | grep true")
+      client1.succeed("curl -v http://${nodes.coremaster.networking.hostName}:1982/imgs/localhost/localhost_latency_15m.png")
     '';
-
 }

--- a/nix/dev-shells/default.nix
+++ b/nix/dev-shells/default.nix
@@ -25,7 +25,7 @@ inputs.nixpkgs.lib.genAttrs
         fish
         git
         jq
-        kermit
+        tio
         screen
         glibcLocales
       ];

--- a/nix/nixos-configurations/core-master/configuration.nix
+++ b/nix/nixos-configurations/core-master/configuration.nix
@@ -12,6 +12,7 @@
     services.monitoring.enable = true;
     services.prometheus.enable = true;
     services.ssh.enable = true;
+    services.wasgeht.enable = true;
     libvirt.enable = true;
     timeServers.enable = true;
 

--- a/nix/nixos-modules/services/bind-master.nix
+++ b/nix/nixos-modules/services/bind-master.nix
@@ -38,7 +38,6 @@ in
 
   config = mkIf cfg.enable {
     networking = {
-      #useDHCP = false;
       firewall.allowedTCPPorts = [
         53
       ];
@@ -52,10 +51,7 @@ in
       bind
     ];
 
-    environment.etc."bind/named.conf".source = config.services.bind.configFile;
-
     systemd.services.bind = {
-      serviceConfig.ExecStart = lib.mkForce "${cfgBind.package.out}/sbin/named -u named ${lib.strings.optionalString cfgBind.ipv4Only "-4"} -c /etc/bind/named.conf -f";
       restartTriggers = [
         cfgBind.configFile
       ];

--- a/nix/nixos-modules/services/default.nix
+++ b/nix/nixos-modules/services/default.nix
@@ -11,5 +11,6 @@
     ./rsyslogd.nix
     ./signs.nix
     ./ssh.nix
+    ./wasgeht.nix
   ];
 }

--- a/nix/nixos-modules/services/kea-master.nix
+++ b/nix/nixos-modules/services/kea-master.nix
@@ -16,7 +16,8 @@ let
     ;
 in
 {
-  options.scale-network.services.keaMaster.enable = mkEnableOption "SCaLE network kea master DHCP server";
+  options.scale-network.services.keaMaster.enable =
+    mkEnableOption "SCaLE network kea master DHCP server";
 
   config = mkIf cfg.enable {
     networking = {

--- a/nix/nixos-modules/services/prometheus.nix
+++ b/nix/nixos-modules/services/prometheus.nix
@@ -11,7 +11,8 @@ let
     ;
 in
 {
-  options.scale-network.services.prometheus.enable = mkEnableOption "SCaLE network prometheus exporter";
+  options.scale-network.services.prometheus.enable =
+    mkEnableOption "SCaLE network prometheus exporter";
 
   config =
     let

--- a/nix/nixos-modules/services/wasgeht.nix
+++ b/nix/nixos-modules/services/wasgeht.nix
@@ -1,0 +1,68 @@
+{
+  config,
+  pkgs,
+  lib,
+  ...
+}:
+let
+
+  cfg = config.scale-network.services.wasgeht;
+
+  inherit (lib)
+    types
+    ;
+
+  inherit (lib.modules)
+    mkIf
+    ;
+
+  inherit (lib.options)
+    mkEnableOption
+    mkOption
+    mkPackageOption
+    ;
+
+in
+
+{
+
+  options.scale-network.services.wasgeht = {
+
+    enable = mkEnableOption "SCaLE wasgeht monitoring service";
+
+    package = mkPackageOption pkgs.scale-network "wasgeht" { };
+
+    hostFile = mkOption {
+      type = types.str;
+      default = "${pkgs.scale-network.scaleInventory}/scale-wasgeht-config.json";
+    };
+
+    logLevel = mkOption {
+      type = types.str;
+      default = "info";
+    };
+
+    port = mkOption {
+      type = types.int;
+      default = 1982;
+    };
+
+    statePath = mkOption {
+      type = types.str;
+      default = "/persist/var/lib/wasgeht";
+    };
+  };
+
+  config = mkIf cfg.enable {
+    systemd.services.wasgeht = {
+      after = [ "network.target" ];
+      serviceConfig = {
+        ExecStart = "${lib.getExe cfg.package} --data-dir=${cfg.statePath} --host-file=${cfg.hostFile} --port=${builtins.toString cfg.port} --log-level={cfg.logLevel}";
+      };
+      unitConfig = {
+        ConditionPathExists = "!${cfg.statePath}";
+      };
+    };
+
+  };
+}

--- a/nix/packages/wasgeht/package.nix
+++ b/nix/packages/wasgeht/package.nix
@@ -2,8 +2,9 @@
   lib,
   buildGoModule,
   fetchFromGitHub,
+  makeWrapper,
+  iputils,
   rrdtool,
-  unixtools,
 }:
 
 buildGoModule {
@@ -25,9 +26,24 @@ buildGoModule {
   ];
 
   buildInputs = [
+    iputils
+    makeWrapper
     rrdtool
-    unixtools.ping
   ];
+
+  propogatedBuildInputs = [
+    iputils
+    rrdtool
+  ];
+
+  postFixup = ''
+    wrapProgram $out/bin/wasgehtd --set PATH ${
+      lib.makeBinPath [
+        rrdtool
+        iputils
+      ]
+    }
+  '';
 
   meta = with lib; {
     description = "90s style monitoring";

--- a/nix/packages/wasgeht/package.nix
+++ b/nix/packages/wasgeht/package.nix
@@ -9,13 +9,13 @@
 
 buildGoModule {
   pname = "wasgeht";
-  version = "0.1.1";
+  version = "0.1.2";
 
   src = fetchFromGitHub {
     owner = "kylerisse";
     repo = "wasgeht";
-    rev = "refs/tags/0.1.1";
-    hash = "sha256-NTASU/vXqr7zwYAXGSz2UD9DcDIcsASH0nduytdJ6J8=";
+    rev = "refs/tags/0.1.2";
+    hash = "sha256-Sqfi3Yo6ZUNZLNy8g+P85Q5JwMUgiGYuQZxVcQOUDLM=";
   };
 
   vendorHash = "sha256-0HDZ3llIgLMxRLNei93XrcYliBzjajU6ZPllo3/IZVY=";
@@ -50,6 +50,6 @@ buildGoModule {
     homepage = "https://github.com/kylerisse/wasgeht";
     license = licenses.mit;
     maintainers = with maintainers; [ ];
-    mainProgram = "wasgeht";
+    mainProgram = "wasgehtd";
   };
 }

--- a/nix/packages/wasgeht/package.nix
+++ b/nix/packages/wasgeht/package.nix
@@ -1,0 +1,39 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+  rrdtool,
+  unixtools,
+}:
+
+buildGoModule {
+  pname = "wasgeht";
+  version = "0.1.1";
+
+  src = fetchFromGitHub {
+    owner = "kylerisse";
+    repo = "wasgeht";
+    rev = "refs/tags/0.1.1";
+    hash = "sha256-NTASU/vXqr7zwYAXGSz2UD9DcDIcsASH0nduytdJ6J8=";
+  };
+
+  vendorHash = "sha256-0HDZ3llIgLMxRLNei93XrcYliBzjajU6ZPllo3/IZVY=";
+
+  ldflags = [
+    "-s"
+    "-w"
+  ];
+
+  buildInputs = [
+    rrdtool
+    unixtools.ping
+  ];
+
+  meta = with lib; {
+    description = "90s style monitoring";
+    homepage = "https://github.com/kylerisse/wasgeht";
+    license = licenses.mit;
+    maintainers = with maintainers; [ ];
+    mainProgram = "wasgeht";
+  };
+}


### PR DESCRIPTION
## Description of PR

Depends on #846 

- Bumps the nixpkgs-unstable flake input.
- The general nixpkgs input is used for legacyPackages, devShells, formatter, and checks. It would be better if this tracked unstable rather than a release.
- Unpin the disko flake input and bump to the latest.
- Adds wasgeht package.

## Previous Behavior

n/a

## New Behavior

n/a

## Tests

`nix flake check`
`nix build .#legacyPackages.x86_64-linux.scale-network.wasgeht`