### PR TITLE
[READY] nix.modules.users: add missing erikreinert entry

### DIFF
--- a/nix/nixos-modules/users/default.nix
+++ b/nix/nixos-modules/users/default.nix
@@ -4,6 +4,7 @@
     ./berkhan.nix
     ./conjones.nix
     ./dlang.nix
+    ./erikreinert.nix
     ./gene.nix
     ./jsh.nix
     ./kylerisse.nix


### PR DESCRIPTION
## Description of PR

Fix broken `master` by including `erikreinert` user entry

## Tests

`nix build .#checks.x86_64-linux.core` passes with latest master