### PR TITLE
treewide: use mapAttrs on a flake output over genAttrs everywhere

### DIFF
--- a/nix/dev-shells/default.nix
+++ b/nix/dev-shells/default.nix
@@ -1,87 +1,96 @@
 inputs:
-inputs.nixpkgs.lib.genAttrs
-  [
-    "x86_64-linux"
-    "aarch64-linux"
-  ]
-  (
-    system:
-    let
-      pkgs = inputs.self.legacyPackages.${system};
+let
 
-      scalePython = [
-        (pkgs.python3.withPackages (
-          ps: with ps; [
-            pytest
-            pylint
-            ipdb
-            jinja2
-            pandas
-          ]
-        ))
-      ];
+  inherit (inputs.nixpkgs)
+    lib
+    ;
 
-      global = with pkgs; [
-        bash
-        curl
-        fish
-        git
-        jq
-        tio
-        screen
-        glibcLocales
-        scale-network.mac2eui64
-      ];
+  inherit (lib.attrsets)
+    mapAttrs
+    ;
 
-      openwrtSub = with pkgs; [
-        dnsmasq
-        expect
-        gomplate
-        magic-wormhole
-        tftp-hpa
-        nettools
-        unixtools.ping
-        iperf3
-        ncurses
-        ncurses.dev
-        pkg-config
-        gcc
-        stdenv
-        scale-network.makeDhcpd
-        scale-network.serverspec
-      ];
+  inherit (lib.trivial)
+    const
+    ;
 
-      networkSub = with pkgs; [
-        perl
-        perlPackages.libnet
-        perlPackages.Expect
-        perlPackages.TermReadKey
-        perlPackages.NetSFTPForeign
-        scale-network.perlNetArp
-        scale-network.perlNetInterface
-        scale-network.perlNetPing
-        ghostscript
-      ];
-    in
-    {
-      scalePython = pkgs.mkShellNoCC {
-        packages = scalePython;
-      };
+in
+mapAttrs (const (
+  pkgs:
+  let
 
-      global = pkgs.mkShellNoCC {
-        packages = global;
-      };
+    scalePython = [
+      (pkgs.python3.withPackages (
+        ps: with ps; [
+          pytest
+          pylint
+          ipdb
+          jinja2
+          pandas
+        ]
+      ))
+    ];
 
-      openwrtSub = pkgs.mkShellNoCC {
-        packages = openwrtSub;
-      };
+    global = with pkgs; [
+      bash
+      curl
+      fish
+      git
+      jq
+      tio
+      screen
+      glibcLocales
+      scale-network.mac2eui64
+    ];
 
-      networkSub = pkgs.mkShellNoCC {
-        packages = networkSub;
-      };
+    openwrtSub = with pkgs; [
+      dnsmasq
+      expect
+      gomplate
+      magic-wormhole
+      tftp-hpa
+      nettools
+      unixtools.ping
+      iperf3
+      ncurses
+      ncurses.dev
+      pkg-config
+      gcc
+      stdenv
+      scale-network.makeDhcpd
+      scale-network.serverspec
+    ];
 
-      default = pkgs.mkShellNoCC {
-        packages = (scalePython ++ global ++ openwrtSub ++ networkSub);
-      };
-    }
-  )
+    networkSub = with pkgs; [
+      perl
+      perlPackages.libnet
+      perlPackages.Expect
+      perlPackages.TermReadKey
+      perlPackages.NetSFTPForeign
+      scale-network.perlNetArp
+      scale-network.perlNetInterface
+      scale-network.perlNetPing
+      ghostscript
+    ];
+  in
+  {
+    scalePython = pkgs.mkShellNoCC {
+      packages = scalePython;
+    };
+
+    global = pkgs.mkShellNoCC {
+      packages = global;
+    };
+
+    openwrtSub = pkgs.mkShellNoCC {
+      packages = openwrtSub;
+    };
+
+    networkSub = pkgs.mkShellNoCC {
+      packages = networkSub;
+    };
+
+    default = pkgs.mkShellNoCC {
+      packages = (scalePython ++ global ++ openwrtSub ++ networkSub);
+    };
+  }
+)) inputs.self.legacyPackages

--- a/nix/formatter/default.nix
+++ b/nix/formatter/default.nix
@@ -1,7 +1,17 @@
 inputs:
-inputs.nixpkgs-unstable.lib.genAttrs [
-  "x86_64-linux"
-  "aarch64-linux"
-  "x86_64-darwin"
-  "aarch64-darwin"
-] (system: inputs.self.formatterModule.${system}.config.build.wrapper)
+let
+
+  inherit (inputs.nixpkgs)
+    lib
+    ;
+
+  inherit (lib.attrsets)
+    mapAttrs
+    ;
+
+  inherit (lib.trivial)
+    const
+    ;
+
+in
+mapAttrs (const (module: module.config.build.wrapper)) inputs.self.formatterModule

--- a/nix/formatterModule/default.nix
+++ b/nix/formatterModule/default.nix
@@ -1,22 +1,27 @@
 inputs:
-inputs.nixpkgs-unstable.lib.genAttrs
-  [
-    "x86_64-linux"
-    "aarch64-linux"
-    "x86_64-darwin"
-    "aarch64-darwin"
-  ]
-  (
-    system:
-    let
-      pkgs = inputs.nixpkgs-unstable.legacyPackages.${system};
-    in
-    (inputs.treefmt-nix.lib.evalModule pkgs {
-      projectRootFile = "flake.nix";
-      programs.nixfmt.enable = true;
-      programs.ruff-format.enable = true;
-      programs.ruff-check.enable = true;
-      programs.mdformat.enable = true;
-      programs.yamlfmt.enable = true;
-    })
-  )
+let
+
+  inherit (inputs.nixpkgs)
+    lib
+    ;
+
+  inherit (lib.attrsets)
+    mapAttrs
+    ;
+
+  inherit (lib.trivial)
+    const
+    ;
+
+in
+mapAttrs (const (
+  pkgs:
+  (inputs.treefmt-nix.lib.evalModule pkgs {
+    projectRootFile = "flake.nix";
+    programs.nixfmt.enable = true;
+    programs.ruff-format.enable = true;
+    programs.ruff-check.enable = true;
+    programs.mdformat.enable = true;
+    programs.yamlfmt.enable = true;
+  })
+)) inputs.self.legacyPackages

--- a/nix/legacy-packages/default.nix
+++ b/nix/legacy-packages/default.nix
@@ -1,8 +1,10 @@
 inputs:
 inputs.nixpkgs.lib.genAttrs
   [
-    "x86_64-linux"
+    "aarch64-darwin"
     "aarch64-linux"
+    "x86_64-darwin"
+    "x86_64-linux"
   ]
   (
     system:

--- a/nix/packages/default.nix
+++ b/nix/packages/default.nix
@@ -1,19 +1,29 @@
 inputs:
-inputs.nixpkgs.lib.genAttrs
-  [
-    "x86_64-linux"
-    "aarch64-linux"
-  ]
-  (system: {
-    inherit (inputs.self.legacyPackages.${system}.scale-network)
-      dhcptest
-      mac2eui64
-      makeDhcpd
-      massflash
-      scaleInventory
-      serverspec
-      perlNetArp
-      perlNetInterface
-      perlNetPing
-      ;
-  })
+let
+
+  inherit (inputs.nixpkgs)
+    lib
+    ;
+
+  inherit (lib.attrsets)
+    mapAttrs
+    ;
+
+  inherit (lib.trivial)
+    const
+    ;
+
+in
+mapAttrs (const (pkgs: {
+  inherit (pkgs.scale-network)
+    dhcptest
+    mac2eui64
+    makeDhcpd
+    massflash
+    scaleInventory
+    serverspec
+    perlNetArp
+    perlNetInterface
+    perlNetPing
+    ;
+})) inputs.self.legacyPackages


### PR DESCRIPTION
The cleans up re-defining list of systems everywhere.

_Should_ be a no-op.