### PR TITLE
nixosModules.services.signs: bumping signs for 22x

### DIFF
--- a/nix/nixos-modules/services/signs.nix
+++ b/nix/nixos-modules/services/signs.nix
@@ -21,7 +21,7 @@ in
     networking.firewall.allowedTCPPorts = [ 80 ];
     virtualisation.oci-containers = {
       containers.scale-signs = {
-        image = "sarcasticadmin/scale-signs:1a4fbab";
+        image = "sarcasticadmin/scale-signs:2309424 ";
         ports = [ "80:80" ];
         extraOptions = [
           "--network=host"

--- a/nix/nixos-modules/services/signs.nix
+++ b/nix/nixos-modules/services/signs.nix
@@ -21,7 +21,6 @@ in
     networking.firewall.allowedTCPPorts = [ 80 ];
     virtualisation.oci-containers = {
       containers.scale-signs = {
-        environmentFiles = [ /var/lib/secrets/scale-sign-secrets.env ];
         image = "sarcasticadmin/scale-signs:1a4fbab";
         ports = [ "80:80" ];
         extraOptions = [


### PR DESCRIPTION
## Description of PR

<!--
Brief description of the changes in PR

If change is related to an open issue template include at the top of your
description.
-->

## Previous Behavior

<!--
What was the behavior before this PR?

Remove this section if not relevant
-->
- signs were previously on 21x config
- 
## New Behavior

<!--
What is the new behavior being introduced in this PR?

Remove this section if not relevant
-->
- signs are on 22x config

## Tests

<!--
How was this PR tested? Please provide as much detail as possible
so we can ensure this change is working as intended before being merged.
-->

- TBD
