### PR TITLE
nixConfigurations.core: enable dhcp4 option 15

### DIFF
--- a/facts/inventory.py
+++ b/facts/inventory.py
@@ -459,6 +459,7 @@ def generatekeaconfig(servers, aps, vlans, outputdir):
                         [x["ipv4"] for x in servers if x["role"] == "core"]
                     ),
                 },
+                {"name": "domain-name", "data": "scale.lan"},
                 {"name": "domain-search", "data": "scale.lan"},
             ],
             "option-def": [

--- a/nix/checks/core.nix
+++ b/nix/checks/core.nix
@@ -148,6 +148,7 @@ in
           systemPackages = with pkgs; [
             ldns
             dig
+            scale-network.dhcptest
           ];
         };
       };
@@ -181,6 +182,10 @@ in
       client1.wait_until_succeeds("test ! -z \"$(drill -Q -z -x ${coremasterAddr.ipv4})\"")
       client1.succeed("test ! -z \"$(systemd-resolve -4 --search=true coreexpo)\"")
       client1.succeed("test ! -z \"$(systemd-resolve -6 --search=true coreexpo)\"")
+      client1.succeed("test ! -z \"$(dhcptest --query --iface eth1 --quiet --request 6 --print-only 6)\"")
+      client1.succeed("test ! -z \"$(dhcptest --query --iface eth1 --quiet --request 15 --print-only 15)\"")
+      client1.succeed("test ! -z \"$(dhcptest --query --iface eth1 --quiet --request 42 --print-only 42)\"")
+      client1.succeed("test ! -z \"$(dhcptest --query --iface eth1 --quiet --request 119 --print-only 119)\"")
     '';
 
   interactive.nodes =

--- a/nix/checks/core.nix
+++ b/nix/checks/core.nix
@@ -18,6 +18,8 @@ in
 {
   name = "core";
 
+  globalTimeout = 120;
+
   nodes = {
     # temporary router since we do not have the junipers for ipv6 router advertisement
     router =

--- a/nix/checks/core.nix
+++ b/nix/checks/core.nix
@@ -170,6 +170,7 @@ in
       coremaster.succeed("named-checkconf ${nodes.coremaster.services.bind.configFile}")
       client1.wait_until_succeeds("ping -c 5 ${coremasterAddr.ipv4}")
       client1.wait_until_succeeds("ping -c 5 -6 ${coremasterAddr.ipv6}")
+      client1.wait_until_succeeds("ping -c 5 coreexpo")
       client1.wait_until_succeeds("ip route show | grep default | grep -w ${routerAddr.ipv4}")
       # ensure that we got the correct prefix and suffix on dhcpv6
       client1.wait_until_succeeds("ip addr show dev eth1 | grep inet6 | grep ${chomp}:d8c")

--- a/nix/packages/default.nix
+++ b/nix/packages/default.nix
@@ -6,6 +6,7 @@ inputs.nixpkgs.lib.genAttrs
   ]
   (system: {
     inherit (inputs.self.legacyPackages.${system}.scale-network)
+      dhcptest
       makeDhcpd
       massflash
       scaleInventory

--- a/nix/packages/dhcptest/package.nix
+++ b/nix/packages/dhcptest/package.nix
@@ -1,0 +1,27 @@
+{
+  stdenv,
+  dmd,
+  fetchFromGitHub,
+}:
+
+stdenv.mkDerivation {
+  pname = "dhcptest";
+  version = "0.9-unstable-2024-03-20";
+
+  src = fetchFromGitHub {
+    owner = "CyberShadow";
+    repo = "dhcptest";
+    rev = "4807603943e7ab984964ad549aeb8b63e0b0b5a2";
+    hash = "sha256-KeICp8rum550lFNbeArWyCff9sDd9nxrbltVXi7yBvI=";
+  };
+
+  nativeBuildInputs = [ dmd ];
+
+  buildPhase = ''
+    dmd dhcptest.d
+  '';
+
+  installPhase = ''
+    install -Dt $out/bin dhcptest
+  '';
+}


### PR DESCRIPTION
## Description of PR

<!--
Brief description of the changes in PR

If change is related to an open issue template include at the top of your
description.
-->

Fixes: #906


## Previous Behavior

<!--
What was the behavior before this PR?

Remove this section if not relevant
-->

- Kea was only setting dhcp4 option 119 for search domain

## New Behavior

<!--
What is the new behavior being introduced in this PR?

Remove this section if not relevant
-->

- Kea needs to also add dhcp4 option 15 for completeness for the search domain

- Including a new package: `dhcptest` which allows for easy testing of DHCP options

- Testing options: `6,15,42,119`

## Tests

<!--
How was this PR tested? Please provide as much detail as possible
so we can ensure this change is working as intended before being merged.
-->

- `nix run .#checks.x86_64-linux.core.config.test.driver -L`
- Testing the failure case (when option 15 is missing):
```
...
client1: must succeed: test ! -z "$(dhcptest --query --iface eth1 --quiet --request 6 --print-only 6)"
coremaster # [   26.993767] kea-dhcp4[856]: 2025-09-15 22:41:01.394 INFO  [kea-dhcp4.dhcp4/856.140139258443456] DHCP4_QUERY_LABEL received query: [hwtype=1 5e:7a:96:cf:4e:42], cid=[no info], tid=0x377d004e
client1: (finished: must succeed: test ! -z "$(dhcptest --query --iface eth1 --quiet --request 6 --print-only 6)", in 0.03 seconds)
client1: must succeed: test ! -z "$(dhcptest --query --iface eth1 --quiet --request 15 --print-only 15)"
coremaster # [   26.995682] kea-dhcp4[856]: 2025-09-15 22:41:01.394 INFO  [kea-dhcp4.packets/856.140139258443456] DHCP4_PACKET_RECEIVED [hwtype=1 5e:7a:96:cf:4e:42], cid=[no info], tid=0x377d004e: DHCPDISCOVER (type 1) received from 10.0.3.80 to 255.255.255.255 on interface eth1
coremaster # [   26.998088] kea-dhcp4[856]: 2025-09-15 22:41:01.394 INFO  [kea-dhcp4.leases/856.140139258443456] DHCP4_LEASE_OFFER [hwtype=1 5e:7a:96:cf:4e:42], cid=[no info], tid=0x377d004e: lease 10.0.3.81 will be offered
coremaster # [   27.000024] kea-dhcp4[856]: 2025-09-15 22:41:01.394 INFO  [kea-dhcp4.packets/856.140139258443456] DHCP4_PACKET_SEND [hwtype=1 5e:7a:96:cf:4e:42], cid=[no info], tid=0x377d004e: trying to send packet DHCPOFFER (type 2) from 10.0.3.20:67 to 255.255.255.255:68 on interface eth1
coremaster # [   27.013125] kea-dhcp4[856]: 2025-09-15 22:41:01.413 INFO  [kea-dhcp4.dhcp4/856.140139258443456] DHCP4_QUERY_LABEL received query: [hwtype=1 2e:69:5b:a2:4e:2a], cid=[no info], tid=0x2dda8ddc
client1: output:
!!! Traceback (most recent call last):
!!!   File "<string>", line 22, in <module>
!!!     client1.succeed("test ! -z \"$(dhcptest --query --iface eth1 --quiet --request 15 --print-only 15)\"")
!!!
!!! RequestedAssertionFailed: command `test ! -z "$(dhcptest --query --iface eth1 --quiet --request 15 --print-only 15)"` failed (exit code 1)
cleanup
kill machine (pid 201692)
qemu-system-x86_64: terminating on signal 15 from pid 201609 (/nix/store/iyff8129iampdw13nlfqalzhxy8y1hi9-python3-3.13.6/bin/python3.13)
coremaster # [   27.014995] kea-dhcp4[856]: 2025-09-15 22:41:01.413 INFO  [kea-dhcp4.packets/856.140139258443456] DHCP4_PACKET_RECEIVED [hwtype=1 2e:69:5b:a2:4e:2a], cid=[no info], tid=0x2dda8ddc: DHCPDISCOVER (type 1) received from 10.0.3.80 to 255.255.255.255 on interface eth1
coremaster # [   27.017461] kea-dhcp4[856]: 2025-09-15 22:41:01.413 INFO  [kea-dhcp4.leases/856.140139258443456] DHCP4_LEASE_OFFER [hwtype=1 2e:69:5b:a2:4e:2a], cid=[no info], tid=0x2dda8ddc: lease 10.0.3.82 will be offered
kill machine (pid 201720)
qemu-system-x86_64: terminating on signal 15 from pid 201609 (/nix/store/iyff8129iampdw13nlfqalzhxy8y1hi9-python3-3.13.6/bin/python3.13)
coremaster # [   27.019567] kea-dhcp4[856]: 2025-09-15 22:41:01.413 INFO  [kea-dhcp4.packets/856.140139258443456] DHCP4_PACKET_SEND [hwtype=1 2e:69:5b:a2:4e:2a], cid=[no info], tid=0x2dda8ddc: trying to send p
kill machine (pid 201745)
qemu-system-x86_64: terminating on signal 15 from pid 201609 (/nix/store/iyff8129iampdw13nlfqalzhxy8y1hi9-python3-3.13.6/bin/python3.13)
kill vlan (pid 201690)
(finished: cleanup, in 0.01 seconds)
```