### PR TITLE
Minor patch to Loader and replacement of dead switch

### DIFF
--- a/switch-configuration/config/scripts/Loader.pm
+++ b/switch-configuration/config/scripts/Loader.pm
@@ -507,7 +507,7 @@ sub override_switch
     {
         # Send cconfiguration file via SFTP, then use Expect to send $SWITCH_COMMANDS to activate
         my $result;
-	my $target = lc($Name).'.scale.lan';
+	#	my $target = lc($Name).'.scale.lan';
         print STDERR "Initializing SFTP connection to $target with user ",$self->{"DefaultUser"},"\n";
         push @messages, "Initializing SFTP connection to $target with user ",$self->{"DefaultUser"},"\n";
         my $sftp = Net::SFTP::Foreign->new($target, (user=>$self->{"DefaultUser"}, password=>$self->{"DefaultPassword"})) || croak("Failed to initiate SFTP to $target ($Name)\n");
@@ -595,7 +595,7 @@ sub override_switch
       #$JUNIPER->send("commit and-quit\n");
       print $JUNIPER "commit and-quit\n";
     }
-    ($pos, $err, $matched, $before, $after) = $JUNIPER->expect(30,
+    ($pos, $err, $matched, $before, $after) = $JUNIPER->expect(60,
             '> '
     );
     $before =~ s/\033/<Esc>/g;

--- a/switch-configuration/config/switchtypes
+++ b/switch-configuration/config/switchtypes
@@ -23,7 +23,7 @@ ExpoIDF		5	103	2001:470:f026:103::200:5	exIDF		X.1		-		ex4200-48p	00:26:88:6e:aa
 Expo-Catwalk	6	103	2001:470:f026:103::200:6	Catwalk		W.1		Loud		ex4200-48p	00:26:88:7d:d3:7f
 MassFlash	7	503	2001:470:f026:503::200:7	MassFlash	Z.9		Normal		ex4200-48p	00:26:88:6e:b6:ff
 AVSwitch	8	503	2001:470:f026:503::200:8	cfAV		I.9		Quiet		ex4200-48p	00:26:88:7d:dd:ff
-Rm209-210	9	503	2001:470:f026:503::200:9	cfRoom		I.9		Normal		ex4200-48p	00:26:88:6e:a1:7f
+DECEASED1	9	503	2001:470:f026:503::200:9	cfRoom		I.9		Normal		ex4200-48p	00:26:88:6e:a1:7f
 Rm211		10	503	2001:470:f026:503::200:10	cfRoom		I.9		Loud		ex4200-48p	2c:6b:f5:39:cb:ff
 Rm214		11	503	2001:470:f026:503::200:11	cfRoom		I.9		Normal		ex4200-48p	00:26:88:60:71:7f
 Rm101-102	12	503	2001:470:f026:503::200:12	cfRoom		I.9		Normal		ex4200-48p	b0:c6:9a:dc:4d:ff
@@ -61,7 +61,7 @@ BallroomDE	43	103	2001:470:f026:103::200:43	exRoom		F.9		Normal		ex4200-48p	00:2
 BallroomF	44	103	2001:470:f026:103::200:44	exRoom		F.9		Loud		ex4200-48p	00:26:88:7c:41:7f
 BallroomG	45	103	2001:470:f026:103::200:45	exRoom		F.9		Normal		ex4200-48p	00:26:88:6e:b1:ff
 BallroomH	46	103	2001:470:f026:103::200:46	exRoom		F.9		Loud		ex4200-48p	00:26:88:7f:0e:7f
-SpareG		47	103	2001:470:f026:103::200:47	cfRoom		Z.9		Normal		ex4200-48p	00:26:88:6e:9f:ff
+Rm209-210	47	103	2001:470:f026:103::200:47	cfRoom		Z.9		Normal		ex4200-48p	00:26:88:6e:9f:ff
 SpareH		48	103	2001:470:f026:103::200:48	exRoom		Z.9		??		ex4200-48p	84:18:88:ac:d7:7f
 SpareI		49	103	2001:470:f026:103::200:49	exRoom		Z.9		??		ex4200-48p	84:18:88:ab:df:ff
 SpareJ		50	103	2001:470:f026:103::200:50	Booth		W.9		??		ex4200-48p	84:18:88:ad:4e:ff


### PR DESCRIPTION
## Description of PR

Minor patch to Loader (correct SFTP for local port)
Funeral for switch 9, Resurrection as switch 47

## Previous Behavior

Unable to achieve Lazarus effect
Did not respond to painful stimuli
Switch 9 pronounced dead at 19:00 UTC March 4, 2025

SFTP tried to go to $HOSTNAME instead of local management interface even with -b and/or -l

## New Behavior

Switch 47 reprovisioned to resurrect Rm209-210

SFTP goes to the right place now.

## Tests

You put your yak hand in,
You put your yak hand out,
You put your yak hand in,
and shake it all about.
You do the Yakey Tacky and you turn yourself about.
That's what it's all about!
