### PR TITLE
[READY] - gha.ci-nixos: correct ignore for massflash-pi attr

### DIFF
--- a/.github/workflows/ci-nixos.yml
+++ b/.github/workflows/ci-nixos.yml
@@ -21,7 +21,7 @@ jobs:
         id: nixosconfigsget
         # get all nixosConfigurations except for massflashPi since its aarch64
         run: |
-          nixosconfignames=$(nix eval .\#nixosConfigurations --apply builtins.attrNames --json | jq -c '. - ["massflashPi"]')
+          nixosconfignames=$(nix eval .\#nixosConfigurations --apply builtins.attrNames --json | jq -c '. - ["massflash-pi"]')
           echo "$nixosconfignames"
           echo "nixosconfignames=$nixosconfignames" >> $GITHUB_OUTPUT
   nixos_configs_build:


### PR DESCRIPTION
## Description of PR

<!--
Brief description of the changes in PR

If change is related to an open issue template include at the top of your
description.
-->

Updating the attr that was ignored original as part of: https://github.com/socallinuxexpo/scale-network/pull/1004. But the attr was changed as part of: https://github.com/socallinuxexpo/scale-network/pull/996

## Tests

- Tested pass post-merge to `master`
<!--
How was this PR tested? Please provide as much detail as possible
so we can ensure this change is working as intended before being merged.
-->
