### PR TITLE
[READY] rsyslog listen on UDP

### DIFF
--- a/nix/checks/loghost.nix
+++ b/nix/checks/loghost.nix
@@ -20,7 +20,9 @@
     coremaster.succeed("systemctl is-active syslog")
     coremaster.succeed("logger -n 127.0.0.1 -P 514 --tcp 'troyTCP'")
     coremaster.succeed("cat /persist/rsyslog/**/root.log | grep troyTCP")
+    coremaster.succeed("cat /persist/rsyslog/**/messages.log | grep troyTCP")
     coremaster.succeed("logger -n 127.0.0.1 -P 514 --udp 'troyUDP'")
     coremaster.succeed("cat /persist/rsyslog/**/root.log | grep troyUDP")
+    coremaster.succeed("cat /persist/rsyslog/**/messages.log | grep troyUDP")
   '';
 }

--- a/nix/checks/loghost.nix
+++ b/nix/checks/loghost.nix
@@ -18,7 +18,9 @@
     start_all()
     coremaster.succeed("sleep 2")
     coremaster.succeed("systemctl is-active syslog")
-    coremaster.succeed("logger -n 127.0.0.1 -P 514 --tcp 'troy'")
-    coremaster.succeed("cat /persist/rsyslog/**/root.log | grep troy")
+    coremaster.succeed("logger -n 127.0.0.1 -P 514 --tcp 'troyTCP'")
+    coremaster.succeed("cat /persist/rsyslog/**/root.log | grep troyTCP")
+    coremaster.succeed("logger -n 127.0.0.1 -P 514 --udp 'troyUDP'")
+    coremaster.succeed("cat /persist/rsyslog/**/root.log | grep troyUDP")
   '';
 }

--- a/nix/nixos-modules/services/rsyslogd.nix
+++ b/nix/nixos-modules/services/rsyslogd.nix
@@ -20,7 +20,10 @@ in
 
   config = mkIf cfg.enable {
 
-    networking.firewall.allowedTCPPorts = [ 514 ];
+    networking.firewall = {
+      allowedTCPPorts = [ 514 ];
+      allowedUDPPorts = [ 514 ];
+    };
 
     environment.systemPackages = with pkgs; [ rsyslog ];
 
@@ -29,6 +32,9 @@ in
       defaultConfig = ''
         module(load="imtcp")
         input(type="imtcp" port="514")
+
+        module(load="imudp")
+        input(type="imudp" port="514")
 
         $template RemoteLogs,"/persist/rsyslog/%HOSTNAME%/%PROGRAMNAME%.log"
         *.* ?RemoteLogs

--- a/nix/nixos-modules/services/rsyslogd.nix
+++ b/nix/nixos-modules/services/rsyslogd.nix
@@ -37,8 +37,10 @@ in
         input(type="imudp" port="514")
 
         $template RemoteLogs,"/persist/rsyslog/%HOSTNAME%/%PROGRAMNAME%.log"
-        *.* ?RemoteLogs
-        & ~
+        ?RemoteLogs
+
+        $template RemoteLogs2,"/persist/rsyslog/%HOSTNAME%/messages.log"
+        ?RemoteLogs2
       '';
     };
   };


### PR DESCRIPTION
## Description of PR

Add UDP support for rsyslog

## Previous Behavior

- rsyslog not listening on UDP

## New Behavior

- rsyslog listening on UDP

## Tests

- `nix build --rebuild -L .#checks.x86_64-linux.loghost`

```
vm-test-run-loghost> (finished: must succeed: sleep 2, in 10.31 seconds)
vm-test-run-loghost> coremaster: must succeed: systemctl is-active syslog
vm-test-run-loghost> (finished: must succeed: systemctl is-active syslog, in 0.05 seconds)
vm-test-run-loghost> coremaster: must succeed: logger -n 127.0.0.1 -P 514 --tcp 'troyTCP'
vm-test-run-loghost> (finished: must succeed: logger -n 127.0.0.1 -P 514 --tcp 'troyTCP', in 0.04 seconds)
vm-test-run-loghost> coremaster: must succeed: cat /persist/rsyslog/**/root.log | grep troyTCP
vm-test-run-loghost> (finished: must succeed: cat /persist/rsyslog/**/root.log | grep troyTCP, in 0.04 seconds)
vm-test-run-loghost> coremaster: must succeed: logger -n 127.0.0.1 -P 514 --udp 'troyUDP'
vm-test-run-loghost> (finished: must succeed: logger -n 127.0.0.1 -P 514 --udp 'troyUDP', in 0.03 seconds)
vm-test-run-loghost> coremaster: must succeed: cat /persist/rsyslog/**/root.log | grep troyUDP
vm-test-run-loghost> (finished: must succeed: cat /persist/rsyslog/**/root.log | grep troyUDP, in 0.03 seconds)
vm-test-run-loghost> (finished: run the VM test script, in 10.63 seconds)
vm-test-run-loghost> test script finished in 10.69s
vm-test-run-loghost> cleanup
```
