### PR TITLE
Added NTP to configuration generator

### DIFF
--- a/switch-configuration/config/scripts/switch_template.pm
+++ b/switch-configuration/config/scripts/switch_template.pm
@@ -693,6 +693,9 @@ EOF
             family inet {
                     address 192.168.255.76/24;
             }
+            family inet6 {
+                address fe80::$Number/64;
+            }
         }
     }
 EOF
@@ -911,6 +914,7 @@ sub build_l3_from_config
         unit $MgtVL {
             family inet6 {
                 address $IPv6addr/64;
+                address fe80::$Number/64;
             }
         }
 EOF
@@ -1824,10 +1828,16 @@ sub build_config_from_template
   debug(5, "Final IPv4 Gateway = \n".$IPV4_DEFGW."\n<end>\n");
   my $OUTPUT = <<EOF;
 system {
+    time-zone UTC;
     host-name $hostname;
     root-authentication {
         encrypted-password "$root_auth";
     }
+    ntp {
+        server 2001:470:f026:503::20;
+        server 2001:470:f026:103::20;
+    }
+
     syslog {
         host loghost {
         any any;

--- a/switch-configuration/config/switchtypes
+++ b/switch-configuration/config/switchtypes
@@ -26,7 +26,7 @@ AVSwitch	8	503	2001:470:f026:503::200:8	cfAV		I.9		Quiet		ex4200-48p	00:26:88:7d
 DECEASED1	9	503	2001:470:f026:503::200:9	cfRoom		Z.9		Normal		ex4200-48p	00:26:88:6e:a1:7f
 Rm211		10	503	2001:470:f026:503::200:10	cfRoom		I.9		Loud		ex4200-48p	2c:6b:f5:39:cb:ff
 Rm214		11	503	2001:470:f026:503::200:11	cfRoom		I.9		Normal		ex4200-48p	00:26:88:60:71:7f
-Rm101-102	12	503	2001:470:f026:503::200:12	cfRoom		I.9		Normal		ex4200-48p	b0:c6:9a:dc:4d:ff
+DECEASED3	12	503	2001:470:f026:503::200:12	cfRoom		Z.9		Normal		ex4200-48p	b0:c6:9a:dc:4d:ff
 Rm103		13	503	2001:470:f026:503::200:13	cfRoom		I.9		Normal		ex4200-48p	00:26:88:7a:8f:ff
 Rm104		14	503	2001:470:f026:503::200:14	cfRoom		I.9		Normal		ex4200-48p	00:26:88:7d:e5:ff
 Rm105		15	503	2001:470:f026:503::200:15	cfRoom		I.9		??		ex4200-48p	b0:c6:9a:db:b5:7f
@@ -62,7 +62,7 @@ BallroomF	44	103	2001:470:f026:103::200:44	exRoom		F.9		Loud		ex4200-48p	00:26:8
 BallroomG	45	103	2001:470:f026:103::200:45	exRoom		F.9		Normal		ex4200-48p	00:26:88:6e:b1:ff
 DECEASED2	46	103	2001:470:f026:103::200:46	exRoom		Z.9		Loud		ex4200-48p	00:26:88:7f:0e:7f
 Rm209-210	47	503	2001:470:f026:503::200:47	cfRoom		I.9		Normal		ex4200-48p	00:26:88:6e:9f:ff
-SpareH		48	103	2001:470:f026:103::200:48	exRoom		Z.9		??		ex4200-48p	84:18:88:ac:d7:7f
+Rm101-102	48	103	2001:470:f026:103::200:48	cfRoom		I.9		??		ex4200-48p	84:18:88:ac:d7:7f
 BallroomH	49	103	2001:470:f026:103::200:49	exRoom		F.9		??		ex4200-48p	84:18:88:ab:df:ff
 Rm208		50	503	2001:470:f026:503::200:50	cfRoom		I.9		??		ex4200-48p	84:18:88:ad:4e:ff
 DONOTUSE	51	103	2001:470:f026:103::200:51	swatch		Z.9		Loud		ex4200-48px	ec:3e:f7:50:58:ff


### PR DESCRIPTION
Added fe80::<num>/64 to me0 and vlan.[15]03 (depending on building. (First of 3 parts to #879, art of the possible)

## Description of PR

Add fe80::<num> to me0 and vlan.[15]03 (depending on building) interfaces
Add NTP
Set timezone to UTC

## Previous Behavior

None of that happened.

## New Behavior

It's happening now.

## Tests

SSH, hand configured bespoke switch, surgical tubing, lubricant, yak and 4 leather goddesses.
No yaks were harmed in the making of this PR. Cannot say the same for the leather goddesses.
