### PR TITLE
[READY] treewide: use nixpkgs-lib for access to lib functions

### DIFF
--- a/nix/checks/default.nix
+++ b/nix/checks/default.nix
@@ -1,7 +1,7 @@
 inputs:
 let
   # inherits
-  inherit (inputs.nixpkgs)
+  inherit (inputs.nixpkgs-lib)
     lib
     ;
 

--- a/nix/dev-shells/default.nix
+++ b/nix/dev-shells/default.nix
@@ -1,7 +1,7 @@
 inputs:
 let
 
-  inherit (inputs.nixpkgs)
+  inherit (inputs.nixpkgs-lib)
     lib
     ;
 

--- a/nix/formatter/default.nix
+++ b/nix/formatter/default.nix
@@ -1,7 +1,7 @@
 inputs:
 let
 
-  inherit (inputs.nixpkgs)
+  inherit (inputs.nixpkgs-lib)
     lib
     ;
 

--- a/nix/formatterModule/default.nix
+++ b/nix/formatterModule/default.nix
@@ -1,7 +1,7 @@
 inputs:
 let
 
-  inherit (inputs.nixpkgs)
+  inherit (inputs.nixpkgs-lib)
     lib
     ;
 

--- a/nix/legacy-packages/default.nix
+++ b/nix/legacy-packages/default.nix
@@ -1,5 +1,5 @@
 inputs:
-inputs.nixpkgs.lib.genAttrs
+inputs.nixpkgs-lib.lib.genAttrs
   [
     "aarch64-darwin"
     "aarch64-linux"

--- a/nix/nixos-modules/default.nix
+++ b/nix/nixos-modules/default.nix
@@ -1,7 +1,7 @@
 inputs:
 let
 
-  inherit (inputs.nixpkgs)
+  inherit (inputs.nixpkgs-lib)
     lib
     ;
 

--- a/nix/overlays/default.nix
+++ b/nix/overlays/default.nix
@@ -7,7 +7,7 @@ let
     attrValues
     ;
 
-  inherit (inputs.nixpkgs-unstable)
+  inherit (inputs.nixpkgs-lib)
     lib
     ;
 

--- a/nix/packages/default.nix
+++ b/nix/packages/default.nix
@@ -1,7 +1,7 @@
 inputs:
 let
 
-  inherit (inputs.nixpkgs)
+  inherit (inputs.nixpkgs-lib)
     lib
     ;
 


### PR DESCRIPTION
Does not include `nixos-configurations` because I did that in https://github.com/socallinuxexpo/scale-network/pull/996