### PR TITLE
Add scraping of wasgeht

### DIFF
--- a/nix/nixos-modules/services/monitoring.nix
+++ b/nix/nixos-modules/services/monitoring.nix
@@ -58,6 +58,14 @@ in
             builtins.readFile "${pkgs.scale-network.scaleInventory}/config/prom.json"
           );
         }
+        {
+          job_name = "wasgeht";
+          static_configs = [
+            {
+              targets = [ "localhost:${toString config.scale-network.services.wasgeht.port}" ];
+            }
+          ];
+        }
       ];
 
       grafana.enable = mkDefault true;


### PR DESCRIPTION
## Description of PR

Add Prometheus scrape config for the wasgeht service's metrics

## Previous Behavior

No metrics were collected

## New Behavior

metrics will be stored in Prometheus and usable for Grafana dashboards

## Tests

Running `:p nixosConfigurations.coreMaster.config.services.prometheus.scrapeConfigs` in the nix repl produces this snippet which shows the expected target is rendered:

```nix
    static_configs = [
      {
        labels = { };
        targets = [ "localhost:1982" ];
      }
    ];
```
