### PR TITLE
nix: Adds routers skeleton

### DIFF
--- a/nix/checks/default.nix
+++ b/nix/checks/default.nix
@@ -56,6 +56,8 @@ genAttrs
     in
     {
       core = pkgs.testers.runNixOSTest (import ./core.nix { inherit inputs lib; });
+      routers = pkgs.testers.runNixOSTest (import ./routers.nix { inherit inputs lib; });
+      router-border = pkgs.testers.runNixOSTest (import ./router-border.nix { inherit inputs lib; });
       loghost = pkgs.testers.runNixOSTest (import ./loghost.nix { inherit inputs; });
       monitor = pkgs.testers.runNixOSTest (import ./monitor.nix { inherit inputs; });
       # impure test and needs to pull container

--- a/nix/checks/router-border.nix
+++ b/nix/checks/router-border.nix
@@ -1,0 +1,35 @@
+{ inputs, lib }:
+{
+  name = "borderrouter";
+
+  nodes = {
+    borderrouter =
+      { lib, ... }:
+      {
+        _module.args = {
+          inherit inputs;
+        };
+        imports = [
+          inputs.self.nixosModules.default
+        ];
+
+        virtualisation.vlans = [
+          1
+          2
+          3
+        ];
+        scale-network = {
+          router.border.enable = true;
+        };
+      };
+  };
+
+  testScript =
+    { nodes, ... }:
+
+    ''
+      start_all()
+      print(borderrouter.succeed("ip -br addr show"))
+    '';
+
+}

--- a/nix/checks/routers.nix
+++ b/nix/checks/routers.nix
@@ -1,0 +1,81 @@
+# This test sets up all the routers and ensures that the network configs are
+# picked up correctly and connectivity works as expected.
+{ inputs, lib }:
+{
+  name = "routers";
+
+  nodes = {
+    border =
+      { lib, ... }:
+      {
+        _module.args = {
+          inherit inputs;
+        };
+        imports = [
+          inputs.self.nixosModules.default
+        ];
+        virtualisation.vlans = [
+          2 # border <-> conference
+          3 # border <-> expo
+        ];
+        scale-network = {
+          router.border.enable = true;
+        };
+      };
+    conference =
+      { lib, ... }:
+      {
+        _module.args = {
+          inherit inputs;
+        };
+        imports = [
+          inputs.self.nixosModules.default
+        ];
+        virtualisation.vlans = [
+          2 # border <-> conference
+          4 # conference <-> expo
+        ];
+        scale-network = {
+          router.conference.enable = true;
+        };
+      };
+    expo =
+      { lib, ... }:
+      {
+        _module.args = {
+          inherit inputs;
+        };
+        imports = [
+          inputs.self.nixosModules.default
+        ];
+        virtualisation.vlans = [
+          3 # border <-> expo
+          4 # conference <-> expo
+        ];
+        scale-network = {
+          router.expo.enable = true;
+        };
+      };
+  };
+
+  testScript =
+    { nodes, ... }:
+    ''
+      start_all()
+      border.wait_for_unit("multi-user.target")
+      conference.wait_for_unit("multi-user.target")
+      expo.wait_for_unit("multi-user.target")
+
+      # border can hit both routers
+      border.succeed("ping -c 5 10.1.1.2")
+      border.succeed("ping -c 5 10.1.2.3")
+
+      # conference should hit neighbors
+      conference.succeed("ping -c 5 10.1.1.1")
+      conference.succeed("ping -c 5 10.1.3.3")
+
+      # expo should hit neighbors
+      expo.succeed("ping -c 5 10.1.2.1")
+      expo.succeed("ping -c 5 10.1.3.2")
+    '';
+}

--- a/nix/nixos-configurations/router-border/README.md
+++ b/nix/nixos-configurations/router-border/README.md
@@ -1,0 +1,27 @@
+# Router features to implement
+
+- [ ] SSH Server
+- [ ] Logging
+- [ ] nftables
+  - [ ] MSS clamping
+  - [ ] NAT
+- [ ] IPv6 Router Advertisement
+- [ ] LLDP
+- [ ] Ipv6 tunnel broker
+
+# Things to remember
+
+- [ ] Increase size of neighbor tables. This is important because we are operating a larged bridged network that will fill up these caches pretty easily.
+- [ ] Add monitoring for neighbor table size
+
+# Things to Monitor
+
+- [ ] NAT port usage
+
+# Running the VM with multiple interfaces
+
+```
+./result/bin/run-router-border-vm \
+    -netdev user,id=net1 -device virtio-net-pci,netdev=net1,mac=52:54:00:12:00:02 \
+    -netdev user,id=net2 -device virtio-net-pci,netdev=net2,mac=52:54:00:12:00:03
+```

--- a/nix/nixos-configurations/router-border/configuration.nix
+++ b/nix/nixos-configurations/router-border/configuration.nix
@@ -1,0 +1,8 @@
+{
+  ...
+}:
+{
+  scale-network = {
+    router.border.enable = true;
+  };
+}

--- a/nix/nixos-configurations/router-border/default.nix
+++ b/nix/nixos-configurations/router-border/default.nix
@@ -1,0 +1,22 @@
+{
+  release = "unstable";
+
+  modules =
+    {
+      config,
+      lib,
+      ...
+    }:
+    {
+      imports = [
+        ./configuration.nix
+        ./hardware-configuration.nix
+        ./disko.nix
+      ];
+
+      config = {
+        nixpkgs.hostPlatform = "x86_64-linux";
+        networking.hostName = "router-border";
+      };
+    };
+}

--- a/nix/nixos-configurations/router-border/disko.nix
+++ b/nix/nixos-configurations/router-border/disko.nix
@@ -1,0 +1,101 @@
+# TODO Setup real disk config
+{
+  disko.devices = {
+    disk = {
+      one = {
+        type = "disk";
+        device = "/dev/disk/by-path/pci-0000:10:00.0-scsi-0:0:10:0";
+        content = {
+          type = "gpt";
+          partitions = {
+            ESP = {
+              size = "512M";
+              type = "EF00";
+              content = {
+                type = "filesystem";
+                format = "vfat";
+                mountpoint = "/boot";
+              };
+            };
+            zfs = {
+              size = "100%";
+              content = {
+                type = "zfs";
+                pool = "tank0";
+              };
+            };
+          };
+        };
+      };
+      two = {
+        type = "disk";
+        device = "/dev/disk/by-path/pci-0000:10:00.0-scsi-0:0:9:0";
+        content = {
+          type = "gpt";
+          partitions = {
+            # Support multiple disks to boot from
+            ESP = {
+              size = "512M";
+              type = "EF00";
+              content = {
+                type = "filesystem";
+                format = "vfat";
+                mountpoint = "/boot2";
+              };
+            };
+            zfs = {
+              size = "100%";
+              content = {
+                type = "zfs";
+                pool = "tank0";
+              };
+            };
+          };
+        };
+      };
+    };
+    zpool = {
+      tank0 = {
+        type = "zpool";
+        mode = "mirror";
+        # Workaround: cannot import 'tank0': I/O error in disko tests
+        options.cachefile = "none";
+        rootFsOptions = {
+          compression = "zstd";
+          "com.sun:auto-snapshot" = "true";
+          acltype = "posixacl";
+          xattr = "sa";
+          canmount = "off";
+          mountpoint = "none";
+        };
+        options = {
+          ashift = "12";
+          autotrim = "on";
+        };
+
+        datasets = {
+          "root" = {
+            type = "zfs_fs";
+            mountpoint = "/";
+            options.mountpoint = "legacy";
+          };
+          "home" = {
+            type = "zfs_fs";
+            mountpoint = "/home";
+            options.mountpoint = "legacy";
+          };
+          "nix" = {
+            type = "zfs_fs";
+            mountpoint = "/nix";
+            options.mountpoint = "legacy";
+          };
+          "persist" = {
+            type = "zfs_fs";
+            mountpoint = "/persist";
+            options.mountpoint = "legacy";
+          };
+        };
+      };
+    };
+  };
+}

--- a/nix/nixos-configurations/router-border/hardware-configuration.nix
+++ b/nix/nixos-configurations/router-border/hardware-configuration.nix
@@ -1,0 +1,51 @@
+{
+  config,
+  lib,
+  modulesPath,
+  ...
+}:
+
+{
+  imports = [
+    (modulesPath + "/installer/scan/not-detected.nix")
+  ];
+
+  # *sas drivers required for Lenovo System x3650 M5 Machine Type: 8871AC1
+  boot.initrd.availableKernelModules = [
+    "ehci_pci"
+    "ahci"
+    "usbhid"
+    "usb_storage"
+    "sd_mod"
+    "mpt3sas"
+    "megaraid_sas"
+  ];
+  boot.initrd.kernelModules = [ ];
+  boot.kernelModules = [ "kvm-intel" ];
+  boot.extraModulePackages = [ ];
+
+  swapDevices = [ ];
+
+  nixpkgs.hostPlatform = lib.mkDefault "x86_64-linux";
+  hardware.cpu.intel.updateMicrocode = lib.mkDefault config.hardware.enableRedistributableFirmware;
+
+  boot.loader.grub = {
+    enable = true;
+    efiSupport = true;
+    efiInstallAsRemovable = true;
+    mirroredBoots = [
+      {
+        devices = [ "nodev" ];
+        path = "/boot";
+      }
+      {
+        devices = [ "nodev" ];
+        path = "/boot2";
+      }
+    ];
+  };
+
+  # ZFS uniq system ID
+  # to generate: head -c4 /dev/urandom | od -A none -t x4
+  networking.hostId = "7cb3bf5b";
+}

--- a/nix/nixos-modules/default.nix
+++ b/nix/nixos-modules/default.nix
@@ -9,6 +9,7 @@ inputs: {
         ./time.nix
         ./services
         ./users
+        ./routers
       ];
     };
 }

--- a/nix/nixos-modules/routers/border.nix
+++ b/nix/nixos-modules/routers/border.nix
@@ -1,0 +1,60 @@
+{
+  config,
+  lib,
+  ...
+}:
+
+let
+  cfg = config.scale-network.router.border;
+  inherit (lib.modules)
+    mkIf
+    ;
+
+  inherit (lib.options)
+    mkEnableOption
+    ;
+in
+{
+  options.scale-network.router.border.enable = mkEnableOption "SCaLE network border router setup";
+
+  config = mkIf cfg.enable {
+    networking.useNetworkd = true;
+    systemd.services.systemd-networkd.environment.SYSTEMD_LOG_LEVEL = "debug";
+
+    boot.kernel.sysctl = {
+      "net.ipv4.conf.all.forwarding" = true;
+      "net.ipv6.conf.all.forwarding" = true;
+    };
+
+    # Physical link to Internet
+    systemd.network.networks."10-inet" = {
+      matchConfig.Name = "eth0";
+      networkConfig.DHCP = true;
+    };
+    # Physical link to conference center
+    systemd.network.networks."10-expo" = {
+      matchConfig.Name = "eth1";
+      networkConfig.DHCP = false;
+      address = [
+        "10.1.1.1/24"
+      ];
+    };
+    # Physical link to expo hall
+    systemd.network.networks."10-cf" = {
+      matchConfig.Name = "eth2";
+      networkConfig.DHCP = false;
+      address = [
+        "10.1.2.1/24"
+      ];
+    };
+    # Physical link to cf Firewall
+    systemd.network.networks."10-cffw" = {
+      matchConfig.Name = "eth3";
+      networkConfig.DHCP = false;
+    };
+
+    networking.nftables.rulesetFile = "";
+
+    system.stateVersion = "25.11";
+  };
+}

--- a/nix/nixos-modules/routers/conference.nix
+++ b/nix/nixos-modules/routers/conference.nix
@@ -1,0 +1,47 @@
+{
+  config,
+  lib,
+  ...
+}:
+
+let
+  cfg = config.scale-network.router.conference;
+
+  inherit (lib.modules)
+    mkIf
+    ;
+
+  inherit (lib.options)
+    mkEnableOption
+    ;
+in
+{
+  options.scale-network.router.conference.enable =
+    mkEnableOption "SCaLE network conference router setup";
+
+  config = mkIf cfg.enable {
+    networking.useNetworkd = true;
+    systemd.services.systemd-networkd.environment.SYSTEMD_LOG_LEVEL = "debug";
+
+    boot.kernel.sysctl = {
+      "net.ipv4.conf.all.forwarding" = true;
+      "net.ipv6.conf.all.forwarding" = true;
+    };
+    # Physical link to border
+    systemd.network.networks."10-border" = {
+      matchConfig.Name = "eth1";
+      networkConfig.DHCP = false;
+      address = [
+        "10.1.1.2/24"
+      ];
+    };
+    # Physical link to expo
+    systemd.network.networks."10-expo" = {
+      matchConfig.Name = "eth2";
+      networkConfig.DHCP = false;
+      address = [
+        "10.1.3.2/24"
+      ];
+    };
+  };
+}

--- a/nix/nixos-modules/routers/default.nix
+++ b/nix/nixos-modules/routers/default.nix
@@ -1,0 +1,8 @@
+{ ... }:
+{
+  imports = [
+    ./border.nix
+    ./conference.nix
+    ./expo.nix
+  ];
+}

--- a/nix/nixos-modules/routers/expo.nix
+++ b/nix/nixos-modules/routers/expo.nix
@@ -1,0 +1,43 @@
+{ config, lib, ... }:
+
+let
+  cfg = config.scale-network.router.expo;
+  inherit (lib.modules)
+    mkIf
+    ;
+
+  inherit (lib.options)
+    mkEnableOption
+    ;
+in
+{
+
+  options.scale-network.router.expo.enable = mkEnableOption "SCaLE network expo router setup";
+
+  config = mkIf cfg.enable {
+    networking.useNetworkd = true;
+    systemd.services.systemd-networkd.environment.SYSTEMD_LOG_LEVEL = "debug";
+
+    boot.kernel.sysctl = {
+      "net.ipv4.conf.all.forwarding" = true;
+      "net.ipv6.conf.all.forwarding" = true;
+    };
+
+    # Physical link to border
+    systemd.network.networks."10-border" = {
+      matchConfig.Name = "eth1";
+      networkConfig.DHCP = false;
+      address = [
+        "10.1.2.3/24"
+      ];
+    };
+    # Physical link to expo
+    systemd.network.networks."10-expo" = {
+      matchConfig.Name = "eth2";
+      networkConfig.DHCP = false;
+      address = [
+        "10.1.3.3/24"
+      ];
+    };
+  };
+}


### PR DESCRIPTION
## Description of PR

Adds base layout for working on nixos based routers. I went with a structure of each router config lives in a nixos module (`nixos-modules/routers`) and that module can then be included in a nixos-configuration and a nixos test. This pr just contains the absolute basics of creating the modules with multiple interfaces and assigns some ips to those interfaces. Included is also a test that brings up all the routers and ensures they can ping each other.

This should be a good jumping off point for us to develop the more advanced features and config that we will need.