### PR TITLE
Switch QoS order - it appears to be inverted

### DIFF
--- a/switch-configuration/config/scripts/switch_template.pm
+++ b/switch-configuration/config/scripts/switch_template.pm
@@ -1974,9 +1974,9 @@ snmp {
 }
 class-of-service {
     forwarding-classes {
-        class wifi queue-num 1;
+        class infra queue-num 1;
         class av queue-num 2;
-        class infra queue-num 3;
+        class wifi queue-num 3;
     }
 }
 interfaces {


### PR DESCRIPTION
https://www.juniper.net/documentation/us/en/software/junos/cos-security-devices/topics/concept/cos-forwarding-class-overview.html

Based on the info below and on manual testing, it appears that infra is the lowest priority prior right now. This inverts the order so that infra is highest priority.

![image](https://github.com/user-attachments/assets/b0a770d2-04c5-4c43-af03-20709bba98d3)