### PR TITLE
Added support for newer storm-control syntax (exceptions for ex4200)

### DIFF
--- a/switch-configuration/config/scripts/switch_template.pm
+++ b/switch-configuration/config/scripts/switch_template.pm
@@ -1651,10 +1651,19 @@ EOF
 #	context: vlans { <here> }
         debug(5, "Name_prefix: x$VV_name_prefix"."x VLID: x$VLID"."x\n");
         my $vv_name = $VV_name_prefix.$VLID;
-            $VV_vlans .= <<EOF;
+        my $l3type;
+        if ($Model !~ /ex4200/)
+        {
+          $l3type = "irb";
+        }
+        else
+        {
+          $l3type = "vlan";
+        }
+        $VV_vlans .= <<EOF;
     $vv_name {
         vlan-id $VLID
-        l3-interface vlan.$VLID;
+        l3-interface $l3type.$VLID;
     }
 EOF
 #	"vlans_l3"    -> $VV_vlans_l3,


### PR DESCRIPTION
A bunch of code format cleanup (mostly tabs->spaces)

## Description of PR

Formatting cleanup and support for strom-control syntax for ex-4300s (and silly tiny switches too)

## Previous Behavior

No storm control config generated for 4300s (or silly tiny switches)

## New Behavior

Storm control config now generated for all switches.

## Tests

ASVAB, MCAT, LSAT, and SAT

All aced.
