### PR TITLE
[READY] - gha.trigger: leverage built-in GITHUB_TOKEN for /tux

### DIFF
--- a/.github/workflows/trigger.yml
+++ b/.github/workflows/trigger.yml
@@ -10,6 +10,8 @@ jobs:
   verify:
     name: Verify Commenter
     runs-on: ubuntu-22.04
+    permissions:
+      pull-requests: write
     steps:
       - name: Standardize PR comment
         id: pr-standardize-comment
@@ -29,7 +31,7 @@ jobs:
           # is not a PR event
           REF=$(curl -sSf \
             --url ${{ steps.pr-standardize-comment.outputs.url }} \
-            --header 'Authorization: Bearer ${{ secrets.SCALE_GITHUB_TOKEN }}' \
+            --header 'Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}' \
             --header 'Content-Type: application/json' | jq -r '.head.ref' \
           )
           echo "subcomm=$SUBCOMM" >> $GITHUB_OUTPUT


### PR DESCRIPTION
## Description of PR

<!--
Brief description of the changes in PR

If change is related to an open issue template include at the top of your
description.
-->

Noticed that the existing token was not able to auth to the API: https://github.com/socallinuxexpo/scale-network/actions/runs/20626190573/job/59237057963#step:3:24

It seems like theres a much better way to do this via GITHUB_TOKEN and `permissions`: https://docs.github.com/en/actions/tutorials/authenticate-with-github_token


## Tests

- Will need to merge into `master` to confirm functionality
- Triggering a job with `/tux` should work after merge
<!--
How was this PR tested? Please provide as much detail as possible
so we can ensure this change is working as intended before being merged.
-->
