### PR TITLE
facts.inventory: flipflop core* CNAMEs

### DIFF
--- a/facts/inventory.py
+++ b/facts/inventory.py
@@ -345,12 +345,12 @@ def serveralias(name):
     match name.lower():
         case "coreexpo":
             payload = [
-                "coremaster",
+                "coreslave",
                 "ntpexpo",
             ]
         case "coreconf":
             payload = [
-                "coreslave",
+                "coremaster",
                 "loghost",
                 "monitoring",
                 "ntpconf",


### PR DESCRIPTION
## Description of PR

<!--
Brief description of the changes in PR

If change is related to an open issue template include at the top of your
description.
-->

Got them the wrong way round

## Previous Behavior

<!--
What was the behavior before this PR?

Remove this section if not relevant
-->

- Point to the wrong core severs for our names

## New Behavior

<!--
What is the new behavior being introduced in this PR?

Remove this section if not relevant
-->
- CNAMES all point to the right place

## Tests

- Verified against both cores after applying these changes:
```
driver workspace $ dig @10.128.3.20 coremaster.scale.lan +short
coreexpo.scale.lan.
10.0.3.20
driver workspace $ dig @10.0.3.20 coremaster.scale.lan +short
coreconf.scale.lan.
10.128.3.20
driver workspace $ dig @10.128.3.20 coreslave.scale.lan +short
coreexpo.scale.lan.
10.0.3.20
driver workspace $ dig @10.0.3.20 coreslave.scale.lan +short
coreexpo.scale.lan.
10.0.3.20

checks.core passes:

```
$ nix build -L .#checks.x86_64-linux.core
```
<!--
How was this PR tested? Please provide as much detail as possible
so we can ensure this change is working as intended before being merged.
-->
