### PR TITLE
22x Signs DST

### DIFF
--- a/nix/nixos-modules/services/signs.nix
+++ b/nix/nixos-modules/services/signs.nix
@@ -35,7 +35,7 @@ in
     virtualisation.oci-containers = {
       containers.scale-signs = {
         ports = [ "8080:80" ];
-        image = "sarcasticadmin/scale-signs:2309424 ";
+        image = "sarcasticadmin/scale-signs:8f6ed2f ";
       };
     };
 


### PR DESCRIPTION
## Description of PR

Sunday morning changes to signs plus disable DHCPv6. https://github.com/socallinuxexpo/scale-signs/pull/76

## Tests

Tested locally `podman run -p 8088:80 sarcasticadmin/scale-signs:8f6ed2f`

![sunday_0845am](https://github.com/user-attachments/assets/72248808-488d-47f6-b73c-9e21343cd761)
![sunday_0945am](https://github.com/user-attachments/assets/d86f3569-ac52-4ebe-a81b-4e05822e38ad)
