### PR TITLE
Grafana fix

### DIFF
--- a/nix/nixos-modules/services/monitoring.nix
+++ b/nix/nixos-modules/services/monitoring.nix
@@ -65,7 +65,7 @@ in
         server = {
           http_addr = "127.0.0.1";
           http_port = 3000;
-          domain = "localhost";
+          domain = "${cfg.nginxFQDN}";
         };
         analytics.reporting_Enabled = false;
       };
@@ -90,6 +90,7 @@ in
       };
 
       nginx.enable = mkDefault true;
+      nginx.recommendedProxySettings = true;
       # TODO: TLS enabled
       # Good example enable TLS, but would like to keep it out of the /nix/store
       # ref: https://github.com/NixOS/nixpkgs/blob/c6fd903606866634312e40cceb2caee8c0c9243f/nixos/tests/custom-ca.nix#L80

--- a/nix/nixos-modules/services/monitoring.nix
+++ b/nix/nixos-modules/services/monitoring.nix
@@ -99,6 +99,9 @@ in
         enableACME = false;
         locations."/" = {
           proxyPass = "http://${toString config.services.grafana.settings.server.http_addr}:${toString config.services.grafana.settings.server.http_port}/";
+        };
+        locations."/api/live" = {
+          proxyPass = "http://${toString config.services.grafana.settings.server.http_addr}:${toString config.services.grafana.settings.server.http_port}/";
           proxyWebsockets = true;
         };
       };


### PR DESCRIPTION
## Description of PR

<!--
Brief description of the changes in PR

If change is related to an open issue template include at the top of your
description.
-->

Fix the domain to be the one actually being accessed, add the recommended proxy settings, and add a location block for `/api/live` for Grafana.

## Previous Behavior

<!--
What was the behavior before this PR?

Remove this section if not relevant
-->

Prior to this, Grafana was not working because the domain was set to localhost


## Tests

<!--
How was this PR tested? Please provide as much detail as possible
so we can ensure this change is working as intended before being merged.
-->

We don't have a good way to test this right now, but plan to write checks in here once we can validate them.
