### PR TITLE
[REVIEW] - nixosConfigurations: remove deprecation warnings

### DIFF
--- a/nix/checks/core.nix
+++ b/nix/checks/core.nix
@@ -174,7 +174,6 @@ in
       interactiveDefaults = hostPort: {
         services.openssh.enable = true;
         services.openssh.settings.PermitRootLogin = mkForce "yes";
-        users.extraUsers.root.initialPassword = "";
         systemd.network.networks."01-eth0" = {
           name = "eth0";
           enable = true;

--- a/nix/nixos-configurations/bootstrap-image/default.nix
+++ b/nix/nixos-configurations/bootstrap-image/default.nix
@@ -1,5 +1,5 @@
 {
-  release = "2405";
+  release = "unstable";
 
   modules =
     {

--- a/nix/nixos-configurations/core-master/default.nix
+++ b/nix/nixos-configurations/core-master/default.nix
@@ -61,8 +61,8 @@
               # block service that depend on network-online.target until route is avail
               linkConfig.RequiredForOnline = "routable";
               routes = [
-                { routeConfig.Gateway = "10.128.3.1"; }
-                { routeConfig.Gateway = "2001:470:f026:503::1"; }
+                { Gateway = "10.128.3.1"; }
+                { Gateway = "2001:470:f026:503::1"; }
               ];
             };
             "10-lan-eno2" = {

--- a/nix/nixos-configurations/core-slave/default.nix
+++ b/nix/nixos-configurations/core-slave/default.nix
@@ -61,8 +61,8 @@
               # block service that depend on network-online.target until route is avail
               linkConfig.RequiredForOnline = "routable";
               routes = [
-                { routeConfig.Gateway = "10.0.3.1"; }
-                { routeConfig.Gateway = "2001:470:f026:103::1"; }
+                { Gateway = "10.0.3.1"; }
+                { Gateway = "2001:470:f026:103::1"; }
               ];
             };
             "10-lan-eno2" = {

--- a/nix/nixos-configurations/dev-server/default.nix
+++ b/nix/nixos-configurations/dev-server/default.nix
@@ -395,14 +395,14 @@
               ];
               routes = [
                 {
-                  routeConfig.Destination = "10.0.0.0/8";
-                  routeConfig.Gateway = "10.0.3.1";
-                  routeConfig.GatewayOnLink = true;
+                  Destination = "10.0.0.0/8";
+                  Gateway = "10.0.3.1";
+                  GatewayOnLink = true;
                 }
                 {
-                  routeConfig.Destination = "2001:470:f026::/48";
-                  routeConfig.Gateway = "2001:470:f026:103::1";
-                  routeConfig.GatewayOnLink = true;
+                  Destination = "2001:470:f026::/48";
+                  Gateway = "2001:470:f026:103::1";
+                  GatewayOnLink = true;
                 }
               ];
             };

--- a/nix/nixos-configurations/dev-server/default.nix
+++ b/nix/nixos-configurations/dev-server/default.nix
@@ -1,5 +1,5 @@
 {
-  release = "2405";
+  release = "unstable";
 
   modules =
     {

--- a/nix/nixos-configurations/massflash/default.nix
+++ b/nix/nixos-configurations/massflash/default.nix
@@ -1,5 +1,5 @@
 {
-  release = "2405";
+  release = "unstable";
 
   modules =
     {

--- a/nix/nixos-modules/base.nix
+++ b/nix/nixos-modules/base.nix
@@ -56,7 +56,12 @@ in
       usbutils
       unixtools.nettools
       wget
-      ((vim_configurable.override { }).customize {
+    ];
+
+    programs.vim = {
+      enable = true;
+      defaultEditor = true;
+      package = (pkgs.vim_configurable.override { }).customize {
         name = "vim";
         # Install plugins for syntax highlighting of nix files
         vimrcConfig.packages.myplugins = with pkgs.vimPlugins; {
@@ -71,12 +76,7 @@ in
           " Disable mouse
           set mouse-=a
         '';
-      })
-    ];
-
-    # Purge nano from being the default
-    environment.variables = {
-      EDITOR = "vim";
+      };
     };
 
     # set 24h military time


### PR DESCRIPTION
## Description of PR

<!--
Brief description of the changes in PR

If change is related to an open issue template include at the top of your
description.
-->

Moving all machines to `unstable` version of nixpkgs (will shuffle these again soon but keeping it consistent for now).

We have minor deprecation warnings that should be handled before we bump to new nixpkgs versions

## Previous Behavior

<!--
What was the behavior before this PR?

Remove this section if not relevant
-->

Various warnings called out in: #965

## New Behavior

No warnings during builds of `toplevel`

<!--
What is the new behavior being introduced in this PR?

Remove this section if not relevant
-->

## Tests

<!--
How was this PR tested? Please provide as much detail as possible
so we can ensure this change is working as intended before being merged.
-->
