### PR TITLE
[READY] gha.ci-nixos: exclude massflashPi from build

### DIFF
--- a/.github/workflows/ci-nixos.yml
+++ b/.github/workflows/ci-nixos.yml
@@ -19,8 +19,9 @@ jobs:
       - uses: DeterminateSystems/magic-nix-cache-action@main
       - name: Get all NixOS configurations
         id: nixosconfigsget
+        # get all nixosConfigurations except for massflashPi since its aarch64
         run: |
-          nixosconfignames=$(nix eval .\#nixosConfigurations --apply builtins.attrNames --json)
+          nixosconfignames=$(nix eval .\#nixosConfigurations --apply builtins.attrNames --json | jq -c '. - ["massflashPi"]')
           echo "$nixosconfignames"
           echo "nixosconfignames=$nixosconfignames" >> $GITHUB_OUTPUT
   nixos_configs_build:


### PR DESCRIPTION
## Description of PR

Currently jobs are failing with the introduction of massflash-pi: https://github.com/socallinuxexpo/scale-network/pull/997 since the assumption was always x86_64 for this CI job. 

<!--
Brief description of the changes in PR

If change is related to an open issue template include at the top of your
description.
-->

## Previous Behavior

- failing build: https://github.com/socallinuxexpo/scale-network/actions/runs/19338787705/job/55321385150
<!--
What was the behavior before this PR?

Remove this section if not relevant
-->

## New Behavior

- Omit `nixosConfiguration.massflashPi`

<!--
What is the new behavior being introduced in this PR?

Remove this section if not relevant
-->

## Tests
- https://github.com/socallinuxexpo/scale-network/actions/runs/19345736471 passes since it omits `massflashPi`
<!--
How was this PR tested? Please provide as much detail as possible
so we can ensure this change is working as intended before being merged.
-->
