### PR TITLE
adds snmp_exporter and scrape jobs to prometheus

### DIFF
--- a/nix/nixos-configurations/core-slave/configuration.nix
+++ b/nix/nixos-configurations/core-slave/configuration.nix
@@ -9,7 +9,8 @@
     services.ntp.enable = true;
     services.rsyslogd.enable = true;
     services.signs.enable = true;
-    services.monitoring.enable = true;
+    # Turning off monitoring so we dont snmp walk
+    services.monitoring.enable = false;
     services.prometheus.enable = true;
     services.ssh.enable = true;
     libvirt.enable = true;

--- a/nix/nixos-modules/services/monitoring.nix
+++ b/nix/nixos-modules/services/monitoring.nix
@@ -66,7 +66,94 @@ in
             }
           ];
         }
+        {
+          job_name = "snmp";
+          static_configs = [
+            {
+              targets = [
+                "noc.scale.lan"
+                "confidf.scale.lan"
+                "nw-idf.scale.lan"
+                "ne-idf.scale.lan"
+                "expoidf.scale.lan"
+                "expo-catwalk.scale.lan"
+                "massflash.scale.lan"
+                "avswitch.scale.lan"
+                "deceased1.scale.lan"
+                "rm211.scale.lan"
+                "rm214.scale.lan"
+                "deceased3.scale.lan"
+                "rm103.scale.lan"
+                "rm104.scale.lan"
+                "rm105.scale.lan"
+                "rm106.scale.lan"
+                "rm107.scale.lan"
+                "sparea.scale.lan"
+                "spareb.scale.lan"
+                "sparec.scale.lan"
+                "spared.scale.lan"
+                "sparee.scale.lan"
+                "sparef.scale.lan"
+                "expoaw.scale.lan"
+                "expoa1.scale.lan"
+                "expoa2.scale.lan"
+                "expoa3.scale.lan"
+                "expoa4.scale.lan"
+                "expoa5.scale.lan"
+                "expob1.scale.lan"
+                "expob2.scale.lan"
+                "expob3.scale.lan"
+                "expob4.scale.lan"
+                "expob5.scale.lan"
+                "expoc1.scale.lan"
+                "expoc2.scale.lan"
+                "expoc3.scale.lan"
+                "expoc4.scale.lan"
+                "expoc5.scale.lan"
+                "ballrooma.scale.lan"
+                "ballroomb.scale.lan"
+                "ballroomc.scale.lan"
+                "ballroomde.scale.lan"
+                "ballroomf.scale.lan"
+                "ballroomg.scale.lan"
+                "deceased2.scale.lan"
+                "rm209-210.scale.lan"
+                "rm101-102.scale.lan"
+                "ballroomh.scale.lan"
+                "rm208.scale.lan"
+                "donotuse.scale.lan"
+                "regdesk.scale.lan"
+                "br-mdf-01.scale.lan"
+                "ex-mdf-01.scale.lan"
+                "cf-mdf-01.scale.lan"
+              ];
+            }
+          ];
+          metrics_path = "/snmp";
+          params = {
+            auth = [ "Junitux" ];
+            module = [ "juniper" ];
+          };
+          relabel_configs = [
+            {
+              source_labels = [ "__address__" ];
+              target_label = "__param_target";
+            }
+            {
+              source_labels = [ "__param_target" ];
+              target_label = "instance";
+            }
+            {
+              target_label = "__address__";
+              replacement = "127.0.0.1:9116";
+            }
+          ];
+        }
       ];
+      prometheus.exporters.snmp = {
+        enable = true;
+        configurationPath = ./snmp.yml;
+      };
 
       grafana.enable = mkDefault true;
       grafana.settings = {

--- a/nix/nixos-modules/services/monitoring.nix
+++ b/nix/nixos-modules/services/monitoring.nix
@@ -20,6 +20,13 @@ let
     mkEnableOption
     mkOption
     ;
+
+  unfilteredList = (
+    builtins.split "\n" (
+      builtins.readFile "${pkgs.scale-network.scaleInventory}/config/all-network-devices"
+    )
+  );
+  filteredList = (builtins.filter (line: line != [ ] && line != "") unfilteredList);
 in
 {
   options.scale-network.services.monitoring = {
@@ -70,63 +77,7 @@ in
           job_name = "snmp";
           static_configs = [
             {
-              targets = [
-                "noc.scale.lan"
-                "confidf.scale.lan"
-                "nw-idf.scale.lan"
-                "ne-idf.scale.lan"
-                "expoidf.scale.lan"
-                "expo-catwalk.scale.lan"
-                "massflash.scale.lan"
-                "avswitch.scale.lan"
-                "deceased1.scale.lan"
-                "rm211.scale.lan"
-                "rm214.scale.lan"
-                "deceased3.scale.lan"
-                "rm103.scale.lan"
-                "rm104.scale.lan"
-                "rm105.scale.lan"
-                "rm106.scale.lan"
-                "rm107.scale.lan"
-                "sparea.scale.lan"
-                "spareb.scale.lan"
-                "sparec.scale.lan"
-                "spared.scale.lan"
-                "sparee.scale.lan"
-                "sparef.scale.lan"
-                "expoaw.scale.lan"
-                "expoa1.scale.lan"
-                "expoa2.scale.lan"
-                "expoa3.scale.lan"
-                "expoa4.scale.lan"
-                "expoa5.scale.lan"
-                "expob1.scale.lan"
-                "expob2.scale.lan"
-                "expob3.scale.lan"
-                "expob4.scale.lan"
-                "expob5.scale.lan"
-                "expoc1.scale.lan"
-                "expoc2.scale.lan"
-                "expoc3.scale.lan"
-                "expoc4.scale.lan"
-                "expoc5.scale.lan"
-                "ballrooma.scale.lan"
-                "ballroomb.scale.lan"
-                "ballroomc.scale.lan"
-                "ballroomde.scale.lan"
-                "ballroomf.scale.lan"
-                "ballroomg.scale.lan"
-                "deceased2.scale.lan"
-                "rm209-210.scale.lan"
-                "rm101-102.scale.lan"
-                "ballroomh.scale.lan"
-                "rm208.scale.lan"
-                "donotuse.scale.lan"
-                "regdesk.scale.lan"
-                "br-mdf-01.scale.lan"
-                "ex-mdf-01.scale.lan"
-                "cf-mdf-01.scale.lan"
-              ];
+              targets = filteredList;
             }
           ];
           metrics_path = "/snmp";

--- a/nix/nixos-modules/services/snmp.yml
+++ b/nix/nixos-modules/services/snmp.yml
@@ -1,0 +1,920 @@
+# WARNING: This file was auto-generated using snmp_exporter generator, manual changes will be lost.
+auths:
+  Junitux:
+    community: Junitux
+    security_level: noAuthNoPriv
+    auth_protocol: MD5
+    priv_protocol: DES
+    version: 2
+  public_v1:
+    community: public
+    security_level: noAuthNoPriv
+    auth_protocol: MD5
+    priv_protocol: DES
+    version: 1
+  public_v2:
+    community: public
+    security_level: noAuthNoPriv
+    auth_protocol: MD5
+    priv_protocol: DES
+    version: 2
+modules:
+  juniper:
+    walk:
+    - 1.3.6.1.2.1.2.2.1.10
+    - 1.3.6.1.2.1.2.2.1.16
+    - 1.3.6.1.2.1.2.2.1.5
+    - 1.3.6.1.4.1.2636.3.1.13
+    - 1.3.6.1.4.1.2636.3.1.15.1.5
+    - 1.3.6.1.4.1.2636.3.1.15.1.8
+    - 1.3.6.1.4.1.2636.3.4.2.2
+    - 1.3.6.1.4.1.2636.3.4.2.3
+    - 1.3.6.1.4.1.2636.3.64.1.1.1.5.1.3
+    metrics:
+    - name: ifInOctets
+      oid: 1.3.6.1.2.1.2.2.1.10
+      type: counter
+      help: The total number of octets received on the interface, including framing
+        characters - 1.3.6.1.2.1.2.2.1.10
+      indexes:
+      - labelname: ifIndex
+        type: gauge
+    - name: ifOutOctets
+      oid: 1.3.6.1.2.1.2.2.1.16
+      type: counter
+      help: The total number of octets transmitted out of the interface, including
+        framing characters - 1.3.6.1.2.1.2.2.1.16
+      indexes:
+      - labelname: ifIndex
+        type: gauge
+    - name: ifSpeed
+      oid: 1.3.6.1.2.1.2.2.1.5
+      type: gauge
+      help: An estimate of the interface's current bandwidth in bits per second -
+        1.3.6.1.2.1.2.2.1.5
+      indexes:
+      - labelname: ifIndex
+        type: gauge
+    - name: jnxOperatingState
+      oid: 1.3.6.1.4.1.2636.3.1.13.1.6
+      type: gauge
+      help: The operating state of this subject. - 1.3.6.1.4.1.2636.3.1.13.1.6
+      indexes:
+      - labelname: jnxOperatingContentsIndex
+        type: gauge
+      - labelname: jnxOperatingL1Index
+        type: gauge
+      - labelname: jnxOperatingL2Index
+        type: gauge
+      - labelname: jnxOperatingL3Index
+        type: gauge
+      lookups:
+      - labels:
+        - jnxOperatingContentsIndex
+        - jnxOperatingL1Index
+        - jnxOperatingL2Index
+        - jnxOperatingL3Index
+        labelname: jnxOperatingDescr
+        oid: 1.3.6.1.4.1.2636.3.1.13.1.5
+        type: DisplayString
+      enum_values:
+        1: unknown
+        2: running
+        3: ready
+        4: reset
+        5: runningAtFullSpeed
+        6: down
+        7: standby
+    - name: jnxOperatingTemp
+      oid: 1.3.6.1.4.1.2636.3.1.13.1.7
+      type: gauge
+      help: The temperature in Celsius (degrees C) of this subject - 1.3.6.1.4.1.2636.3.1.13.1.7
+      indexes:
+      - labelname: jnxOperatingContentsIndex
+        type: gauge
+      - labelname: jnxOperatingL1Index
+        type: gauge
+      - labelname: jnxOperatingL2Index
+        type: gauge
+      - labelname: jnxOperatingL3Index
+        type: gauge
+      lookups:
+      - labels:
+        - jnxOperatingContentsIndex
+        - jnxOperatingL1Index
+        - jnxOperatingL2Index
+        - jnxOperatingL3Index
+        labelname: jnxOperatingDescr
+        oid: 1.3.6.1.4.1.2636.3.1.13.1.5
+        type: DisplayString
+    - name: jnxOperatingCPU
+      oid: 1.3.6.1.4.1.2636.3.1.13.1.8
+      type: gauge
+      help: The CPU utilization in percentage of this subject - 1.3.6.1.4.1.2636.3.1.13.1.8
+      indexes:
+      - labelname: jnxOperatingContentsIndex
+        type: gauge
+      - labelname: jnxOperatingL1Index
+        type: gauge
+      - labelname: jnxOperatingL2Index
+        type: gauge
+      - labelname: jnxOperatingL3Index
+        type: gauge
+      lookups:
+      - labels:
+        - jnxOperatingContentsIndex
+        - jnxOperatingL1Index
+        - jnxOperatingL2Index
+        - jnxOperatingL3Index
+        labelname: jnxOperatingDescr
+        oid: 1.3.6.1.4.1.2636.3.1.13.1.5
+        type: DisplayString
+    - name: jnxOperatingISR
+      oid: 1.3.6.1.4.1.2636.3.1.13.1.9
+      type: gauge
+      help: The CPU utilization in percentage of this subject spending in interrupt
+        service routine (ISR) - 1.3.6.1.4.1.2636.3.1.13.1.9
+      indexes:
+      - labelname: jnxOperatingContentsIndex
+        type: gauge
+      - labelname: jnxOperatingL1Index
+        type: gauge
+      - labelname: jnxOperatingL2Index
+        type: gauge
+      - labelname: jnxOperatingL3Index
+        type: gauge
+      lookups:
+      - labels:
+        - jnxOperatingContentsIndex
+        - jnxOperatingL1Index
+        - jnxOperatingL2Index
+        - jnxOperatingL3Index
+        labelname: jnxOperatingDescr
+        oid: 1.3.6.1.4.1.2636.3.1.13.1.5
+        type: DisplayString
+    - name: jnxOperatingDRAMSize
+      oid: 1.3.6.1.4.1.2636.3.1.13.1.10
+      type: gauge
+      help: The DRAM size in bytes of this subject - 1.3.6.1.4.1.2636.3.1.13.1.10
+      indexes:
+      - labelname: jnxOperatingContentsIndex
+        type: gauge
+      - labelname: jnxOperatingL1Index
+        type: gauge
+      - labelname: jnxOperatingL2Index
+        type: gauge
+      - labelname: jnxOperatingL3Index
+        type: gauge
+      lookups:
+      - labels:
+        - jnxOperatingContentsIndex
+        - jnxOperatingL1Index
+        - jnxOperatingL2Index
+        - jnxOperatingL3Index
+        labelname: jnxOperatingDescr
+        oid: 1.3.6.1.4.1.2636.3.1.13.1.5
+        type: DisplayString
+    - name: jnxOperatingBuffer
+      oid: 1.3.6.1.4.1.2636.3.1.13.1.11
+      type: gauge
+      help: The buffer pool utilization in percentage of this subject - 1.3.6.1.4.1.2636.3.1.13.1.11
+      indexes:
+      - labelname: jnxOperatingContentsIndex
+        type: gauge
+      - labelname: jnxOperatingL1Index
+        type: gauge
+      - labelname: jnxOperatingL2Index
+        type: gauge
+      - labelname: jnxOperatingL3Index
+        type: gauge
+      lookups:
+      - labels:
+        - jnxOperatingContentsIndex
+        - jnxOperatingL1Index
+        - jnxOperatingL2Index
+        - jnxOperatingL3Index
+        labelname: jnxOperatingDescr
+        oid: 1.3.6.1.4.1.2636.3.1.13.1.5
+        type: DisplayString
+    - name: jnxOperatingHeap
+      oid: 1.3.6.1.4.1.2636.3.1.13.1.12
+      type: gauge
+      help: The heap utilization in percentage of this subject - 1.3.6.1.4.1.2636.3.1.13.1.12
+      indexes:
+      - labelname: jnxOperatingContentsIndex
+        type: gauge
+      - labelname: jnxOperatingL1Index
+        type: gauge
+      - labelname: jnxOperatingL2Index
+        type: gauge
+      - labelname: jnxOperatingL3Index
+        type: gauge
+      lookups:
+      - labels:
+        - jnxOperatingContentsIndex
+        - jnxOperatingL1Index
+        - jnxOperatingL2Index
+        - jnxOperatingL3Index
+        labelname: jnxOperatingDescr
+        oid: 1.3.6.1.4.1.2636.3.1.13.1.5
+        type: DisplayString
+    - name: jnxOperatingUpTime
+      oid: 1.3.6.1.4.1.2636.3.1.13.1.13
+      type: gauge
+      help: The time interval in 10-millisecond period that this subject has been
+        up and running - 1.3.6.1.4.1.2636.3.1.13.1.13
+      indexes:
+      - labelname: jnxOperatingContentsIndex
+        type: gauge
+      - labelname: jnxOperatingL1Index
+        type: gauge
+      - labelname: jnxOperatingL2Index
+        type: gauge
+      - labelname: jnxOperatingL3Index
+        type: gauge
+      lookups:
+      - labels:
+        - jnxOperatingContentsIndex
+        - jnxOperatingL1Index
+        - jnxOperatingL2Index
+        - jnxOperatingL3Index
+        labelname: jnxOperatingDescr
+        oid: 1.3.6.1.4.1.2636.3.1.13.1.5
+        type: DisplayString
+    - name: jnxOperatingLastRestart
+      oid: 1.3.6.1.4.1.2636.3.1.13.1.14
+      type: gauge
+      help: The value of sysUpTime when this subject last restarted - 1.3.6.1.4.1.2636.3.1.13.1.14
+      indexes:
+      - labelname: jnxOperatingContentsIndex
+        type: gauge
+      - labelname: jnxOperatingL1Index
+        type: gauge
+      - labelname: jnxOperatingL2Index
+        type: gauge
+      - labelname: jnxOperatingL3Index
+        type: gauge
+      lookups:
+      - labels:
+        - jnxOperatingContentsIndex
+        - jnxOperatingL1Index
+        - jnxOperatingL2Index
+        - jnxOperatingL3Index
+        labelname: jnxOperatingDescr
+        oid: 1.3.6.1.4.1.2636.3.1.13.1.5
+        type: DisplayString
+    - name: jnxOperatingMemory
+      oid: 1.3.6.1.4.1.2636.3.1.13.1.15
+      type: gauge
+      help: The installed memory size in Megabytes of this subject - 1.3.6.1.4.1.2636.3.1.13.1.15
+      indexes:
+      - labelname: jnxOperatingContentsIndex
+        type: gauge
+      - labelname: jnxOperatingL1Index
+        type: gauge
+      - labelname: jnxOperatingL2Index
+        type: gauge
+      - labelname: jnxOperatingL3Index
+        type: gauge
+      lookups:
+      - labels:
+        - jnxOperatingContentsIndex
+        - jnxOperatingL1Index
+        - jnxOperatingL2Index
+        - jnxOperatingL3Index
+        labelname: jnxOperatingDescr
+        oid: 1.3.6.1.4.1.2636.3.1.13.1.5
+        type: DisplayString
+    - name: jnxOperatingStateOrdered
+      oid: 1.3.6.1.4.1.2636.3.1.13.1.16
+      type: gauge
+      help: The operating state of this subject - 1.3.6.1.4.1.2636.3.1.13.1.16
+      indexes:
+      - labelname: jnxOperatingContentsIndex
+        type: gauge
+      - labelname: jnxOperatingL1Index
+        type: gauge
+      - labelname: jnxOperatingL2Index
+        type: gauge
+      - labelname: jnxOperatingL3Index
+        type: gauge
+      lookups:
+      - labels:
+        - jnxOperatingContentsIndex
+        - jnxOperatingL1Index
+        - jnxOperatingL2Index
+        - jnxOperatingL3Index
+        labelname: jnxOperatingDescr
+        oid: 1.3.6.1.4.1.2636.3.1.13.1.5
+        type: DisplayString
+      enum_values:
+        1: running
+        2: standby
+        3: ready
+        4: runningAtFullSpeed
+        5: reset
+        6: down
+        7: unknown
+    - name: jnxOperatingChassisId
+      oid: 1.3.6.1.4.1.2636.3.1.13.1.17
+      type: gauge
+      help: Identifies the chassis on which the contents of this row exists. - 1.3.6.1.4.1.2636.3.1.13.1.17
+      indexes:
+      - labelname: jnxOperatingContentsIndex
+        type: gauge
+      - labelname: jnxOperatingL1Index
+        type: gauge
+      - labelname: jnxOperatingL2Index
+        type: gauge
+      - labelname: jnxOperatingL3Index
+        type: gauge
+      lookups:
+      - labels:
+        - jnxOperatingContentsIndex
+        - jnxOperatingL1Index
+        - jnxOperatingL2Index
+        - jnxOperatingL3Index
+        labelname: jnxOperatingDescr
+        oid: 1.3.6.1.4.1.2636.3.1.13.1.5
+        type: DisplayString
+      enum_values:
+        1: unknown
+        2: singleChassis
+        3: scc
+        4: lcc0
+        5: lcc1
+        6: lcc2
+        7: lcc3
+        8: jcs1
+        9: jcs2
+        10: jcs3
+        11: jcs4
+        12: node0
+        13: node1
+        14: sfc0
+        15: sfc1
+        16: sfc2
+        17: sfc3
+        18: sfc4
+        19: lcc4
+        20: lcc5
+        21: lcc6
+        22: lcc7
+        23: lcc8
+        24: lcc9
+        25: lcc10
+        26: lcc11
+        27: lcc12
+        28: lcc13
+        29: lcc14
+        30: lcc15
+        31: member0
+        32: member1
+        33: member2
+        34: member3
+        35: member4
+        36: member5
+        37: member6
+        38: member7
+        39: nodeDevice
+        40: interconnectDevice
+        41: controlPlaneDevice
+        42: directorDevice
+        43: gnf1
+        44: gnf2
+        45: gnf3
+        46: gnf4
+        47: gnf5
+        48: gnf6
+        49: gnf7
+        50: gnf8
+        51: gnf9
+        52: gnf10
+    - name: jnxOperatingChassisDescr
+      oid: 1.3.6.1.4.1.2636.3.1.13.1.18
+      type: DisplayString
+      help: A textual description of the chassis on which the contents of this row
+        exists. - 1.3.6.1.4.1.2636.3.1.13.1.18
+      indexes:
+      - labelname: jnxOperatingContentsIndex
+        type: gauge
+      - labelname: jnxOperatingL1Index
+        type: gauge
+      - labelname: jnxOperatingL2Index
+        type: gauge
+      - labelname: jnxOperatingL3Index
+        type: gauge
+      lookups:
+      - labels:
+        - jnxOperatingContentsIndex
+        - jnxOperatingL1Index
+        - jnxOperatingL2Index
+        - jnxOperatingL3Index
+        labelname: jnxOperatingDescr
+        oid: 1.3.6.1.4.1.2636.3.1.13.1.5
+        type: DisplayString
+    - name: jnxOperatingRestartTime
+      oid: 1.3.6.1.4.1.2636.3.1.13.1.19
+      type: DateAndTime
+      help: The time at which this entity last restarted. - 1.3.6.1.4.1.2636.3.1.13.1.19
+      indexes:
+      - labelname: jnxOperatingContentsIndex
+        type: gauge
+      - labelname: jnxOperatingL1Index
+        type: gauge
+      - labelname: jnxOperatingL2Index
+        type: gauge
+      - labelname: jnxOperatingL3Index
+        type: gauge
+      lookups:
+      - labels:
+        - jnxOperatingContentsIndex
+        - jnxOperatingL1Index
+        - jnxOperatingL2Index
+        - jnxOperatingL3Index
+        labelname: jnxOperatingDescr
+        oid: 1.3.6.1.4.1.2636.3.1.13.1.5
+        type: DisplayString
+    - name: jnxOperating1MinLoadAvg
+      oid: 1.3.6.1.4.1.2636.3.1.13.1.20
+      type: gauge
+      help: The CPU Load Average over the last 1 minutes Here it will be shown as
+        percentage value Zero if unavailable or inapplicable. - 1.3.6.1.4.1.2636.3.1.13.1.20
+      indexes:
+      - labelname: jnxOperatingContentsIndex
+        type: gauge
+      - labelname: jnxOperatingL1Index
+        type: gauge
+      - labelname: jnxOperatingL2Index
+        type: gauge
+      - labelname: jnxOperatingL3Index
+        type: gauge
+      lookups:
+      - labels:
+        - jnxOperatingContentsIndex
+        - jnxOperatingL1Index
+        - jnxOperatingL2Index
+        - jnxOperatingL3Index
+        labelname: jnxOperatingDescr
+        oid: 1.3.6.1.4.1.2636.3.1.13.1.5
+        type: DisplayString
+    - name: jnxOperating5MinLoadAvg
+      oid: 1.3.6.1.4.1.2636.3.1.13.1.21
+      type: gauge
+      help: The CPU Load Average over the last 5 minutes Here it will be shown as
+        percentage value Zero if unavailable or inapplicable. - 1.3.6.1.4.1.2636.3.1.13.1.21
+      indexes:
+      - labelname: jnxOperatingContentsIndex
+        type: gauge
+      - labelname: jnxOperatingL1Index
+        type: gauge
+      - labelname: jnxOperatingL2Index
+        type: gauge
+      - labelname: jnxOperatingL3Index
+        type: gauge
+      lookups:
+      - labels:
+        - jnxOperatingContentsIndex
+        - jnxOperatingL1Index
+        - jnxOperatingL2Index
+        - jnxOperatingL3Index
+        labelname: jnxOperatingDescr
+        oid: 1.3.6.1.4.1.2636.3.1.13.1.5
+        type: DisplayString
+    - name: jnxOperating15MinLoadAvg
+      oid: 1.3.6.1.4.1.2636.3.1.13.1.22
+      type: gauge
+      help: The CPU Load Average over the last 15 minutes Here it will be shown as
+        percentage value Zero if unavailable or inapplicable. - 1.3.6.1.4.1.2636.3.1.13.1.22
+      indexes:
+      - labelname: jnxOperatingContentsIndex
+        type: gauge
+      - labelname: jnxOperatingL1Index
+        type: gauge
+      - labelname: jnxOperatingL2Index
+        type: gauge
+      - labelname: jnxOperatingL3Index
+        type: gauge
+      lookups:
+      - labels:
+        - jnxOperatingContentsIndex
+        - jnxOperatingL1Index
+        - jnxOperatingL2Index
+        - jnxOperatingL3Index
+        labelname: jnxOperatingDescr
+        oid: 1.3.6.1.4.1.2636.3.1.13.1.5
+        type: DisplayString
+    - name: jnxOperating1MinAvgCPU
+      oid: 1.3.6.1.4.1.2636.3.1.13.1.23
+      type: gauge
+      help: The CPU utilization in percentage of this subject averaged over last 1
+        minutes - 1.3.6.1.4.1.2636.3.1.13.1.23
+      indexes:
+      - labelname: jnxOperatingContentsIndex
+        type: gauge
+      - labelname: jnxOperatingL1Index
+        type: gauge
+      - labelname: jnxOperatingL2Index
+        type: gauge
+      - labelname: jnxOperatingL3Index
+        type: gauge
+      lookups:
+      - labels:
+        - jnxOperatingContentsIndex
+        - jnxOperatingL1Index
+        - jnxOperatingL2Index
+        - jnxOperatingL3Index
+        labelname: jnxOperatingDescr
+        oid: 1.3.6.1.4.1.2636.3.1.13.1.5
+        type: DisplayString
+    - name: jnxOperating5MinAvgCPU
+      oid: 1.3.6.1.4.1.2636.3.1.13.1.24
+      type: gauge
+      help: The CPU utilization in percentage of this subject averaged over last 5
+        minutes - 1.3.6.1.4.1.2636.3.1.13.1.24
+      indexes:
+      - labelname: jnxOperatingContentsIndex
+        type: gauge
+      - labelname: jnxOperatingL1Index
+        type: gauge
+      - labelname: jnxOperatingL2Index
+        type: gauge
+      - labelname: jnxOperatingL3Index
+        type: gauge
+      lookups:
+      - labels:
+        - jnxOperatingContentsIndex
+        - jnxOperatingL1Index
+        - jnxOperatingL2Index
+        - jnxOperatingL3Index
+        labelname: jnxOperatingDescr
+        oid: 1.3.6.1.4.1.2636.3.1.13.1.5
+        type: DisplayString
+    - name: jnxOperating15MinAvgCPU
+      oid: 1.3.6.1.4.1.2636.3.1.13.1.25
+      type: gauge
+      help: The CPU utilization in percentage of this subject averaged over last 15
+        minutes - 1.3.6.1.4.1.2636.3.1.13.1.25
+      indexes:
+      - labelname: jnxOperatingContentsIndex
+        type: gauge
+      - labelname: jnxOperatingL1Index
+        type: gauge
+      - labelname: jnxOperatingL2Index
+        type: gauge
+      - labelname: jnxOperatingL3Index
+        type: gauge
+      lookups:
+      - labels:
+        - jnxOperatingContentsIndex
+        - jnxOperatingL1Index
+        - jnxOperatingL2Index
+        - jnxOperatingL3Index
+        labelname: jnxOperatingDescr
+        oid: 1.3.6.1.4.1.2636.3.1.13.1.5
+        type: DisplayString
+    - name: jnxOperatingFRUPower
+      oid: 1.3.6.1.4.1.2636.3.1.13.1.26
+      type: gauge
+      help: The present power of each FRU - 1.3.6.1.4.1.2636.3.1.13.1.26
+      indexes:
+      - labelname: jnxOperatingContentsIndex
+        type: gauge
+      - labelname: jnxOperatingL1Index
+        type: gauge
+      - labelname: jnxOperatingL2Index
+        type: gauge
+      - labelname: jnxOperatingL3Index
+        type: gauge
+      lookups:
+      - labels:
+        - jnxOperatingContentsIndex
+        - jnxOperatingL1Index
+        - jnxOperatingL2Index
+        - jnxOperatingL3Index
+        labelname: jnxOperatingDescr
+        oid: 1.3.6.1.4.1.2636.3.1.13.1.5
+        type: DisplayString
+    - name: jnxOperatingBufferCP
+      oid: 1.3.6.1.4.1.2636.3.1.13.1.27
+      type: gauge
+      help: The buffer pool utilization in percentage of this subject in control plane
+        - 1.3.6.1.4.1.2636.3.1.13.1.27
+      indexes:
+      - labelname: jnxOperatingContentsIndex
+        type: gauge
+      - labelname: jnxOperatingL1Index
+        type: gauge
+      - labelname: jnxOperatingL2Index
+        type: gauge
+      - labelname: jnxOperatingL3Index
+        type: gauge
+      lookups:
+      - labels:
+        - jnxOperatingContentsIndex
+        - jnxOperatingL1Index
+        - jnxOperatingL2Index
+        - jnxOperatingL3Index
+        labelname: jnxOperatingDescr
+        oid: 1.3.6.1.4.1.2636.3.1.13.1.5
+        type: DisplayString
+    - name: jnxOperatingMemoryCP
+      oid: 1.3.6.1.4.1.2636.3.1.13.1.28
+      type: gauge
+      help: The Allocated memory size for control plane in Megabytes - 1.3.6.1.4.1.2636.3.1.13.1.28
+      indexes:
+      - labelname: jnxOperatingContentsIndex
+        type: gauge
+      - labelname: jnxOperatingL1Index
+        type: gauge
+      - labelname: jnxOperatingL2Index
+        type: gauge
+      - labelname: jnxOperatingL3Index
+        type: gauge
+      lookups:
+      - labels:
+        - jnxOperatingContentsIndex
+        - jnxOperatingL1Index
+        - jnxOperatingL2Index
+        - jnxOperatingL3Index
+        labelname: jnxOperatingDescr
+        oid: 1.3.6.1.4.1.2636.3.1.13.1.5
+        type: DisplayString
+    - name: jnxOperatingBufferExt
+      oid: 1.3.6.1.4.1.2636.3.1.13.1.29
+      type: gauge
+      help: The buffer pool utilization in percentage of this subject - 1.3.6.1.4.1.2636.3.1.13.1.29
+      indexes:
+      - labelname: jnxOperatingContentsIndex
+        type: gauge
+      - labelname: jnxOperatingL1Index
+        type: gauge
+      - labelname: jnxOperatingL2Index
+        type: gauge
+      - labelname: jnxOperatingL3Index
+        type: gauge
+      lookups:
+      - labels:
+        - jnxOperatingContentsIndex
+        - jnxOperatingL1Index
+        - jnxOperatingL2Index
+        - jnxOperatingL3Index
+        labelname: jnxOperatingDescr
+        oid: 1.3.6.1.4.1.2636.3.1.13.1.5
+        type: DisplayString
+    - name: jnxOperatingTemperature
+      oid: 1.3.6.1.4.1.2636.3.1.13.1.30
+      type: gauge
+      help: The temperature in Celsius (degrees C) of this subject - 1.3.6.1.4.1.2636.3.1.13.1.30
+      indexes:
+      - labelname: jnxOperatingContentsIndex
+        type: gauge
+      - labelname: jnxOperatingL1Index
+        type: gauge
+      - labelname: jnxOperatingL2Index
+        type: gauge
+      - labelname: jnxOperatingL3Index
+        type: gauge
+      lookups:
+      - labels:
+        - jnxOperatingContentsIndex
+        - jnxOperatingL1Index
+        - jnxOperatingL2Index
+        - jnxOperatingL3Index
+        labelname: jnxOperatingDescr
+        oid: 1.3.6.1.4.1.2636.3.1.13.1.5
+        type: DisplayString
+    - name: jnxFruState
+      oid: 1.3.6.1.4.1.2636.3.1.15.1.8
+      type: EnumAsStateSet
+      help: The current state for this subject. - 1.3.6.1.4.1.2636.3.1.15.1.8
+      indexes:
+      - labelname: jnxFruContentsIndex
+        type: gauge
+      - labelname: jnxFruL1Index
+        type: gauge
+      - labelname: jnxFruL2Index
+        type: gauge
+      - labelname: jnxFruL3Index
+        type: gauge
+      lookups:
+      - labels:
+        - jnxFruContentsIndex
+        - jnxFruL1Index
+        - jnxFruL2Index
+        - jnxFruL3Index
+        labelname: jnxFruName
+        oid: 1.3.6.1.4.1.2636.3.1.15.1.5
+        type: DisplayString
+      - labels: []
+        labelname: jnxFruContentsIndex
+      - labels: []
+        labelname: jnxFruL1Index
+      - labels: []
+        labelname: jnxFruL2Index
+      - labels: []
+        labelname: jnxFruL3Index
+      enum_values:
+        1: unknown
+        2: empty
+        3: present
+        4: ready
+        5: announceOnline
+        6: online
+        7: anounceOffline
+        8: offline
+        9: diagnostic
+        10: standby
+    - name: jnxYellowAlarmState
+      oid: 1.3.6.1.4.1.2636.3.4.2.2.1
+      type: EnumAsStateSet
+      help: The yellow alarm state on the craft interface panel - 1.3.6.1.4.1.2636.3.4.2.2.1
+      enum_values:
+        1: other
+        2: "off"
+        3: "on"
+    - name: jnxYellowAlarmCount
+      oid: 1.3.6.1.4.1.2636.3.4.2.2.2
+      type: gauge
+      help: The number of currently active and non-silent yellow alarms - 1.3.6.1.4.1.2636.3.4.2.2.2
+    - name: jnxYellowAlarmLastChange
+      oid: 1.3.6.1.4.1.2636.3.4.2.2.3
+      type: gauge
+      help: The value of sysUpTime when the yellow alarm last changed - either from
+        off to on or vice versa - 1.3.6.1.4.1.2636.3.4.2.2.3
+    - name: jnxRedAlarmState
+      oid: 1.3.6.1.4.1.2636.3.4.2.3.1
+      type: EnumAsStateSet
+      help: The red alarm indication on the craft interface panel - 1.3.6.1.4.1.2636.3.4.2.3.1
+      enum_values:
+        1: other
+        2: "off"
+        3: "on"
+    - name: jnxRedAlarmCount
+      oid: 1.3.6.1.4.1.2636.3.4.2.3.2
+      type: gauge
+      help: The number of currently active and non-silent red alarms - 1.3.6.1.4.1.2636.3.4.2.3.2
+    - name: jnxRedAlarmLastChange
+      oid: 1.3.6.1.4.1.2636.3.4.2.3.3
+      type: gauge
+      help: The value of sysUpTime when the red alarm last changed - either from off
+        to on or vice versa - 1.3.6.1.4.1.2636.3.4.2.3.3
+    - name: jnxSubscriberPortTerminatedCounter
+      oid: 1.3.6.1.4.1.2636.3.64.1.1.1.5.1.3
+      type: counter
+      help: Number of active Tunneled subscribers present on the port - 1.3.6.1.4.1.2636.3.64.1.1.1.5.1.3
+      indexes:
+      - labelname: jnxSubscriberPort
+        type: DisplayString
+  juniper_optics:
+    walk:
+    - 1.3.6.1.2.1.31.1.1.1.1
+    - 1.3.6.1.2.1.31.1.1.1.18
+    - 1.3.6.1.4.1.2636.3.60.1.1.1.1.1
+    - 1.3.6.1.4.1.2636.3.60.1.1.1.1.4
+    - 1.3.6.1.4.1.2636.3.60.1.1.1.1.5
+    - 1.3.6.1.4.1.2636.3.60.1.1.1.1.6
+    - 1.3.6.1.4.1.2636.3.60.1.1.1.1.7
+    metrics:
+    - name: jnxDomCurrentAlarms
+      oid: 1.3.6.1.4.1.2636.3.60.1.1.1.1.1
+      type: Bits
+      help: This object identifies all the active DOM alarms on a SFF physical interface
+        on this router. - 1.3.6.1.4.1.2636.3.60.1.1.1.1.1
+      indexes:
+      - labelname: ifIndex
+        type: gauge
+      lookups:
+      - labels:
+        - ifIndex
+        labelname: ifName
+        oid: 1.3.6.1.2.1.31.1.1.1.1
+        type: DisplayString
+      - labels:
+        - ifIndex
+        labelname: ifAlias
+        oid: 1.3.6.1.2.1.31.1.1.1.18
+        type: DisplayString
+      - labels: []
+        labelname: ifIndex
+      enum_values:
+        0: domRxLossSignalAlarm
+        1: domRxCDRLossLockAlarm
+        2: domRxNotReadyAlarm
+        3: domRxLaserPowerHighAlarm
+        4: domRxLaserPowerLowAlarm
+        5: domTxLaserBiasCurrentHighAlarm
+        6: domTxLaserBiasCurrentLowAlarm
+        7: domTxLaserOutputPowerHighAlarm
+        8: domTxLaserOutputPowerLowAlarm
+        9: domTxDataNotReadyAlarm
+        10: domTxNotReadyAlarm
+        11: domTxLaserFaultAlarm
+        12: domTxCDRLossLockAlarm
+        13: domModuleTemperatureHighAlarm
+        14: domModuleTemperatureLowAlarm
+        15: domModuleNotReadyAlarm
+        16: domModulePowerDownAlarm
+        17: domLinkDownAlarm
+        18: domModuleRemovedAlarm
+        19: domModuleVoltageHighAlarm
+        20: domModuleVoltageLowAlarm
+        21: domTxDither
+        22: domTecFault
+        23: domWavelengthUnlocked
+        24: domTxTuned
+    - name: jnxDomCurrentWarnings
+      oid: 1.3.6.1.4.1.2636.3.60.1.1.1.1.4
+      type: Bits
+      help: This object identifies all the active DOM warnings on a SFF physical interface
+        on this router. - 1.3.6.1.4.1.2636.3.60.1.1.1.1.4
+      indexes:
+      - labelname: ifIndex
+        type: gauge
+      lookups:
+      - labels:
+        - ifIndex
+        labelname: ifName
+        oid: 1.3.6.1.2.1.31.1.1.1.1
+        type: DisplayString
+      - labels:
+        - ifIndex
+        labelname: ifAlias
+        oid: 1.3.6.1.2.1.31.1.1.1.18
+        type: DisplayString
+      - labels: []
+        labelname: ifIndex
+      enum_values:
+        0: domRxLaserPowerHighWarning
+        1: domRxLaserPowerLowWarning
+        2: domTxLaserBiasCurrentHighWarning
+        3: domTxLaserBiasCurrentLowWarning
+        4: domTxLaserOutputPowerHighWarning
+        5: domTxLaserOutputPowerLowWarning
+        6: domModuleTemperatureHighWarning
+        7: domModuleTemperatureLowWarning
+        8: domModuleVoltageHighWarning
+        9: domModuleVoltageLowWarning
+    - name: jnxDomCurrentRxLaserPower
+      oid: 1.3.6.1.4.1.2636.3.60.1.1.1.1.5
+      type: gauge
+      help: Receiver laser power. - 1.3.6.1.4.1.2636.3.60.1.1.1.1.5
+      indexes:
+      - labelname: ifIndex
+        type: gauge
+      lookups:
+      - labels:
+        - ifIndex
+        labelname: ifName
+        oid: 1.3.6.1.2.1.31.1.1.1.1
+        type: DisplayString
+      - labels:
+        - ifIndex
+        labelname: ifAlias
+        oid: 1.3.6.1.2.1.31.1.1.1.18
+        type: DisplayString
+      - labels: []
+        labelname: ifIndex
+      scale: 0.01
+    - name: jnxDomCurrentTxLaserBiasCurrent
+      oid: 1.3.6.1.4.1.2636.3.60.1.1.1.1.6
+      type: gauge
+      help: Transmitter laser bias current. - 1.3.6.1.4.1.2636.3.60.1.1.1.1.6
+      indexes:
+      - labelname: ifIndex
+        type: gauge
+      lookups:
+      - labels:
+        - ifIndex
+        labelname: ifName
+        oid: 1.3.6.1.2.1.31.1.1.1.1
+        type: DisplayString
+      - labels:
+        - ifIndex
+        labelname: ifAlias
+        oid: 1.3.6.1.2.1.31.1.1.1.18
+        type: DisplayString
+      - labels: []
+        labelname: ifIndex
+      scale: 0.001
+    - name: jnxDomCurrentTxLaserOutputPower
+      oid: 1.3.6.1.4.1.2636.3.60.1.1.1.1.7
+      type: gauge
+      help: Transmitter laser output power. - 1.3.6.1.4.1.2636.3.60.1.1.1.1.7
+      indexes:
+      - labelname: ifIndex
+        type: gauge
+      lookups:
+      - labels:
+        - ifIndex
+        labelname: ifName
+        oid: 1.3.6.1.2.1.31.1.1.1.1
+        type: DisplayString
+      - labels:
+        - ifIndex
+        labelname: ifAlias
+        oid: 1.3.6.1.2.1.31.1.1.1.18
+        type: DisplayString
+      - labels: []
+        labelname: ifIndex
+      scale: 0.01

--- a/nix/nixos-modules/services/snmp.yml
+++ b/nix/nixos-modules/services/snmp.yml
@@ -21,900 +21,883 @@ auths:
 modules:
   juniper:
     walk:
-    - 1.3.6.1.2.1.2.2.1.10
-    - 1.3.6.1.2.1.2.2.1.16
-    - 1.3.6.1.2.1.2.2.1.5
-    - 1.3.6.1.4.1.2636.3.1.13
-    - 1.3.6.1.4.1.2636.3.1.15.1.5
-    - 1.3.6.1.4.1.2636.3.1.15.1.8
-    - 1.3.6.1.4.1.2636.3.4.2.2
-    - 1.3.6.1.4.1.2636.3.4.2.3
-    - 1.3.6.1.4.1.2636.3.64.1.1.1.5.1.3
+      - 1.3.6.1.2.1.2.2.1.10
+      - 1.3.6.1.2.1.2.2.1.16
+      - 1.3.6.1.2.1.2.2.1.5
+      - 1.3.6.1.4.1.2636.3.1.13
+      - 1.3.6.1.4.1.2636.3.1.15.1.5
+      - 1.3.6.1.4.1.2636.3.1.15.1.8
+      - 1.3.6.1.4.1.2636.3.4.2.2
+      - 1.3.6.1.4.1.2636.3.4.2.3
+      - 1.3.6.1.4.1.2636.3.64.1.1.1.5.1.3
     metrics:
-    - name: ifInOctets
-      oid: 1.3.6.1.2.1.2.2.1.10
-      type: counter
-      help: The total number of octets received on the interface, including framing
-        characters - 1.3.6.1.2.1.2.2.1.10
-      indexes:
-      - labelname: ifIndex
+      - name: ifInOctets
+        oid: 1.3.6.1.2.1.2.2.1.10
+        type: counter
+        help: The total number of octets received on the interface, including framing characters - 1.3.6.1.2.1.2.2.1.10
+        indexes:
+          - labelname: ifIndex
+            type: gauge
+      - name: ifOutOctets
+        oid: 1.3.6.1.2.1.2.2.1.16
+        type: counter
+        help: The total number of octets transmitted out of the interface, including framing characters - 1.3.6.1.2.1.2.2.1.16
+        indexes:
+          - labelname: ifIndex
+            type: gauge
+      - name: ifSpeed
+        oid: 1.3.6.1.2.1.2.2.1.5
         type: gauge
-    - name: ifOutOctets
-      oid: 1.3.6.1.2.1.2.2.1.16
-      type: counter
-      help: The total number of octets transmitted out of the interface, including
-        framing characters - 1.3.6.1.2.1.2.2.1.16
-      indexes:
-      - labelname: ifIndex
+        help: An estimate of the interface's current bandwidth in bits per second - 1.3.6.1.2.1.2.2.1.5
+        indexes:
+          - labelname: ifIndex
+            type: gauge
+      - name: jnxOperatingState
+        oid: 1.3.6.1.4.1.2636.3.1.13.1.6
         type: gauge
-    - name: ifSpeed
-      oid: 1.3.6.1.2.1.2.2.1.5
-      type: gauge
-      help: An estimate of the interface's current bandwidth in bits per second -
-        1.3.6.1.2.1.2.2.1.5
-      indexes:
-      - labelname: ifIndex
+        help: The operating state of this subject. - 1.3.6.1.4.1.2636.3.1.13.1.6
+        indexes:
+          - labelname: jnxOperatingContentsIndex
+            type: gauge
+          - labelname: jnxOperatingL1Index
+            type: gauge
+          - labelname: jnxOperatingL2Index
+            type: gauge
+          - labelname: jnxOperatingL3Index
+            type: gauge
+        lookups:
+          - labels:
+              - jnxOperatingContentsIndex
+              - jnxOperatingL1Index
+              - jnxOperatingL2Index
+              - jnxOperatingL3Index
+            labelname: jnxOperatingDescr
+            oid: 1.3.6.1.4.1.2636.3.1.13.1.5
+            type: DisplayString
+        enum_values:
+          1: unknown
+          2: running
+          3: ready
+          4: reset
+          5: runningAtFullSpeed
+          6: down
+          7: standby
+      - name: jnxOperatingTemp
+        oid: 1.3.6.1.4.1.2636.3.1.13.1.7
         type: gauge
-    - name: jnxOperatingState
-      oid: 1.3.6.1.4.1.2636.3.1.13.1.6
-      type: gauge
-      help: The operating state of this subject. - 1.3.6.1.4.1.2636.3.1.13.1.6
-      indexes:
-      - labelname: jnxOperatingContentsIndex
+        help: The temperature in Celsius (degrees C) of this subject - 1.3.6.1.4.1.2636.3.1.13.1.7
+        indexes:
+          - labelname: jnxOperatingContentsIndex
+            type: gauge
+          - labelname: jnxOperatingL1Index
+            type: gauge
+          - labelname: jnxOperatingL2Index
+            type: gauge
+          - labelname: jnxOperatingL3Index
+            type: gauge
+        lookups:
+          - labels:
+              - jnxOperatingContentsIndex
+              - jnxOperatingL1Index
+              - jnxOperatingL2Index
+              - jnxOperatingL3Index
+            labelname: jnxOperatingDescr
+            oid: 1.3.6.1.4.1.2636.3.1.13.1.5
+            type: DisplayString
+      - name: jnxOperatingCPU
+        oid: 1.3.6.1.4.1.2636.3.1.13.1.8
         type: gauge
-      - labelname: jnxOperatingL1Index
+        help: The CPU utilization in percentage of this subject - 1.3.6.1.4.1.2636.3.1.13.1.8
+        indexes:
+          - labelname: jnxOperatingContentsIndex
+            type: gauge
+          - labelname: jnxOperatingL1Index
+            type: gauge
+          - labelname: jnxOperatingL2Index
+            type: gauge
+          - labelname: jnxOperatingL3Index
+            type: gauge
+        lookups:
+          - labels:
+              - jnxOperatingContentsIndex
+              - jnxOperatingL1Index
+              - jnxOperatingL2Index
+              - jnxOperatingL3Index
+            labelname: jnxOperatingDescr
+            oid: 1.3.6.1.4.1.2636.3.1.13.1.5
+            type: DisplayString
+      - name: jnxOperatingISR
+        oid: 1.3.6.1.4.1.2636.3.1.13.1.9
         type: gauge
-      - labelname: jnxOperatingL2Index
+        help: The CPU utilization in percentage of this subject spending in interrupt service routine (ISR) - 1.3.6.1.4.1.2636.3.1.13.1.9
+        indexes:
+          - labelname: jnxOperatingContentsIndex
+            type: gauge
+          - labelname: jnxOperatingL1Index
+            type: gauge
+          - labelname: jnxOperatingL2Index
+            type: gauge
+          - labelname: jnxOperatingL3Index
+            type: gauge
+        lookups:
+          - labels:
+              - jnxOperatingContentsIndex
+              - jnxOperatingL1Index
+              - jnxOperatingL2Index
+              - jnxOperatingL3Index
+            labelname: jnxOperatingDescr
+            oid: 1.3.6.1.4.1.2636.3.1.13.1.5
+            type: DisplayString
+      - name: jnxOperatingDRAMSize
+        oid: 1.3.6.1.4.1.2636.3.1.13.1.10
         type: gauge
-      - labelname: jnxOperatingL3Index
+        help: The DRAM size in bytes of this subject - 1.3.6.1.4.1.2636.3.1.13.1.10
+        indexes:
+          - labelname: jnxOperatingContentsIndex
+            type: gauge
+          - labelname: jnxOperatingL1Index
+            type: gauge
+          - labelname: jnxOperatingL2Index
+            type: gauge
+          - labelname: jnxOperatingL3Index
+            type: gauge
+        lookups:
+          - labels:
+              - jnxOperatingContentsIndex
+              - jnxOperatingL1Index
+              - jnxOperatingL2Index
+              - jnxOperatingL3Index
+            labelname: jnxOperatingDescr
+            oid: 1.3.6.1.4.1.2636.3.1.13.1.5
+            type: DisplayString
+      - name: jnxOperatingBuffer
+        oid: 1.3.6.1.4.1.2636.3.1.13.1.11
         type: gauge
-      lookups:
-      - labels:
-        - jnxOperatingContentsIndex
-        - jnxOperatingL1Index
-        - jnxOperatingL2Index
-        - jnxOperatingL3Index
-        labelname: jnxOperatingDescr
-        oid: 1.3.6.1.4.1.2636.3.1.13.1.5
+        help: The buffer pool utilization in percentage of this subject - 1.3.6.1.4.1.2636.3.1.13.1.11
+        indexes:
+          - labelname: jnxOperatingContentsIndex
+            type: gauge
+          - labelname: jnxOperatingL1Index
+            type: gauge
+          - labelname: jnxOperatingL2Index
+            type: gauge
+          - labelname: jnxOperatingL3Index
+            type: gauge
+        lookups:
+          - labels:
+              - jnxOperatingContentsIndex
+              - jnxOperatingL1Index
+              - jnxOperatingL2Index
+              - jnxOperatingL3Index
+            labelname: jnxOperatingDescr
+            oid: 1.3.6.1.4.1.2636.3.1.13.1.5
+            type: DisplayString
+      - name: jnxOperatingHeap
+        oid: 1.3.6.1.4.1.2636.3.1.13.1.12
+        type: gauge
+        help: The heap utilization in percentage of this subject - 1.3.6.1.4.1.2636.3.1.13.1.12
+        indexes:
+          - labelname: jnxOperatingContentsIndex
+            type: gauge
+          - labelname: jnxOperatingL1Index
+            type: gauge
+          - labelname: jnxOperatingL2Index
+            type: gauge
+          - labelname: jnxOperatingL3Index
+            type: gauge
+        lookups:
+          - labels:
+              - jnxOperatingContentsIndex
+              - jnxOperatingL1Index
+              - jnxOperatingL2Index
+              - jnxOperatingL3Index
+            labelname: jnxOperatingDescr
+            oid: 1.3.6.1.4.1.2636.3.1.13.1.5
+            type: DisplayString
+      - name: jnxOperatingUpTime
+        oid: 1.3.6.1.4.1.2636.3.1.13.1.13
+        type: gauge
+        help: The time interval in 10-millisecond period that this subject has been up and running - 1.3.6.1.4.1.2636.3.1.13.1.13
+        indexes:
+          - labelname: jnxOperatingContentsIndex
+            type: gauge
+          - labelname: jnxOperatingL1Index
+            type: gauge
+          - labelname: jnxOperatingL2Index
+            type: gauge
+          - labelname: jnxOperatingL3Index
+            type: gauge
+        lookups:
+          - labels:
+              - jnxOperatingContentsIndex
+              - jnxOperatingL1Index
+              - jnxOperatingL2Index
+              - jnxOperatingL3Index
+            labelname: jnxOperatingDescr
+            oid: 1.3.6.1.4.1.2636.3.1.13.1.5
+            type: DisplayString
+      - name: jnxOperatingLastRestart
+        oid: 1.3.6.1.4.1.2636.3.1.13.1.14
+        type: gauge
+        help: The value of sysUpTime when this subject last restarted - 1.3.6.1.4.1.2636.3.1.13.1.14
+        indexes:
+          - labelname: jnxOperatingContentsIndex
+            type: gauge
+          - labelname: jnxOperatingL1Index
+            type: gauge
+          - labelname: jnxOperatingL2Index
+            type: gauge
+          - labelname: jnxOperatingL3Index
+            type: gauge
+        lookups:
+          - labels:
+              - jnxOperatingContentsIndex
+              - jnxOperatingL1Index
+              - jnxOperatingL2Index
+              - jnxOperatingL3Index
+            labelname: jnxOperatingDescr
+            oid: 1.3.6.1.4.1.2636.3.1.13.1.5
+            type: DisplayString
+      - name: jnxOperatingMemory
+        oid: 1.3.6.1.4.1.2636.3.1.13.1.15
+        type: gauge
+        help: The installed memory size in Megabytes of this subject - 1.3.6.1.4.1.2636.3.1.13.1.15
+        indexes:
+          - labelname: jnxOperatingContentsIndex
+            type: gauge
+          - labelname: jnxOperatingL1Index
+            type: gauge
+          - labelname: jnxOperatingL2Index
+            type: gauge
+          - labelname: jnxOperatingL3Index
+            type: gauge
+        lookups:
+          - labels:
+              - jnxOperatingContentsIndex
+              - jnxOperatingL1Index
+              - jnxOperatingL2Index
+              - jnxOperatingL3Index
+            labelname: jnxOperatingDescr
+            oid: 1.3.6.1.4.1.2636.3.1.13.1.5
+            type: DisplayString
+      - name: jnxOperatingStateOrdered
+        oid: 1.3.6.1.4.1.2636.3.1.13.1.16
+        type: gauge
+        help: The operating state of this subject - 1.3.6.1.4.1.2636.3.1.13.1.16
+        indexes:
+          - labelname: jnxOperatingContentsIndex
+            type: gauge
+          - labelname: jnxOperatingL1Index
+            type: gauge
+          - labelname: jnxOperatingL2Index
+            type: gauge
+          - labelname: jnxOperatingL3Index
+            type: gauge
+        lookups:
+          - labels:
+              - jnxOperatingContentsIndex
+              - jnxOperatingL1Index
+              - jnxOperatingL2Index
+              - jnxOperatingL3Index
+            labelname: jnxOperatingDescr
+            oid: 1.3.6.1.4.1.2636.3.1.13.1.5
+            type: DisplayString
+        enum_values:
+          1: running
+          2: standby
+          3: ready
+          4: runningAtFullSpeed
+          5: reset
+          6: down
+          7: unknown
+      - name: jnxOperatingChassisId
+        oid: 1.3.6.1.4.1.2636.3.1.13.1.17
+        type: gauge
+        help: Identifies the chassis on which the contents of this row exists. - 1.3.6.1.4.1.2636.3.1.13.1.17
+        indexes:
+          - labelname: jnxOperatingContentsIndex
+            type: gauge
+          - labelname: jnxOperatingL1Index
+            type: gauge
+          - labelname: jnxOperatingL2Index
+            type: gauge
+          - labelname: jnxOperatingL3Index
+            type: gauge
+        lookups:
+          - labels:
+              - jnxOperatingContentsIndex
+              - jnxOperatingL1Index
+              - jnxOperatingL2Index
+              - jnxOperatingL3Index
+            labelname: jnxOperatingDescr
+            oid: 1.3.6.1.4.1.2636.3.1.13.1.5
+            type: DisplayString
+        enum_values:
+          1: unknown
+          2: singleChassis
+          3: scc
+          4: lcc0
+          5: lcc1
+          6: lcc2
+          7: lcc3
+          8: jcs1
+          9: jcs2
+          10: jcs3
+          11: jcs4
+          12: node0
+          13: node1
+          14: sfc0
+          15: sfc1
+          16: sfc2
+          17: sfc3
+          18: sfc4
+          19: lcc4
+          20: lcc5
+          21: lcc6
+          22: lcc7
+          23: lcc8
+          24: lcc9
+          25: lcc10
+          26: lcc11
+          27: lcc12
+          28: lcc13
+          29: lcc14
+          30: lcc15
+          31: member0
+          32: member1
+          33: member2
+          34: member3
+          35: member4
+          36: member5
+          37: member6
+          38: member7
+          39: nodeDevice
+          40: interconnectDevice
+          41: controlPlaneDevice
+          42: directorDevice
+          43: gnf1
+          44: gnf2
+          45: gnf3
+          46: gnf4
+          47: gnf5
+          48: gnf6
+          49: gnf7
+          50: gnf8
+          51: gnf9
+          52: gnf10
+      - name: jnxOperatingChassisDescr
+        oid: 1.3.6.1.4.1.2636.3.1.13.1.18
         type: DisplayString
-      enum_values:
-        1: unknown
-        2: running
-        3: ready
-        4: reset
-        5: runningAtFullSpeed
-        6: down
-        7: standby
-    - name: jnxOperatingTemp
-      oid: 1.3.6.1.4.1.2636.3.1.13.1.7
-      type: gauge
-      help: The temperature in Celsius (degrees C) of this subject - 1.3.6.1.4.1.2636.3.1.13.1.7
-      indexes:
-      - labelname: jnxOperatingContentsIndex
-        type: gauge
-      - labelname: jnxOperatingL1Index
-        type: gauge
-      - labelname: jnxOperatingL2Index
-        type: gauge
-      - labelname: jnxOperatingL3Index
-        type: gauge
-      lookups:
-      - labels:
-        - jnxOperatingContentsIndex
-        - jnxOperatingL1Index
-        - jnxOperatingL2Index
-        - jnxOperatingL3Index
-        labelname: jnxOperatingDescr
-        oid: 1.3.6.1.4.1.2636.3.1.13.1.5
-        type: DisplayString
-    - name: jnxOperatingCPU
-      oid: 1.3.6.1.4.1.2636.3.1.13.1.8
-      type: gauge
-      help: The CPU utilization in percentage of this subject - 1.3.6.1.4.1.2636.3.1.13.1.8
-      indexes:
-      - labelname: jnxOperatingContentsIndex
-        type: gauge
-      - labelname: jnxOperatingL1Index
-        type: gauge
-      - labelname: jnxOperatingL2Index
-        type: gauge
-      - labelname: jnxOperatingL3Index
-        type: gauge
-      lookups:
-      - labels:
-        - jnxOperatingContentsIndex
-        - jnxOperatingL1Index
-        - jnxOperatingL2Index
-        - jnxOperatingL3Index
-        labelname: jnxOperatingDescr
-        oid: 1.3.6.1.4.1.2636.3.1.13.1.5
-        type: DisplayString
-    - name: jnxOperatingISR
-      oid: 1.3.6.1.4.1.2636.3.1.13.1.9
-      type: gauge
-      help: The CPU utilization in percentage of this subject spending in interrupt
-        service routine (ISR) - 1.3.6.1.4.1.2636.3.1.13.1.9
-      indexes:
-      - labelname: jnxOperatingContentsIndex
-        type: gauge
-      - labelname: jnxOperatingL1Index
-        type: gauge
-      - labelname: jnxOperatingL2Index
-        type: gauge
-      - labelname: jnxOperatingL3Index
-        type: gauge
-      lookups:
-      - labels:
-        - jnxOperatingContentsIndex
-        - jnxOperatingL1Index
-        - jnxOperatingL2Index
-        - jnxOperatingL3Index
-        labelname: jnxOperatingDescr
-        oid: 1.3.6.1.4.1.2636.3.1.13.1.5
-        type: DisplayString
-    - name: jnxOperatingDRAMSize
-      oid: 1.3.6.1.4.1.2636.3.1.13.1.10
-      type: gauge
-      help: The DRAM size in bytes of this subject - 1.3.6.1.4.1.2636.3.1.13.1.10
-      indexes:
-      - labelname: jnxOperatingContentsIndex
-        type: gauge
-      - labelname: jnxOperatingL1Index
-        type: gauge
-      - labelname: jnxOperatingL2Index
-        type: gauge
-      - labelname: jnxOperatingL3Index
-        type: gauge
-      lookups:
-      - labels:
-        - jnxOperatingContentsIndex
-        - jnxOperatingL1Index
-        - jnxOperatingL2Index
-        - jnxOperatingL3Index
-        labelname: jnxOperatingDescr
-        oid: 1.3.6.1.4.1.2636.3.1.13.1.5
-        type: DisplayString
-    - name: jnxOperatingBuffer
-      oid: 1.3.6.1.4.1.2636.3.1.13.1.11
-      type: gauge
-      help: The buffer pool utilization in percentage of this subject - 1.3.6.1.4.1.2636.3.1.13.1.11
-      indexes:
-      - labelname: jnxOperatingContentsIndex
-        type: gauge
-      - labelname: jnxOperatingL1Index
-        type: gauge
-      - labelname: jnxOperatingL2Index
-        type: gauge
-      - labelname: jnxOperatingL3Index
-        type: gauge
-      lookups:
-      - labels:
-        - jnxOperatingContentsIndex
-        - jnxOperatingL1Index
-        - jnxOperatingL2Index
-        - jnxOperatingL3Index
-        labelname: jnxOperatingDescr
-        oid: 1.3.6.1.4.1.2636.3.1.13.1.5
-        type: DisplayString
-    - name: jnxOperatingHeap
-      oid: 1.3.6.1.4.1.2636.3.1.13.1.12
-      type: gauge
-      help: The heap utilization in percentage of this subject - 1.3.6.1.4.1.2636.3.1.13.1.12
-      indexes:
-      - labelname: jnxOperatingContentsIndex
-        type: gauge
-      - labelname: jnxOperatingL1Index
-        type: gauge
-      - labelname: jnxOperatingL2Index
-        type: gauge
-      - labelname: jnxOperatingL3Index
-        type: gauge
-      lookups:
-      - labels:
-        - jnxOperatingContentsIndex
-        - jnxOperatingL1Index
-        - jnxOperatingL2Index
-        - jnxOperatingL3Index
-        labelname: jnxOperatingDescr
-        oid: 1.3.6.1.4.1.2636.3.1.13.1.5
-        type: DisplayString
-    - name: jnxOperatingUpTime
-      oid: 1.3.6.1.4.1.2636.3.1.13.1.13
-      type: gauge
-      help: The time interval in 10-millisecond period that this subject has been
-        up and running - 1.3.6.1.4.1.2636.3.1.13.1.13
-      indexes:
-      - labelname: jnxOperatingContentsIndex
-        type: gauge
-      - labelname: jnxOperatingL1Index
-        type: gauge
-      - labelname: jnxOperatingL2Index
-        type: gauge
-      - labelname: jnxOperatingL3Index
-        type: gauge
-      lookups:
-      - labels:
-        - jnxOperatingContentsIndex
-        - jnxOperatingL1Index
-        - jnxOperatingL2Index
-        - jnxOperatingL3Index
-        labelname: jnxOperatingDescr
-        oid: 1.3.6.1.4.1.2636.3.1.13.1.5
-        type: DisplayString
-    - name: jnxOperatingLastRestart
-      oid: 1.3.6.1.4.1.2636.3.1.13.1.14
-      type: gauge
-      help: The value of sysUpTime when this subject last restarted - 1.3.6.1.4.1.2636.3.1.13.1.14
-      indexes:
-      - labelname: jnxOperatingContentsIndex
-        type: gauge
-      - labelname: jnxOperatingL1Index
-        type: gauge
-      - labelname: jnxOperatingL2Index
-        type: gauge
-      - labelname: jnxOperatingL3Index
-        type: gauge
-      lookups:
-      - labels:
-        - jnxOperatingContentsIndex
-        - jnxOperatingL1Index
-        - jnxOperatingL2Index
-        - jnxOperatingL3Index
-        labelname: jnxOperatingDescr
-        oid: 1.3.6.1.4.1.2636.3.1.13.1.5
-        type: DisplayString
-    - name: jnxOperatingMemory
-      oid: 1.3.6.1.4.1.2636.3.1.13.1.15
-      type: gauge
-      help: The installed memory size in Megabytes of this subject - 1.3.6.1.4.1.2636.3.1.13.1.15
-      indexes:
-      - labelname: jnxOperatingContentsIndex
-        type: gauge
-      - labelname: jnxOperatingL1Index
-        type: gauge
-      - labelname: jnxOperatingL2Index
-        type: gauge
-      - labelname: jnxOperatingL3Index
-        type: gauge
-      lookups:
-      - labels:
-        - jnxOperatingContentsIndex
-        - jnxOperatingL1Index
-        - jnxOperatingL2Index
-        - jnxOperatingL3Index
-        labelname: jnxOperatingDescr
-        oid: 1.3.6.1.4.1.2636.3.1.13.1.5
-        type: DisplayString
-    - name: jnxOperatingStateOrdered
-      oid: 1.3.6.1.4.1.2636.3.1.13.1.16
-      type: gauge
-      help: The operating state of this subject - 1.3.6.1.4.1.2636.3.1.13.1.16
-      indexes:
-      - labelname: jnxOperatingContentsIndex
-        type: gauge
-      - labelname: jnxOperatingL1Index
-        type: gauge
-      - labelname: jnxOperatingL2Index
-        type: gauge
-      - labelname: jnxOperatingL3Index
-        type: gauge
-      lookups:
-      - labels:
-        - jnxOperatingContentsIndex
-        - jnxOperatingL1Index
-        - jnxOperatingL2Index
-        - jnxOperatingL3Index
-        labelname: jnxOperatingDescr
-        oid: 1.3.6.1.4.1.2636.3.1.13.1.5
-        type: DisplayString
-      enum_values:
-        1: running
-        2: standby
-        3: ready
-        4: runningAtFullSpeed
-        5: reset
-        6: down
-        7: unknown
-    - name: jnxOperatingChassisId
-      oid: 1.3.6.1.4.1.2636.3.1.13.1.17
-      type: gauge
-      help: Identifies the chassis on which the contents of this row exists. - 1.3.6.1.4.1.2636.3.1.13.1.17
-      indexes:
-      - labelname: jnxOperatingContentsIndex
-        type: gauge
-      - labelname: jnxOperatingL1Index
-        type: gauge
-      - labelname: jnxOperatingL2Index
-        type: gauge
-      - labelname: jnxOperatingL3Index
-        type: gauge
-      lookups:
-      - labels:
-        - jnxOperatingContentsIndex
-        - jnxOperatingL1Index
-        - jnxOperatingL2Index
-        - jnxOperatingL3Index
-        labelname: jnxOperatingDescr
-        oid: 1.3.6.1.4.1.2636.3.1.13.1.5
-        type: DisplayString
-      enum_values:
-        1: unknown
-        2: singleChassis
-        3: scc
-        4: lcc0
-        5: lcc1
-        6: lcc2
-        7: lcc3
-        8: jcs1
-        9: jcs2
-        10: jcs3
-        11: jcs4
-        12: node0
-        13: node1
-        14: sfc0
-        15: sfc1
-        16: sfc2
-        17: sfc3
-        18: sfc4
-        19: lcc4
-        20: lcc5
-        21: lcc6
-        22: lcc7
-        23: lcc8
-        24: lcc9
-        25: lcc10
-        26: lcc11
-        27: lcc12
-        28: lcc13
-        29: lcc14
-        30: lcc15
-        31: member0
-        32: member1
-        33: member2
-        34: member3
-        35: member4
-        36: member5
-        37: member6
-        38: member7
-        39: nodeDevice
-        40: interconnectDevice
-        41: controlPlaneDevice
-        42: directorDevice
-        43: gnf1
-        44: gnf2
-        45: gnf3
-        46: gnf4
-        47: gnf5
-        48: gnf6
-        49: gnf7
-        50: gnf8
-        51: gnf9
-        52: gnf10
-    - name: jnxOperatingChassisDescr
-      oid: 1.3.6.1.4.1.2636.3.1.13.1.18
-      type: DisplayString
-      help: A textual description of the chassis on which the contents of this row
-        exists. - 1.3.6.1.4.1.2636.3.1.13.1.18
-      indexes:
-      - labelname: jnxOperatingContentsIndex
-        type: gauge
-      - labelname: jnxOperatingL1Index
-        type: gauge
-      - labelname: jnxOperatingL2Index
-        type: gauge
-      - labelname: jnxOperatingL3Index
-        type: gauge
-      lookups:
-      - labels:
-        - jnxOperatingContentsIndex
-        - jnxOperatingL1Index
-        - jnxOperatingL2Index
-        - jnxOperatingL3Index
-        labelname: jnxOperatingDescr
-        oid: 1.3.6.1.4.1.2636.3.1.13.1.5
-        type: DisplayString
-    - name: jnxOperatingRestartTime
-      oid: 1.3.6.1.4.1.2636.3.1.13.1.19
-      type: DateAndTime
-      help: The time at which this entity last restarted. - 1.3.6.1.4.1.2636.3.1.13.1.19
-      indexes:
-      - labelname: jnxOperatingContentsIndex
-        type: gauge
-      - labelname: jnxOperatingL1Index
-        type: gauge
-      - labelname: jnxOperatingL2Index
-        type: gauge
-      - labelname: jnxOperatingL3Index
-        type: gauge
-      lookups:
-      - labels:
-        - jnxOperatingContentsIndex
-        - jnxOperatingL1Index
-        - jnxOperatingL2Index
-        - jnxOperatingL3Index
-        labelname: jnxOperatingDescr
-        oid: 1.3.6.1.4.1.2636.3.1.13.1.5
-        type: DisplayString
-    - name: jnxOperating1MinLoadAvg
-      oid: 1.3.6.1.4.1.2636.3.1.13.1.20
-      type: gauge
-      help: The CPU Load Average over the last 1 minutes Here it will be shown as
-        percentage value Zero if unavailable or inapplicable. - 1.3.6.1.4.1.2636.3.1.13.1.20
-      indexes:
-      - labelname: jnxOperatingContentsIndex
-        type: gauge
-      - labelname: jnxOperatingL1Index
-        type: gauge
-      - labelname: jnxOperatingL2Index
-        type: gauge
-      - labelname: jnxOperatingL3Index
-        type: gauge
-      lookups:
-      - labels:
-        - jnxOperatingContentsIndex
-        - jnxOperatingL1Index
-        - jnxOperatingL2Index
-        - jnxOperatingL3Index
-        labelname: jnxOperatingDescr
-        oid: 1.3.6.1.4.1.2636.3.1.13.1.5
-        type: DisplayString
-    - name: jnxOperating5MinLoadAvg
-      oid: 1.3.6.1.4.1.2636.3.1.13.1.21
-      type: gauge
-      help: The CPU Load Average over the last 5 minutes Here it will be shown as
-        percentage value Zero if unavailable or inapplicable. - 1.3.6.1.4.1.2636.3.1.13.1.21
-      indexes:
-      - labelname: jnxOperatingContentsIndex
-        type: gauge
-      - labelname: jnxOperatingL1Index
-        type: gauge
-      - labelname: jnxOperatingL2Index
-        type: gauge
-      - labelname: jnxOperatingL3Index
-        type: gauge
-      lookups:
-      - labels:
-        - jnxOperatingContentsIndex
-        - jnxOperatingL1Index
-        - jnxOperatingL2Index
-        - jnxOperatingL3Index
-        labelname: jnxOperatingDescr
-        oid: 1.3.6.1.4.1.2636.3.1.13.1.5
-        type: DisplayString
-    - name: jnxOperating15MinLoadAvg
-      oid: 1.3.6.1.4.1.2636.3.1.13.1.22
-      type: gauge
-      help: The CPU Load Average over the last 15 minutes Here it will be shown as
-        percentage value Zero if unavailable or inapplicable. - 1.3.6.1.4.1.2636.3.1.13.1.22
-      indexes:
-      - labelname: jnxOperatingContentsIndex
-        type: gauge
-      - labelname: jnxOperatingL1Index
-        type: gauge
-      - labelname: jnxOperatingL2Index
-        type: gauge
-      - labelname: jnxOperatingL3Index
-        type: gauge
-      lookups:
-      - labels:
-        - jnxOperatingContentsIndex
-        - jnxOperatingL1Index
-        - jnxOperatingL2Index
-        - jnxOperatingL3Index
-        labelname: jnxOperatingDescr
-        oid: 1.3.6.1.4.1.2636.3.1.13.1.5
-        type: DisplayString
-    - name: jnxOperating1MinAvgCPU
-      oid: 1.3.6.1.4.1.2636.3.1.13.1.23
-      type: gauge
-      help: The CPU utilization in percentage of this subject averaged over last 1
-        minutes - 1.3.6.1.4.1.2636.3.1.13.1.23
-      indexes:
-      - labelname: jnxOperatingContentsIndex
-        type: gauge
-      - labelname: jnxOperatingL1Index
-        type: gauge
-      - labelname: jnxOperatingL2Index
-        type: gauge
-      - labelname: jnxOperatingL3Index
-        type: gauge
-      lookups:
-      - labels:
-        - jnxOperatingContentsIndex
-        - jnxOperatingL1Index
-        - jnxOperatingL2Index
-        - jnxOperatingL3Index
-        labelname: jnxOperatingDescr
-        oid: 1.3.6.1.4.1.2636.3.1.13.1.5
-        type: DisplayString
-    - name: jnxOperating5MinAvgCPU
-      oid: 1.3.6.1.4.1.2636.3.1.13.1.24
-      type: gauge
-      help: The CPU utilization in percentage of this subject averaged over last 5
-        minutes - 1.3.6.1.4.1.2636.3.1.13.1.24
-      indexes:
-      - labelname: jnxOperatingContentsIndex
-        type: gauge
-      - labelname: jnxOperatingL1Index
-        type: gauge
-      - labelname: jnxOperatingL2Index
-        type: gauge
-      - labelname: jnxOperatingL3Index
-        type: gauge
-      lookups:
-      - labels:
-        - jnxOperatingContentsIndex
-        - jnxOperatingL1Index
-        - jnxOperatingL2Index
-        - jnxOperatingL3Index
-        labelname: jnxOperatingDescr
-        oid: 1.3.6.1.4.1.2636.3.1.13.1.5
-        type: DisplayString
-    - name: jnxOperating15MinAvgCPU
-      oid: 1.3.6.1.4.1.2636.3.1.13.1.25
-      type: gauge
-      help: The CPU utilization in percentage of this subject averaged over last 15
-        minutes - 1.3.6.1.4.1.2636.3.1.13.1.25
-      indexes:
-      - labelname: jnxOperatingContentsIndex
-        type: gauge
-      - labelname: jnxOperatingL1Index
-        type: gauge
-      - labelname: jnxOperatingL2Index
-        type: gauge
-      - labelname: jnxOperatingL3Index
-        type: gauge
-      lookups:
-      - labels:
-        - jnxOperatingContentsIndex
-        - jnxOperatingL1Index
-        - jnxOperatingL2Index
-        - jnxOperatingL3Index
-        labelname: jnxOperatingDescr
-        oid: 1.3.6.1.4.1.2636.3.1.13.1.5
-        type: DisplayString
-    - name: jnxOperatingFRUPower
-      oid: 1.3.6.1.4.1.2636.3.1.13.1.26
-      type: gauge
-      help: The present power of each FRU - 1.3.6.1.4.1.2636.3.1.13.1.26
-      indexes:
-      - labelname: jnxOperatingContentsIndex
-        type: gauge
-      - labelname: jnxOperatingL1Index
-        type: gauge
-      - labelname: jnxOperatingL2Index
-        type: gauge
-      - labelname: jnxOperatingL3Index
-        type: gauge
-      lookups:
-      - labels:
-        - jnxOperatingContentsIndex
-        - jnxOperatingL1Index
-        - jnxOperatingL2Index
-        - jnxOperatingL3Index
-        labelname: jnxOperatingDescr
-        oid: 1.3.6.1.4.1.2636.3.1.13.1.5
-        type: DisplayString
-    - name: jnxOperatingBufferCP
-      oid: 1.3.6.1.4.1.2636.3.1.13.1.27
-      type: gauge
-      help: The buffer pool utilization in percentage of this subject in control plane
-        - 1.3.6.1.4.1.2636.3.1.13.1.27
-      indexes:
-      - labelname: jnxOperatingContentsIndex
-        type: gauge
-      - labelname: jnxOperatingL1Index
-        type: gauge
-      - labelname: jnxOperatingL2Index
-        type: gauge
-      - labelname: jnxOperatingL3Index
-        type: gauge
-      lookups:
-      - labels:
-        - jnxOperatingContentsIndex
-        - jnxOperatingL1Index
-        - jnxOperatingL2Index
-        - jnxOperatingL3Index
-        labelname: jnxOperatingDescr
-        oid: 1.3.6.1.4.1.2636.3.1.13.1.5
-        type: DisplayString
-    - name: jnxOperatingMemoryCP
-      oid: 1.3.6.1.4.1.2636.3.1.13.1.28
-      type: gauge
-      help: The Allocated memory size for control plane in Megabytes - 1.3.6.1.4.1.2636.3.1.13.1.28
-      indexes:
-      - labelname: jnxOperatingContentsIndex
-        type: gauge
-      - labelname: jnxOperatingL1Index
-        type: gauge
-      - labelname: jnxOperatingL2Index
-        type: gauge
-      - labelname: jnxOperatingL3Index
-        type: gauge
-      lookups:
-      - labels:
-        - jnxOperatingContentsIndex
-        - jnxOperatingL1Index
-        - jnxOperatingL2Index
-        - jnxOperatingL3Index
-        labelname: jnxOperatingDescr
-        oid: 1.3.6.1.4.1.2636.3.1.13.1.5
-        type: DisplayString
-    - name: jnxOperatingBufferExt
-      oid: 1.3.6.1.4.1.2636.3.1.13.1.29
-      type: gauge
-      help: The buffer pool utilization in percentage of this subject - 1.3.6.1.4.1.2636.3.1.13.1.29
-      indexes:
-      - labelname: jnxOperatingContentsIndex
-        type: gauge
-      - labelname: jnxOperatingL1Index
-        type: gauge
-      - labelname: jnxOperatingL2Index
-        type: gauge
-      - labelname: jnxOperatingL3Index
-        type: gauge
-      lookups:
-      - labels:
-        - jnxOperatingContentsIndex
-        - jnxOperatingL1Index
-        - jnxOperatingL2Index
-        - jnxOperatingL3Index
-        labelname: jnxOperatingDescr
-        oid: 1.3.6.1.4.1.2636.3.1.13.1.5
-        type: DisplayString
-    - name: jnxOperatingTemperature
-      oid: 1.3.6.1.4.1.2636.3.1.13.1.30
-      type: gauge
-      help: The temperature in Celsius (degrees C) of this subject - 1.3.6.1.4.1.2636.3.1.13.1.30
-      indexes:
-      - labelname: jnxOperatingContentsIndex
-        type: gauge
-      - labelname: jnxOperatingL1Index
-        type: gauge
-      - labelname: jnxOperatingL2Index
-        type: gauge
-      - labelname: jnxOperatingL3Index
-        type: gauge
-      lookups:
-      - labels:
-        - jnxOperatingContentsIndex
-        - jnxOperatingL1Index
-        - jnxOperatingL2Index
-        - jnxOperatingL3Index
-        labelname: jnxOperatingDescr
-        oid: 1.3.6.1.4.1.2636.3.1.13.1.5
-        type: DisplayString
-    - name: jnxFruState
-      oid: 1.3.6.1.4.1.2636.3.1.15.1.8
-      type: EnumAsStateSet
-      help: The current state for this subject. - 1.3.6.1.4.1.2636.3.1.15.1.8
-      indexes:
-      - labelname: jnxFruContentsIndex
-        type: gauge
-      - labelname: jnxFruL1Index
-        type: gauge
-      - labelname: jnxFruL2Index
-        type: gauge
-      - labelname: jnxFruL3Index
-        type: gauge
-      lookups:
-      - labels:
-        - jnxFruContentsIndex
-        - jnxFruL1Index
-        - jnxFruL2Index
-        - jnxFruL3Index
-        labelname: jnxFruName
-        oid: 1.3.6.1.4.1.2636.3.1.15.1.5
-        type: DisplayString
-      - labels: []
-        labelname: jnxFruContentsIndex
-      - labels: []
-        labelname: jnxFruL1Index
-      - labels: []
-        labelname: jnxFruL2Index
-      - labels: []
-        labelname: jnxFruL3Index
-      enum_values:
-        1: unknown
-        2: empty
-        3: present
-        4: ready
-        5: announceOnline
-        6: online
-        7: anounceOffline
-        8: offline
-        9: diagnostic
-        10: standby
-    - name: jnxYellowAlarmState
-      oid: 1.3.6.1.4.1.2636.3.4.2.2.1
-      type: EnumAsStateSet
-      help: The yellow alarm state on the craft interface panel - 1.3.6.1.4.1.2636.3.4.2.2.1
-      enum_values:
-        1: other
-        2: "off"
-        3: "on"
-    - name: jnxYellowAlarmCount
-      oid: 1.3.6.1.4.1.2636.3.4.2.2.2
-      type: gauge
-      help: The number of currently active and non-silent yellow alarms - 1.3.6.1.4.1.2636.3.4.2.2.2
-    - name: jnxYellowAlarmLastChange
-      oid: 1.3.6.1.4.1.2636.3.4.2.2.3
-      type: gauge
-      help: The value of sysUpTime when the yellow alarm last changed - either from
-        off to on or vice versa - 1.3.6.1.4.1.2636.3.4.2.2.3
-    - name: jnxRedAlarmState
-      oid: 1.3.6.1.4.1.2636.3.4.2.3.1
-      type: EnumAsStateSet
-      help: The red alarm indication on the craft interface panel - 1.3.6.1.4.1.2636.3.4.2.3.1
-      enum_values:
-        1: other
-        2: "off"
-        3: "on"
-    - name: jnxRedAlarmCount
-      oid: 1.3.6.1.4.1.2636.3.4.2.3.2
-      type: gauge
-      help: The number of currently active and non-silent red alarms - 1.3.6.1.4.1.2636.3.4.2.3.2
-    - name: jnxRedAlarmLastChange
-      oid: 1.3.6.1.4.1.2636.3.4.2.3.3
-      type: gauge
-      help: The value of sysUpTime when the red alarm last changed - either from off
-        to on or vice versa - 1.3.6.1.4.1.2636.3.4.2.3.3
-    - name: jnxSubscriberPortTerminatedCounter
-      oid: 1.3.6.1.4.1.2636.3.64.1.1.1.5.1.3
-      type: counter
-      help: Number of active Tunneled subscribers present on the port - 1.3.6.1.4.1.2636.3.64.1.1.1.5.1.3
-      indexes:
-      - labelname: jnxSubscriberPort
-        type: DisplayString
+        help: A textual description of the chassis on which the contents of this row exists. - 1.3.6.1.4.1.2636.3.1.13.1.18
+        indexes:
+          - labelname: jnxOperatingContentsIndex
+            type: gauge
+          - labelname: jnxOperatingL1Index
+            type: gauge
+          - labelname: jnxOperatingL2Index
+            type: gauge
+          - labelname: jnxOperatingL3Index
+            type: gauge
+        lookups:
+          - labels:
+              - jnxOperatingContentsIndex
+              - jnxOperatingL1Index
+              - jnxOperatingL2Index
+              - jnxOperatingL3Index
+            labelname: jnxOperatingDescr
+            oid: 1.3.6.1.4.1.2636.3.1.13.1.5
+            type: DisplayString
+      - name: jnxOperatingRestartTime
+        oid: 1.3.6.1.4.1.2636.3.1.13.1.19
+        type: DateAndTime
+        help: The time at which this entity last restarted. - 1.3.6.1.4.1.2636.3.1.13.1.19
+        indexes:
+          - labelname: jnxOperatingContentsIndex
+            type: gauge
+          - labelname: jnxOperatingL1Index
+            type: gauge
+          - labelname: jnxOperatingL2Index
+            type: gauge
+          - labelname: jnxOperatingL3Index
+            type: gauge
+        lookups:
+          - labels:
+              - jnxOperatingContentsIndex
+              - jnxOperatingL1Index
+              - jnxOperatingL2Index
+              - jnxOperatingL3Index
+            labelname: jnxOperatingDescr
+            oid: 1.3.6.1.4.1.2636.3.1.13.1.5
+            type: DisplayString
+      - name: jnxOperating1MinLoadAvg
+        oid: 1.3.6.1.4.1.2636.3.1.13.1.20
+        type: gauge
+        help: The CPU Load Average over the last 1 minutes Here it will be shown as percentage value Zero if unavailable or inapplicable. - 1.3.6.1.4.1.2636.3.1.13.1.20
+        indexes:
+          - labelname: jnxOperatingContentsIndex
+            type: gauge
+          - labelname: jnxOperatingL1Index
+            type: gauge
+          - labelname: jnxOperatingL2Index
+            type: gauge
+          - labelname: jnxOperatingL3Index
+            type: gauge
+        lookups:
+          - labels:
+              - jnxOperatingContentsIndex
+              - jnxOperatingL1Index
+              - jnxOperatingL2Index
+              - jnxOperatingL3Index
+            labelname: jnxOperatingDescr
+            oid: 1.3.6.1.4.1.2636.3.1.13.1.5
+            type: DisplayString
+      - name: jnxOperating5MinLoadAvg
+        oid: 1.3.6.1.4.1.2636.3.1.13.1.21
+        type: gauge
+        help: The CPU Load Average over the last 5 minutes Here it will be shown as percentage value Zero if unavailable or inapplicable. - 1.3.6.1.4.1.2636.3.1.13.1.21
+        indexes:
+          - labelname: jnxOperatingContentsIndex
+            type: gauge
+          - labelname: jnxOperatingL1Index
+            type: gauge
+          - labelname: jnxOperatingL2Index
+            type: gauge
+          - labelname: jnxOperatingL3Index
+            type: gauge
+        lookups:
+          - labels:
+              - jnxOperatingContentsIndex
+              - jnxOperatingL1Index
+              - jnxOperatingL2Index
+              - jnxOperatingL3Index
+            labelname: jnxOperatingDescr
+            oid: 1.3.6.1.4.1.2636.3.1.13.1.5
+            type: DisplayString
+      - name: jnxOperating15MinLoadAvg
+        oid: 1.3.6.1.4.1.2636.3.1.13.1.22
+        type: gauge
+        help: The CPU Load Average over the last 15 minutes Here it will be shown as percentage value Zero if unavailable or inapplicable. - 1.3.6.1.4.1.2636.3.1.13.1.22
+        indexes:
+          - labelname: jnxOperatingContentsIndex
+            type: gauge
+          - labelname: jnxOperatingL1Index
+            type: gauge
+          - labelname: jnxOperatingL2Index
+            type: gauge
+          - labelname: jnxOperatingL3Index
+            type: gauge
+        lookups:
+          - labels:
+              - jnxOperatingContentsIndex
+              - jnxOperatingL1Index
+              - jnxOperatingL2Index
+              - jnxOperatingL3Index
+            labelname: jnxOperatingDescr
+            oid: 1.3.6.1.4.1.2636.3.1.13.1.5
+            type: DisplayString
+      - name: jnxOperating1MinAvgCPU
+        oid: 1.3.6.1.4.1.2636.3.1.13.1.23
+        type: gauge
+        help: The CPU utilization in percentage of this subject averaged over last 1 minutes - 1.3.6.1.4.1.2636.3.1.13.1.23
+        indexes:
+          - labelname: jnxOperatingContentsIndex
+            type: gauge
+          - labelname: jnxOperatingL1Index
+            type: gauge
+          - labelname: jnxOperatingL2Index
+            type: gauge
+          - labelname: jnxOperatingL3Index
+            type: gauge
+        lookups:
+          - labels:
+              - jnxOperatingContentsIndex
+              - jnxOperatingL1Index
+              - jnxOperatingL2Index
+              - jnxOperatingL3Index
+            labelname: jnxOperatingDescr
+            oid: 1.3.6.1.4.1.2636.3.1.13.1.5
+            type: DisplayString
+      - name: jnxOperating5MinAvgCPU
+        oid: 1.3.6.1.4.1.2636.3.1.13.1.24
+        type: gauge
+        help: The CPU utilization in percentage of this subject averaged over last 5 minutes - 1.3.6.1.4.1.2636.3.1.13.1.24
+        indexes:
+          - labelname: jnxOperatingContentsIndex
+            type: gauge
+          - labelname: jnxOperatingL1Index
+            type: gauge
+          - labelname: jnxOperatingL2Index
+            type: gauge
+          - labelname: jnxOperatingL3Index
+            type: gauge
+        lookups:
+          - labels:
+              - jnxOperatingContentsIndex
+              - jnxOperatingL1Index
+              - jnxOperatingL2Index
+              - jnxOperatingL3Index
+            labelname: jnxOperatingDescr
+            oid: 1.3.6.1.4.1.2636.3.1.13.1.5
+            type: DisplayString
+      - name: jnxOperating15MinAvgCPU
+        oid: 1.3.6.1.4.1.2636.3.1.13.1.25
+        type: gauge
+        help: The CPU utilization in percentage of this subject averaged over last 15 minutes - 1.3.6.1.4.1.2636.3.1.13.1.25
+        indexes:
+          - labelname: jnxOperatingContentsIndex
+            type: gauge
+          - labelname: jnxOperatingL1Index
+            type: gauge
+          - labelname: jnxOperatingL2Index
+            type: gauge
+          - labelname: jnxOperatingL3Index
+            type: gauge
+        lookups:
+          - labels:
+              - jnxOperatingContentsIndex
+              - jnxOperatingL1Index
+              - jnxOperatingL2Index
+              - jnxOperatingL3Index
+            labelname: jnxOperatingDescr
+            oid: 1.3.6.1.4.1.2636.3.1.13.1.5
+            type: DisplayString
+      - name: jnxOperatingFRUPower
+        oid: 1.3.6.1.4.1.2636.3.1.13.1.26
+        type: gauge
+        help: The present power of each FRU - 1.3.6.1.4.1.2636.3.1.13.1.26
+        indexes:
+          - labelname: jnxOperatingContentsIndex
+            type: gauge
+          - labelname: jnxOperatingL1Index
+            type: gauge
+          - labelname: jnxOperatingL2Index
+            type: gauge
+          - labelname: jnxOperatingL3Index
+            type: gauge
+        lookups:
+          - labels:
+              - jnxOperatingContentsIndex
+              - jnxOperatingL1Index
+              - jnxOperatingL2Index
+              - jnxOperatingL3Index
+            labelname: jnxOperatingDescr
+            oid: 1.3.6.1.4.1.2636.3.1.13.1.5
+            type: DisplayString
+      - name: jnxOperatingBufferCP
+        oid: 1.3.6.1.4.1.2636.3.1.13.1.27
+        type: gauge
+        help: The buffer pool utilization in percentage of this subject in control plane - 1.3.6.1.4.1.2636.3.1.13.1.27
+        indexes:
+          - labelname: jnxOperatingContentsIndex
+            type: gauge
+          - labelname: jnxOperatingL1Index
+            type: gauge
+          - labelname: jnxOperatingL2Index
+            type: gauge
+          - labelname: jnxOperatingL3Index
+            type: gauge
+        lookups:
+          - labels:
+              - jnxOperatingContentsIndex
+              - jnxOperatingL1Index
+              - jnxOperatingL2Index
+              - jnxOperatingL3Index
+            labelname: jnxOperatingDescr
+            oid: 1.3.6.1.4.1.2636.3.1.13.1.5
+            type: DisplayString
+      - name: jnxOperatingMemoryCP
+        oid: 1.3.6.1.4.1.2636.3.1.13.1.28
+        type: gauge
+        help: The Allocated memory size for control plane in Megabytes - 1.3.6.1.4.1.2636.3.1.13.1.28
+        indexes:
+          - labelname: jnxOperatingContentsIndex
+            type: gauge
+          - labelname: jnxOperatingL1Index
+            type: gauge
+          - labelname: jnxOperatingL2Index
+            type: gauge
+          - labelname: jnxOperatingL3Index
+            type: gauge
+        lookups:
+          - labels:
+              - jnxOperatingContentsIndex
+              - jnxOperatingL1Index
+              - jnxOperatingL2Index
+              - jnxOperatingL3Index
+            labelname: jnxOperatingDescr
+            oid: 1.3.6.1.4.1.2636.3.1.13.1.5
+            type: DisplayString
+      - name: jnxOperatingBufferExt
+        oid: 1.3.6.1.4.1.2636.3.1.13.1.29
+        type: gauge
+        help: The buffer pool utilization in percentage of this subject - 1.3.6.1.4.1.2636.3.1.13.1.29
+        indexes:
+          - labelname: jnxOperatingContentsIndex
+            type: gauge
+          - labelname: jnxOperatingL1Index
+            type: gauge
+          - labelname: jnxOperatingL2Index
+            type: gauge
+          - labelname: jnxOperatingL3Index
+            type: gauge
+        lookups:
+          - labels:
+              - jnxOperatingContentsIndex
+              - jnxOperatingL1Index
+              - jnxOperatingL2Index
+              - jnxOperatingL3Index
+            labelname: jnxOperatingDescr
+            oid: 1.3.6.1.4.1.2636.3.1.13.1.5
+            type: DisplayString
+      - name: jnxOperatingTemperature
+        oid: 1.3.6.1.4.1.2636.3.1.13.1.30
+        type: gauge
+        help: The temperature in Celsius (degrees C) of this subject - 1.3.6.1.4.1.2636.3.1.13.1.30
+        indexes:
+          - labelname: jnxOperatingContentsIndex
+            type: gauge
+          - labelname: jnxOperatingL1Index
+            type: gauge
+          - labelname: jnxOperatingL2Index
+            type: gauge
+          - labelname: jnxOperatingL3Index
+            type: gauge
+        lookups:
+          - labels:
+              - jnxOperatingContentsIndex
+              - jnxOperatingL1Index
+              - jnxOperatingL2Index
+              - jnxOperatingL3Index
+            labelname: jnxOperatingDescr
+            oid: 1.3.6.1.4.1.2636.3.1.13.1.5
+            type: DisplayString
+      - name: jnxFruState
+        oid: 1.3.6.1.4.1.2636.3.1.15.1.8
+        type: EnumAsStateSet
+        help: The current state for this subject. - 1.3.6.1.4.1.2636.3.1.15.1.8
+        indexes:
+          - labelname: jnxFruContentsIndex
+            type: gauge
+          - labelname: jnxFruL1Index
+            type: gauge
+          - labelname: jnxFruL2Index
+            type: gauge
+          - labelname: jnxFruL3Index
+            type: gauge
+        lookups:
+          - labels:
+              - jnxFruContentsIndex
+              - jnxFruL1Index
+              - jnxFruL2Index
+              - jnxFruL3Index
+            labelname: jnxFruName
+            oid: 1.3.6.1.4.1.2636.3.1.15.1.5
+            type: DisplayString
+          - labels: []
+            labelname: jnxFruContentsIndex
+          - labels: []
+            labelname: jnxFruL1Index
+          - labels: []
+            labelname: jnxFruL2Index
+          - labels: []
+            labelname: jnxFruL3Index
+        enum_values:
+          1: unknown
+          2: empty
+          3: present
+          4: ready
+          5: announceOnline
+          6: online
+          7: anounceOffline
+          8: offline
+          9: diagnostic
+          10: standby
+      - name: jnxYellowAlarmState
+        oid: 1.3.6.1.4.1.2636.3.4.2.2.1
+        type: EnumAsStateSet
+        help: The yellow alarm state on the craft interface panel - 1.3.6.1.4.1.2636.3.4.2.2.1
+        enum_values:
+          1: other
+          2: "off"
+          3: "on"
+      - name: jnxYellowAlarmCount
+        oid: 1.3.6.1.4.1.2636.3.4.2.2.2
+        type: gauge
+        help: The number of currently active and non-silent yellow alarms - 1.3.6.1.4.1.2636.3.4.2.2.2
+      - name: jnxYellowAlarmLastChange
+        oid: 1.3.6.1.4.1.2636.3.4.2.2.3
+        type: gauge
+        help: The value of sysUpTime when the yellow alarm last changed - either from off to on or vice versa - 1.3.6.1.4.1.2636.3.4.2.2.3
+      - name: jnxRedAlarmState
+        oid: 1.3.6.1.4.1.2636.3.4.2.3.1
+        type: EnumAsStateSet
+        help: The red alarm indication on the craft interface panel - 1.3.6.1.4.1.2636.3.4.2.3.1
+        enum_values:
+          1: other
+          2: "off"
+          3: "on"
+      - name: jnxRedAlarmCount
+        oid: 1.3.6.1.4.1.2636.3.4.2.3.2
+        type: gauge
+        help: The number of currently active and non-silent red alarms - 1.3.6.1.4.1.2636.3.4.2.3.2
+      - name: jnxRedAlarmLastChange
+        oid: 1.3.6.1.4.1.2636.3.4.2.3.3
+        type: gauge
+        help: The value of sysUpTime when the red alarm last changed - either from off to on or vice versa - 1.3.6.1.4.1.2636.3.4.2.3.3
+      - name: jnxSubscriberPortTerminatedCounter
+        oid: 1.3.6.1.4.1.2636.3.64.1.1.1.5.1.3
+        type: counter
+        help: Number of active Tunneled subscribers present on the port - 1.3.6.1.4.1.2636.3.64.1.1.1.5.1.3
+        indexes:
+          - labelname: jnxSubscriberPort
+            type: DisplayString
   juniper_optics:
     walk:
-    - 1.3.6.1.2.1.31.1.1.1.1
-    - 1.3.6.1.2.1.31.1.1.1.18
-    - 1.3.6.1.4.1.2636.3.60.1.1.1.1.1
-    - 1.3.6.1.4.1.2636.3.60.1.1.1.1.4
-    - 1.3.6.1.4.1.2636.3.60.1.1.1.1.5
-    - 1.3.6.1.4.1.2636.3.60.1.1.1.1.6
-    - 1.3.6.1.4.1.2636.3.60.1.1.1.1.7
+      - 1.3.6.1.2.1.31.1.1.1.1
+      - 1.3.6.1.2.1.31.1.1.1.18
+      - 1.3.6.1.4.1.2636.3.60.1.1.1.1.1
+      - 1.3.6.1.4.1.2636.3.60.1.1.1.1.4
+      - 1.3.6.1.4.1.2636.3.60.1.1.1.1.5
+      - 1.3.6.1.4.1.2636.3.60.1.1.1.1.6
+      - 1.3.6.1.4.1.2636.3.60.1.1.1.1.7
     metrics:
-    - name: jnxDomCurrentAlarms
-      oid: 1.3.6.1.4.1.2636.3.60.1.1.1.1.1
-      type: Bits
-      help: This object identifies all the active DOM alarms on a SFF physical interface
-        on this router. - 1.3.6.1.4.1.2636.3.60.1.1.1.1.1
-      indexes:
-      - labelname: ifIndex
+      - name: jnxDomCurrentAlarms
+        oid: 1.3.6.1.4.1.2636.3.60.1.1.1.1.1
+        type: Bits
+        help: This object identifies all the active DOM alarms on a SFF physical interface on this router. - 1.3.6.1.4.1.2636.3.60.1.1.1.1.1
+        indexes:
+          - labelname: ifIndex
+            type: gauge
+        lookups:
+          - labels:
+              - ifIndex
+            labelname: ifName
+            oid: 1.3.6.1.2.1.31.1.1.1.1
+            type: DisplayString
+          - labels:
+              - ifIndex
+            labelname: ifAlias
+            oid: 1.3.6.1.2.1.31.1.1.1.18
+            type: DisplayString
+          - labels: []
+            labelname: ifIndex
+        enum_values:
+          0: domRxLossSignalAlarm
+          1: domRxCDRLossLockAlarm
+          2: domRxNotReadyAlarm
+          3: domRxLaserPowerHighAlarm
+          4: domRxLaserPowerLowAlarm
+          5: domTxLaserBiasCurrentHighAlarm
+          6: domTxLaserBiasCurrentLowAlarm
+          7: domTxLaserOutputPowerHighAlarm
+          8: domTxLaserOutputPowerLowAlarm
+          9: domTxDataNotReadyAlarm
+          10: domTxNotReadyAlarm
+          11: domTxLaserFaultAlarm
+          12: domTxCDRLossLockAlarm
+          13: domModuleTemperatureHighAlarm
+          14: domModuleTemperatureLowAlarm
+          15: domModuleNotReadyAlarm
+          16: domModulePowerDownAlarm
+          17: domLinkDownAlarm
+          18: domModuleRemovedAlarm
+          19: domModuleVoltageHighAlarm
+          20: domModuleVoltageLowAlarm
+          21: domTxDither
+          22: domTecFault
+          23: domWavelengthUnlocked
+          24: domTxTuned
+      - name: jnxDomCurrentWarnings
+        oid: 1.3.6.1.4.1.2636.3.60.1.1.1.1.4
+        type: Bits
+        help: This object identifies all the active DOM warnings on a SFF physical interface on this router. - 1.3.6.1.4.1.2636.3.60.1.1.1.1.4
+        indexes:
+          - labelname: ifIndex
+            type: gauge
+        lookups:
+          - labels:
+              - ifIndex
+            labelname: ifName
+            oid: 1.3.6.1.2.1.31.1.1.1.1
+            type: DisplayString
+          - labels:
+              - ifIndex
+            labelname: ifAlias
+            oid: 1.3.6.1.2.1.31.1.1.1.18
+            type: DisplayString
+          - labels: []
+            labelname: ifIndex
+        enum_values:
+          0: domRxLaserPowerHighWarning
+          1: domRxLaserPowerLowWarning
+          2: domTxLaserBiasCurrentHighWarning
+          3: domTxLaserBiasCurrentLowWarning
+          4: domTxLaserOutputPowerHighWarning
+          5: domTxLaserOutputPowerLowWarning
+          6: domModuleTemperatureHighWarning
+          7: domModuleTemperatureLowWarning
+          8: domModuleVoltageHighWarning
+          9: domModuleVoltageLowWarning
+      - name: jnxDomCurrentRxLaserPower
+        oid: 1.3.6.1.4.1.2636.3.60.1.1.1.1.5
         type: gauge
-      lookups:
-      - labels:
-        - ifIndex
-        labelname: ifName
-        oid: 1.3.6.1.2.1.31.1.1.1.1
-        type: DisplayString
-      - labels:
-        - ifIndex
-        labelname: ifAlias
-        oid: 1.3.6.1.2.1.31.1.1.1.18
-        type: DisplayString
-      - labels: []
-        labelname: ifIndex
-      enum_values:
-        0: domRxLossSignalAlarm
-        1: domRxCDRLossLockAlarm
-        2: domRxNotReadyAlarm
-        3: domRxLaserPowerHighAlarm
-        4: domRxLaserPowerLowAlarm
-        5: domTxLaserBiasCurrentHighAlarm
-        6: domTxLaserBiasCurrentLowAlarm
-        7: domTxLaserOutputPowerHighAlarm
-        8: domTxLaserOutputPowerLowAlarm
-        9: domTxDataNotReadyAlarm
-        10: domTxNotReadyAlarm
-        11: domTxLaserFaultAlarm
-        12: domTxCDRLossLockAlarm
-        13: domModuleTemperatureHighAlarm
-        14: domModuleTemperatureLowAlarm
-        15: domModuleNotReadyAlarm
-        16: domModulePowerDownAlarm
-        17: domLinkDownAlarm
-        18: domModuleRemovedAlarm
-        19: domModuleVoltageHighAlarm
-        20: domModuleVoltageLowAlarm
-        21: domTxDither
-        22: domTecFault
-        23: domWavelengthUnlocked
-        24: domTxTuned
-    - name: jnxDomCurrentWarnings
-      oid: 1.3.6.1.4.1.2636.3.60.1.1.1.1.4
-      type: Bits
-      help: This object identifies all the active DOM warnings on a SFF physical interface
-        on this router. - 1.3.6.1.4.1.2636.3.60.1.1.1.1.4
-      indexes:
-      - labelname: ifIndex
+        help: Receiver laser power. - 1.3.6.1.4.1.2636.3.60.1.1.1.1.5
+        indexes:
+          - labelname: ifIndex
+            type: gauge
+        lookups:
+          - labels:
+              - ifIndex
+            labelname: ifName
+            oid: 1.3.6.1.2.1.31.1.1.1.1
+            type: DisplayString
+          - labels:
+              - ifIndex
+            labelname: ifAlias
+            oid: 1.3.6.1.2.1.31.1.1.1.18
+            type: DisplayString
+          - labels: []
+            labelname: ifIndex
+        scale: 0.01
+      - name: jnxDomCurrentTxLaserBiasCurrent
+        oid: 1.3.6.1.4.1.2636.3.60.1.1.1.1.6
         type: gauge
-      lookups:
-      - labels:
-        - ifIndex
-        labelname: ifName
-        oid: 1.3.6.1.2.1.31.1.1.1.1
-        type: DisplayString
-      - labels:
-        - ifIndex
-        labelname: ifAlias
-        oid: 1.3.6.1.2.1.31.1.1.1.18
-        type: DisplayString
-      - labels: []
-        labelname: ifIndex
-      enum_values:
-        0: domRxLaserPowerHighWarning
-        1: domRxLaserPowerLowWarning
-        2: domTxLaserBiasCurrentHighWarning
-        3: domTxLaserBiasCurrentLowWarning
-        4: domTxLaserOutputPowerHighWarning
-        5: domTxLaserOutputPowerLowWarning
-        6: domModuleTemperatureHighWarning
-        7: domModuleTemperatureLowWarning
-        8: domModuleVoltageHighWarning
-        9: domModuleVoltageLowWarning
-    - name: jnxDomCurrentRxLaserPower
-      oid: 1.3.6.1.4.1.2636.3.60.1.1.1.1.5
-      type: gauge
-      help: Receiver laser power. - 1.3.6.1.4.1.2636.3.60.1.1.1.1.5
-      indexes:
-      - labelname: ifIndex
+        help: Transmitter laser bias current. - 1.3.6.1.4.1.2636.3.60.1.1.1.1.6
+        indexes:
+          - labelname: ifIndex
+            type: gauge
+        lookups:
+          - labels:
+              - ifIndex
+            labelname: ifName
+            oid: 1.3.6.1.2.1.31.1.1.1.1
+            type: DisplayString
+          - labels:
+              - ifIndex
+            labelname: ifAlias
+            oid: 1.3.6.1.2.1.31.1.1.1.18
+            type: DisplayString
+          - labels: []
+            labelname: ifIndex
+        scale: 0.001
+      - name: jnxDomCurrentTxLaserOutputPower
+        oid: 1.3.6.1.4.1.2636.3.60.1.1.1.1.7
         type: gauge
-      lookups:
-      - labels:
-        - ifIndex
-        labelname: ifName
-        oid: 1.3.6.1.2.1.31.1.1.1.1
-        type: DisplayString
-      - labels:
-        - ifIndex
-        labelname: ifAlias
-        oid: 1.3.6.1.2.1.31.1.1.1.18
-        type: DisplayString
-      - labels: []
-        labelname: ifIndex
-      scale: 0.01
-    - name: jnxDomCurrentTxLaserBiasCurrent
-      oid: 1.3.6.1.4.1.2636.3.60.1.1.1.1.6
-      type: gauge
-      help: Transmitter laser bias current. - 1.3.6.1.4.1.2636.3.60.1.1.1.1.6
-      indexes:
-      - labelname: ifIndex
-        type: gauge
-      lookups:
-      - labels:
-        - ifIndex
-        labelname: ifName
-        oid: 1.3.6.1.2.1.31.1.1.1.1
-        type: DisplayString
-      - labels:
-        - ifIndex
-        labelname: ifAlias
-        oid: 1.3.6.1.2.1.31.1.1.1.18
-        type: DisplayString
-      - labels: []
-        labelname: ifIndex
-      scale: 0.001
-    - name: jnxDomCurrentTxLaserOutputPower
-      oid: 1.3.6.1.4.1.2636.3.60.1.1.1.1.7
-      type: gauge
-      help: Transmitter laser output power. - 1.3.6.1.4.1.2636.3.60.1.1.1.1.7
-      indexes:
-      - labelname: ifIndex
-        type: gauge
-      lookups:
-      - labels:
-        - ifIndex
-        labelname: ifName
-        oid: 1.3.6.1.2.1.31.1.1.1.1
-        type: DisplayString
-      - labels:
-        - ifIndex
-        labelname: ifAlias
-        oid: 1.3.6.1.2.1.31.1.1.1.18
-        type: DisplayString
-      - labels: []
-        labelname: ifIndex
-      scale: 0.01
+        help: Transmitter laser output power. - 1.3.6.1.4.1.2636.3.60.1.1.1.1.7
+        indexes:
+          - labelname: ifIndex
+            type: gauge
+        lookups:
+          - labels:
+              - ifIndex
+            labelname: ifName
+            oid: 1.3.6.1.2.1.31.1.1.1.1
+            type: DisplayString
+          - labels:
+              - ifIndex
+            labelname: ifAlias
+            oid: 1.3.6.1.2.1.31.1.1.1.18
+            type: DisplayString
+          - labels: []
+            labelname: ifIndex
+        scale: 0.01


### PR DESCRIPTION
## Description of PR

adds snmp_exporter and scrape jobs to prometheus
## Previous Behavior
no data

## New Behavior
data !
![screenshot_2025-03-06-210034](https://github.com/user-attachments/assets/e0bd3d5e-4cc9-4326-8b57-0b8e69a4cbf6)

## Tests

I was able to run the same config on my laptop, on the noc vlan and create graphs.



## Notes
The snmp.yaml was generated using https://github.com/prometheus/snmp_exporter/tree/v0.28.0/generator paired down the just the juniper stats we care about
