### PR TITLE
nixosConfigurations.coreSlave: bindMaster=enabled

### DIFF
--- a/nix/nixos-configurations/core-slave/configuration.nix
+++ b/nix/nixos-configurations/core-slave/configuration.nix
@@ -5,10 +5,7 @@
   scale-network = {
     base.enable = true;
     services.keaMaster.enable = true;
-    services.bindSlave = {
-      enable = true;
-      masters = [ "2001:470:f026:503::20" ];
-    };
+    services.bindMaster.enable = true;
     services.ntp.enable = true;
     services.rsyslogd.enable = true;
     services.signs.enable = true;


### PR DESCRIPTION


## Description of PR

<!--
Brief description of the changes in PR

If change is related to an open issue template include at the top of your
description.
-->

Simplify and unify our DNS servers across configs. Masters for both. Remove the complexity of the master -> slave replication

## Previous Behavior

<!--
What was the behavior before this PR?

Remove this section if not relevant
-->

- Slave replication for scale.lan zones

## New Behavior

<!--
What is the new behavior being introduced in this PR?

Remove this section if not relevant
-->

- run both bind severs as masters for scale.lan

## Tests

<!--
How was this PR tested? Please provide as much detail as possible
so we can ensure this change is working as intended before being merged.
-->

- Applied and verified working against the slave:

```
$ dig @10.0.3.20 coreexpo.scale.lan +short
10.0.3.20
```
