### PR TITLE
[READY] Add v6 OSPF to frr.nix

### DIFF
--- a/nix/nixos-modules/services/frr.nix
+++ b/nix/nixos-modules/services/frr.nix
@@ -50,10 +50,12 @@ in
          passive-interface default
          network 10.0.0.0/8 area 0
          redistribute connected
+         redistribute static
         exit
         router ospf6
          passive-interface default
          redistribute connected
+         redistribute static
         exit
       '';
     };


### PR DESCRIPTION
## Description of PR

Add v6 OSPF config to FRR

## Previous Behavior

No v6 OSPF config existed for FRR

## New Behavior

Setup OSPFv3 (OSPF6) in FRR

-------------------------------------------------

My concern here is, I cannot find any FRR documentation for...

```
fast-reroute per-prefix
    enable
    keep-all-paths
```