### PR TITLE
[READY] - nixosConfigurations.dev-server: enable binfmt aarch64-linux

### DIFF
--- a/nix/nixos-configurations/dev-server/default.nix
+++ b/nix/nixos-configurations/dev-server/default.nix
@@ -41,6 +41,8 @@
           experimental-features = nix-command flakes
         '';
 
+        boot.binfmt.emulatedSystems = [ "aarch64-linux" ];
+
         networking = {
           useNetworkd = true;
           useDHCP = false;


### PR DESCRIPTION
## Description of PR

<!--
Brief description of the changes in PR

If change is related to an open issue template include at the top of your
description.
-->

Allows for building arm64 binaries on the `dev-server`


## Tests

- `rebuild-switch` and confirmed functionality in `dev-server`
<!--
How was this PR tested? Please provide as much detail as possible
so we can ensure this change is working as intended before being merged.
-->
