### PR TITLE
facts.inventory: set dhcp4 options to string

### DIFF
--- a/facts/inventory.py
+++ b/facts/inventory.py
@@ -464,7 +464,7 @@ def generatekeaconfig(servers, aps, vlans, outputdir):
                 {
                     "name": "radio24-channel",
                     "code": 224,
-                    "type": "uint8",
+                    "type": "string",
                     "array": False,
                     "record-types": "",
                     "space": "dhcp4",
@@ -473,7 +473,7 @@ def generatekeaconfig(servers, aps, vlans, outputdir):
                 {
                     "name": "radio5-channel",
                     "code": 225,
-                    "type": "uint8",
+                    "type": "string",
                     "array": False,
                     "record-types": "",
                     "space": "dhcp4",
@@ -482,7 +482,7 @@ def generatekeaconfig(servers, aps, vlans, outputdir):
                 {
                     "name": "ap-network-config",
                     "code": 226,
-                    "type": "uint8",
+                    "type": "string",
                     "array": False,
                     "record-types": "",
                     "space": "dhcp4",


### PR DESCRIPTION
## Description of PR

<!--
Brief description of the changes in PR

If change is related to an open issue template include at the top of your
description.
-->

- Setting this to a string instead of uint8

## Previous Behavior

<!--
What was the behavior before this PR?

Remove this section if not relevant
-->
- dhcp options were uint8

## New Behavior

<!--
What is the new behavior being introduced in this PR?

Remove this section if not relevant
-->
- dhcp options set to string

## Tests

- Verified working on coreMaster
<!--
How was this PR tested? Please provide as much detail as possible
so we can ensure this change is working as intended before being merged.
-->
