### PR TITLE
[READY] nixos-modules.routers.*: vlans and bridges for ospf area0

### DIFF
--- a/nix/nixos-modules/routers/border.nix
+++ b/nix/nixos-modules/routers/border.nix
@@ -63,19 +63,76 @@ in
     systemd.network = {
       enable = true;
 
+      netdevs = {
+        "20-bridge900" = {
+          netdevConfig = {
+            Kind = "bridge";
+            Name = "bridge900";
+          };
+        };
+        "20-vlan900" = {
+          netdevConfig = {
+            Kind = "vlan";
+            Name = "vlan900";
+          };
+          vlanConfig.Id = 900;
+        };
+        "25-bridge901" = {
+          netdevConfig = {
+            Kind = "bridge";
+            Name = "bridge901";
+          };
+        };
+        "25-vlan901" = {
+          netdevConfig = {
+            Kind = "vlan";
+            Name = "vlan901";
+          };
+          vlanConfig.Id = 901;
+        };
+      };
       networks = mkMerge [
         {
           # Physical link to conference center
-          "10-cf" = {
+          "30-cf" = {
             matchConfig.Name = cfg.frrConferenceInterface;
+            networkConfig = {
+              LinkLocalAddressing = "no";
+            };
+            vlan = [
+              "vlan900"
+            ];
+          };
+          "30-expo" = {
+            matchConfig.Name = cfg.frrExpoInterface;
+            networkConfig = {
+              LinkLocalAddressing = "no";
+            };
+            vlan = [
+              "vlan901"
+            ];
+          };
+          "40-vlan900" = {
+            matchConfig.Name = "vlan900";
+            networkConfig = {
+              Bridge = "bridge900";
+            };
+          };
+          "40-vlan901" = {
+            matchConfig.Name = "vlan901";
+            networkConfig = {
+              Bridge = "bridge901";
+            };
+          };
+          "50-bridge900" = {
+            matchConfig.Name = "bridge900";
             networkConfig.DHCP = false;
             address = [
               "10.1.1.1/24"
             ];
           };
-          # Physical link to expo
-          "10-expo" = {
-            matchConfig.Name = cfg.frrExpoInterface;
+          "50-bridge901" = {
+            matchConfig.Name = "bridge901";
             networkConfig.DHCP = false;
             address = [
               "10.1.2.1/24"
@@ -135,8 +192,8 @@ in
       services.frr.enable = true;
       services.frr.router-id = "10.1.1.1";
       services.frr.broadcast-interface = [
-        cfg.frrExpoInterface
-        cfg.frrConferenceInterface
+        "bridge900" # cf
+        "bridge901" # expo
       ];
     };
   };

--- a/nix/nixos-modules/routers/conference.nix
+++ b/nix/nixos-modules/routers/conference.nix
@@ -83,6 +83,32 @@ in
             Name = "bridge500";
           };
         };
+        "25-bridge900" = {
+          netdevConfig = {
+            Kind = "bridge";
+            Name = "bridge900";
+          };
+        };
+        "25-vlan900" = {
+          netdevConfig = {
+            Kind = "vlan";
+            Name = "vlan900";
+          };
+          vlanConfig.Id = 900;
+        };
+        "20-bridge902" = {
+          netdevConfig = {
+            Kind = "bridge";
+            Name = "bridge902";
+          };
+        };
+        "20-vlan902" = {
+          netdevConfig = {
+            Kind = "vlan";
+            Name = "vlan902";
+          };
+          vlanConfig.Id = 902;
+        };
       };
       # Physical link to border
       networks = {
@@ -129,8 +155,38 @@ in
             "2001:470:f026:500::1/64"
           ];
         };
-        "10-border" = {
+        "30-border" = {
           matchConfig.Name = cfg.frrBorderInterface;
+          networkConfig = {
+            LinkLocalAddressing = "no";
+          };
+          vlan = [
+            "vlan900"
+          ];
+        };
+        "30-expo" = {
+          matchConfig.Name = cfg.frrExpoInterface;
+          networkConfig = {
+            LinkLocalAddressing = "no";
+          };
+          vlan = [
+            "vlan902"
+          ];
+        };
+        "40-vlan900" = {
+          matchConfig.Name = "vlan900";
+          networkConfig = {
+            Bridge = "bridge900";
+          };
+        };
+        "40-vlan902" = {
+          matchConfig.Name = "vlan902";
+          networkConfig = {
+            Bridge = "bridge902";
+          };
+        };
+        "50-bridge900" = {
+          matchConfig.Name = "bridge900";
           networkConfig.DHCP = false;
           address = [
             "10.1.1.2/24"
@@ -140,9 +196,8 @@ in
             { Gateway = "10.1.1.1"; }
           ];
         };
-        # Physical link to expo
-        "10-expo" = {
-          matchConfig.Name = cfg.frrExpoInterface;
+        "50-bridge902" = {
+          matchConfig.Name = "bridge902";
           networkConfig.DHCP = false;
           address = [
             "10.1.3.2/24"
@@ -157,8 +212,8 @@ in
       services.frr.enable = true;
       services.frr.router-id = "10.1.1.2";
       services.frr.broadcast-interface = [
-        cfg.frrBorderInterface
-        cfg.frrExpoInterface
+        "bridge900" # border
+        "bridge902" # expo
       ];
       services.dhcp4-relay."tech" = {
         enable = true;

--- a/nix/nixos-modules/routers/expo.nix
+++ b/nix/nixos-modules/routers/expo.nix
@@ -49,10 +49,67 @@ in
 
     systemd.network = {
       enable = true;
+      netdevs = {
+        "25-bridge901" = {
+          netdevConfig = {
+            Kind = "bridge";
+            Name = "bridge901";
+          };
+        };
+        "25-vlan901" = {
+          netdevConfig = {
+            Kind = "vlan";
+            Name = "vlan901";
+          };
+          vlanConfig.Id = 901;
+        };
+        "20-bridge902" = {
+          netdevConfig = {
+            Kind = "bridge";
+            Name = "bridge902";
+          };
+        };
+        "20-vlan902" = {
+          netdevConfig = {
+            Kind = "vlan";
+            Name = "vlan902";
+          };
+          vlanConfig.Id = 902;
+        };
+      };
       networks = {
-        # Physical link to border
-        "10-border" = {
+        "30-border" = {
           matchConfig.Name = cfg.frrBorderInterface;
+          networkConfig = {
+            LinkLocalAddressing = "no";
+          };
+          vlan = [
+            "vlan901"
+          ];
+        };
+        "30-cf" = {
+          matchConfig.Name = cfg.frrConferenceInterface;
+          networkConfig = {
+            LinkLocalAddressing = "no";
+          };
+          vlan = [
+            "vlan902"
+          ];
+        };
+        "40-vlan901" = {
+          matchConfig.Name = "vlan901";
+          networkConfig = {
+            Bridge = "bridge901";
+          };
+        };
+        "40-vlan902" = {
+          matchConfig.Name = "vlan902";
+          networkConfig = {
+            Bridge = "bridge902";
+          };
+        };
+        "50-bridge901" = {
+          matchConfig.Name = "bridge901";
           networkConfig.DHCP = false;
           address = [
             "10.1.2.3/24"
@@ -62,9 +119,8 @@ in
             { Gateway = "10.1.2.1"; }
           ];
         };
-        # Physical link to conference
-        "10-cf" = {
-          matchConfig.Name = cfg.frrConferenceInterface;
+        "50-bridge902" = {
+          matchConfig.Name = "bridge902";
           networkConfig.DHCP = false;
           address = [
             "10.1.3.3/24"
@@ -79,8 +135,8 @@ in
       services.frr.enable = true;
       services.frr.router-id = "10.1.2.3";
       services.frr.broadcast-interface = [
-        cfg.frrBorderInterface
-        cfg.frrConferenceInterface
+        "bridge901" # border
+        "bridge902" # conf
       ];
     };
   };


### PR DESCRIPTION
## Description of PR

<!--
Brief description of the changes in PR

If change is related to an open issue template include at the top of your
description.
-->

vlans and bridges for the ospf network to match previous config from junipers SRXs

## Tests

- vm tests pass: `nix run .#checks.x86_64-linux.routers.driver`
- Applied to existing bare metal config and passes after restarting frr on each node:

```
# systemctl stop frr.service

[root@router-expo:~]# systemctl start frr.service

[root@router-expo:~]# vtysh

Hello, this is FRRouting (version 10.4.1).
Copyright 1996-2005 Kunihiro Ishiguro, et al.

router-expo# show ip ospf neighbor

Neighbor ID     Pri State           Up Time         Dead Time Address         Interface                        RXmtL RqstL DBsmL
10.1.1.1          1 Full/DR         17.260s            2.718s 10.1.2.1        bridge901:10.1.2.3                   0     0     0
10.1.1.2          1 Full/DR         17.261s            2.256s 10.1.3.2        bridge902:10.1.3.3                   0     0     0

router-expo#
````
<!--
How was this PR tested? Please provide as much detail as possible
so we can ensure this change is working as intended before being merged.
-->
