### PR TITLE
[WIP] facts.inventory: add DNS search domain to all DHCP pools

### DIFF
--- a/facts/inventory.py
+++ b/facts/inventory.py
@@ -568,7 +568,10 @@ def generatekeaconfig(servers, aps, vlans, outputdir):
                 "pools": [
                     {"pool": vlan["ipv4dhcpStart"] + " - " + vlan["ipv4dhcpEnd"]}
                 ],
-                "option-data": [{"name": "routers", "data": str(vlan["ipv4router"])}],
+                "option-data": [
+                    {"name": "routers", "data": str(vlan["ipv4router"])},
+                    {"name": "domain-search", "data": "scale.lan"},
+                ],
             }
             # lower lease times for the APs
             if vlan["name"] in ["cfInfra", "exInfra"]:
@@ -603,6 +606,7 @@ def generatekeaconfig(servers, aps, vlans, outputdir):
                 "pools": [
                     {"pool": vlan["ipv6dhcpStart"] + " - " + vlan["ipv6dhcpEnd"]}
                 ],
+                "option-data": [{"name": "domain-search", "data": "scale.lan"}],
             }
             # lower lease times for the APs
             if vlan["name"] in ["cfInfra", "exInfra"]:


### PR DESCRIPTION
## Description of PR

Adds DNS search domain to all DHCP pools. 

## Tests

1. `> nix build .#scaleInventory`
2. Reviewed output of DHCP checking v4 pool

```
{
        "subnet": "10.128.10.0/24",
        "id": 10128100,
        "user-context": {
          "vlan": "cfInstl"
        },
        "pools": [
          {
            "pool": "10.128.10.80 - 10.128.10.254"
          }
        ],
        "option-data": [
          {
            "name": "routers",
            "data": "10.128.10.1"
          },
          {
            "name": "domain-search",
            "data": "scale.lan"
          }
        ]
      }
```

3. Reviewed output of DHCP checking v6 pool

```
{
        "subnet": "2001:470:f026:507::/64",
        "id": 25863,
        "user-context": {
          "vlan": "cfSigns"
        },
        "pools": [
          {
            "pool": "2001:470:f026:507:d8c::1 - 2001:470:f026:507:d8c::800"
          }
        ],
        "option-data": [
          {
            "name": "domain-search",
            "data": "scale.lan"
          }
        ]
      },
```