### PR TITLE
[READY] nix.pkgs.mac2eui64: init

### DIFF
--- a/nix/dev-shells/default.nix
+++ b/nix/dev-shells/default.nix
@@ -30,6 +30,7 @@ inputs.nixpkgs.lib.genAttrs
         tio
         screen
         glibcLocales
+        scale-network.mac2eui64
       ];
 
       openwrtSub = with pkgs; [

--- a/nix/packages/default.nix
+++ b/nix/packages/default.nix
@@ -7,6 +7,7 @@ inputs.nixpkgs.lib.genAttrs
   (system: {
     inherit (inputs.self.legacyPackages.${system}.scale-network)
       dhcptest
+      mac2eui64
       makeDhcpd
       massflash
       scaleInventory

--- a/nix/packages/mac2eui64/mac2eui64.py
+++ b/nix/packages/mac2eui64/mac2eui64.py
@@ -4,26 +4,29 @@ import ipaddress
 import re
 import sys
 
+
 def mac2eui64(mac, prefix=None):
-    '''
+    """
     Convert a MAC address to a EUI64 address
     or, with prefix provided, a full IPv6 address
-    '''
+    """
     # http://tools.ietf.org/html/rfc4291#section-2.5.1
-    eui64 = re.sub(r'[.:-]', '', mac).lower()
-    eui64 = eui64[0:6] + 'fffe' + eui64[6:]
+    eui64 = re.sub(r"[.:-]", "", mac).lower()
+    eui64 = eui64[0:6] + "fffe" + eui64[6:]
     eui64 = hex(int(eui64[0:2], 16) ^ 2)[2:].zfill(2) + eui64[2:]
 
     if prefix is None:
-        return ':'.join(re.findall(r'.{4}', eui64))
+        return ":".join(re.findall(r".{4}", eui64))
     else:
         try:
             net = ipaddress.ip_network(prefix, strict=False)
-            euil = int('0x{0}'.format(eui64), 16)
+            euil = int("0x{0}".format(eui64), 16)
             return str(net[euil])
-        except:  # pylint: disable=bare-except
+        except:  # noqa: E722
             return
+
+
 if len(sys.argv) == 3:
-  print(mac2eui64(mac=sys.argv[1], prefix=sys.argv[2]))
+    print(mac2eui64(mac=sys.argv[1], prefix=sys.argv[2]))
 else:
-  print(mac2eui64(mac= sys.argv[1] ))
+    print(mac2eui64(mac=sys.argv[1]))

--- a/nix/packages/mac2eui64/mac2eui64.py
+++ b/nix/packages/mac2eui64/mac2eui64.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python3
+
+import ipaddress
+import re
+import sys
+
+def mac2eui64(mac, prefix=None):
+    '''
+    Convert a MAC address to a EUI64 address
+    or, with prefix provided, a full IPv6 address
+    '''
+    # http://tools.ietf.org/html/rfc4291#section-2.5.1
+    eui64 = re.sub(r'[.:-]', '', mac).lower()
+    eui64 = eui64[0:6] + 'fffe' + eui64[6:]
+    eui64 = hex(int(eui64[0:2], 16) ^ 2)[2:].zfill(2) + eui64[2:]
+
+    if prefix is None:
+        return ':'.join(re.findall(r'.{4}', eui64))
+    else:
+        try:
+            net = ipaddress.ip_network(prefix, strict=False)
+            euil = int('0x{0}'.format(eui64), 16)
+            return str(net[euil])
+        except:  # pylint: disable=bare-except
+            return
+if len(sys.argv) == 3:
+  print(mac2eui64(mac=sys.argv[1], prefix=sys.argv[2]))
+else:
+  print(mac2eui64(mac= sys.argv[1] ))

--- a/nix/packages/mac2eui64/package.nix
+++ b/nix/packages/mac2eui64/package.nix
@@ -1,0 +1,18 @@
+{
+  pkgs,
+  lib,
+}:
+let
+  inherit (pkgs.writers)
+    writePython3Bin
+    ;
+  inherit (lib.strings)
+    removePrefix
+    ;
+
+  scriptContent = builtins.readFile ./mac2eui64.py;
+  scriptNoShebang = removePrefix "#!/usr/bin/env python3\n" scriptContent;
+in
+writePython3Bin "mac2eui64" {
+  doCheck = true;
+} scriptNoShebang


### PR DESCRIPTION
## Description of PR

<!--
Brief description of the changes in PR

If change is related to an open issue template include at the top of your
description.
-->

Supersedes: #955

Everything else releated to #955 was corrected as part of #972

We have had to generate the eui64 values before so this script should be kept for the next time we have to do such converstions. 

## Previous Behavior

<!--
What was the behavior before this PR?

Remove this section if not relevant
-->

- No standard way of converting from mac to eui64

## New Behavior

<!--
What is the new behavior being introduced in this PR?

Remove this section if not relevant
-->

- `mac2eui64` is available in the default devShell

## Tests

<!--
How was this PR tested? Please provide as much detail as possible
so we can ensure this change is working as intended before being merged.
-->

- confirming that `mac2eui64` works and is able to locate an existing entry in `facts/pi/pis.csv`

``` 
$ nix run .#mac2eui64 dc:a6:32:41:79:6a
dea6:32ff:fe41:796a
$ ag dea6:32ff:fe41:796a
facts/pi/pis.csv
2:pi4-001,dc:a6:32:41:79:6a,dea6:32ff:fe41:796a
```
