### PR TITLE
docs: Add new hardware docs for OpenWrt One

### DIFF
--- a/openwrt/docs/MT7981X.md
+++ b/openwrt/docs/MT7981X.md
@@ -1,0 +1,29 @@
+# OpenWrt One (mt7981x)
+
+**IMPORTANT: Prepare an empty FAT32 formatted flash drive with a Master Boot Record (MBR) partition table. If there are any other files in the USB drive, or has a GUID Partition Table (GPT), it won't work.**
+
+## Mass device flashing:
+See [Massflash](./MASSFLASH.md)
+
+## Firmware upgrade by USB:
+
+- The file MUST be named or the flash update WON'T WORK.
+"openwrt-mediatek-filogic-openwrt_one-squashfs-sysupgrade.itb".
+- The NAND/NOR boot switch must be in the 'NAND' position.
+- Insert USB stick into the front of device.
+- Press and hold 'RESET' button while powering up device (USB-C or POE).
+- Continue holding 'RESET' until amber LED is blinking.
+- Wait for the middle 'OK' light to go green.
+
+## Firmware recovery:
+If the device fails to boot or has become unresponsive:
+
+- Place the following files on the USB stick:
+"openwrt-mediatek-filogic-openwrt_one-snand-preloader.bin"
+"openwrt-mediatek-filogic-openwrt_one-factory.ubi"
+(The 2 above files must be named exactly, or recovery won't work!)
+- Insert USB stick on the front of device.
+- Flip the "NAND/NOR" boot switch to the 'NOR' position.
+- Press and hold the front button while powering up device (USB-C or POE).
+- Wait for the middle 'OK' light to go green.
+


### PR DESCRIPTION
## Description of PR
Added OpenWrt One hardware docs

## Previous Behavior
No OpenWrt Ones in Docs

## New Behavior
Added OpenWrt One hardware docs 

## Tests
Read by:
@sarcasticadmin 
OpenWrt One APs successfully flashed on supposedly "won't flash" APs. 