### PR TITLE
Allow deployments by non-root user

### DIFF
--- a/nix/nixos-modules/base.nix
+++ b/nix/nixos-modules/base.nix
@@ -27,6 +27,9 @@ in
       experimental-features = nix-command flakes
     '';
 
+    # Enable deployments by non-root user.
+    nix.settings.trusted-users = [ "@wheel" ];
+
     environment.systemPackages = with pkgs; [
       bc
       binutils


### PR DESCRIPTION
This is nice if you're trying to do a remote deploy (build on your laptop, deploy to a remote machine).