### PR TITLE
facts.inventory: support dhcp6 ntp-server option

### DIFF
--- a/facts/inventory.py
+++ b/facts/inventory.py
@@ -528,6 +528,23 @@ def generatekeaconfig(servers, aps, vlans, outputdir):
                         [x["ipv6"] for x in servers if x["role"] == "core"]
                     ),
                 },
+                {
+                    # option 56 which deprecates option 31 (RFC 4075)
+                    # https://www.rfc-editor.org/rfc/rfc5908
+                    # this option itself is empty but has associated sub-options (1-3)
+                    "name": "ntp-server",
+                },
+                {
+                    # option 56 requires at least one sub-option
+                    # https://kea.readthedocs.io/en/kea-3.0.0/arm/dhcp6-srv.html#ntp-server-suboptions
+                    # either name or code is sufficient to identify the sub-option but prefer to be explicit
+                    "name": "ntp-server-address",
+                    "code": 1,
+                    "space": "v6-ntp-server-suboptions",
+                    "data": ",".join(
+                        [x["ipv6"] for x in servers if x["role"] == "core"]
+                    ),
+                },
                 {"name": "domain-search", "data": "scale.lan"},
             ],
             "option-def": [],

--- a/nix/checks/core.nix
+++ b/nix/checks/core.nix
@@ -166,7 +166,7 @@ in
       coremaster.wait_for_unit("ntpd.service")
       coremaster.wait_for_unit("bind.service")
       coremaster.succeed("kea-dhcp4 -t /etc/kea/dhcp4-server.conf")
-      coremaster.succeed("named-checkconf ${nodes.coremaster.config.services.bind.configFile}")
+      coremaster.succeed("named-checkconf ${nodes.coremaster.services.bind.configFile}")
       client1.wait_until_succeeds("ping -c 5 ${coremasterAddr.ipv4}")
       client1.wait_until_succeeds("ip route show | grep default | grep -w ${routerAddr.ipv4}")
       # ensure that we got the correct prefix and suffix on dhcpv6

--- a/nix/checks/core.nix
+++ b/nix/checks/core.nix
@@ -166,8 +166,10 @@ in
       coremaster.wait_for_unit("ntpd.service")
       coremaster.wait_for_unit("bind.service")
       coremaster.succeed("kea-dhcp4 -t /etc/kea/dhcp4-server.conf")
+      coremaster.succeed("kea-dhcp6 -t /etc/kea/dhcp6-server.conf")
       coremaster.succeed("named-checkconf ${nodes.coremaster.services.bind.configFile}")
       client1.wait_until_succeeds("ping -c 5 ${coremasterAddr.ipv4}")
+      client1.wait_until_succeeds("ping -c 5 -6 ${coremasterAddr.ipv6}")
       client1.wait_until_succeeds("ip route show | grep default | grep -w ${routerAddr.ipv4}")
       # ensure that we got the correct prefix and suffix on dhcpv6
       client1.wait_until_succeeds("ip addr show dev eth1 | grep inet6 | grep ${chomp}:d8c")


### PR DESCRIPTION
## Description of PR

<!--
Brief description of the changes in PR

If change is related to an open issue template include at the top of your
description.
-->

Fixes: https://github.com/socallinuxexpo/scale-network/issues/593

Revert: https://github.com/socallinuxexpo/scale-network/commit/37a7a87b079161e308c5eddfc791a3d6e46e0fb4

Sets the necessary dhcp6 option `ntp-server` (56) and sub-option according to documention in kea: https://kea.readthedocs.io/en/kea-3.0.0/arm/dhcp6-srv.html#ntp-server-suboptions

## Previous Behavior

<!--
What was the behavior before this PR?

Remove this section if not relevant
-->

- Previously only dhcp4 had `ntp-servers` set

## New Behavior

<!--
What is the new behavior being introduced in this PR?

Remove this section if not relevant
-->

- ntp-servers are provided on both dhcp4 and dhcp6

## Tests

<!--
How was this PR tested? Please provide as much detail as possible
so we can ensure this change is working as intended before being merged.
-->

- Confirmed vmTest for core are passing and that config contains expected values:

```
{
  "Dhcp6": {
    "valid-lifetime": 1440,
    "min-valid-lifetime": 1440,
    "max-valid-lifetime": 1440,
    "interfaces-config": {
      "interfaces": [
        "@@INTERFACE@@",
        "@@INTERFACE@@/@@SERVERADDRESS@@"
      ],
      "service-sockets-max-retries": 5,
      "service-sockets-retry-wait-time": 5000
    },
    "lease-database": {
      "type": "memfile",
      "persist": true,
      "name": "/var/lib/kea/dhcp6.leases"
    },
    "option-data": [
      {
        "name": "dns-servers",
        "data": "2001:470:f026:103::20,2001:470:f026:503::20"
      },
      {
        "name": "ntp-server"
      },
      {
        "name": "ntp-server-address",
        "code": 1,
        "space": "v6-ntp-server-suboptions",
        "data": "2001:470:f026:103::20,2001:470:f026:503::20"
      },
      {
        "name": "domain-search",
        "data": "scale.lan"
      }
    ],
    "option-def": [],
    "reservations-global": true,
    "reservations-in-subnet": false,
    "reservations": [],
    "subnet6": [
      {
...
```