### PR TITLE
Update snmp.yml with SNMP Retries and Timeout Values

### DIFF
--- a/nix/nixos-modules/services/snmp.yml
+++ b/nix/nixos-modules/services/snmp.yml
@@ -20,6 +20,10 @@ auths:
     version: 2
 modules:
   juniper:
+    max_repetitions: 25  # How many objects to request with GET/GETBULK, defaults to 25.
+                         # May need to be reduced for buggy devices.
+    retries: 3   # How many times to retry a failed request, defaults to 3.
+    timeout: 180s # Timeout for each individual SNMP request, defaults to 2s.
     walk:
       - 1.3.6.1.2.1.2.2.1.10
       - 1.3.6.1.2.1.2.2.1.16
@@ -752,6 +756,10 @@ modules:
           - labelname: jnxSubscriberPort
             type: DisplayString
   juniper_optics:
+    max_repetitions: 25  # How many objects to request with GET/GETBULK, defaults to 25.
+                         # May need to be reduced for buggy devices.
+    retries: 3   # How many times to retry a failed request, defaults to 3.
+    timeout: 180s # Timeout for each individual SNMP request, defaults to 2s.
     walk:
       - 1.3.6.1.2.1.31.1.1.1.1
       - 1.3.6.1.2.1.31.1.1.1.18


### PR DESCRIPTION
## Description of PR

Add retries and timeouts to Prometheus SNMP exporter.

## Previous Behavior

No retries or timeouts were defined, causing data to not be collected.

## New Behavior

Add retries and timeouts, in the hopes that data will be collected, regardless of how long it takes.