### PR TITLE
nix/nixos-modules/users/djacu: add ssh key for malachite root

### DIFF
--- a/nix/nixos-modules/users/djacu.nix
+++ b/nix/nixos-modules/users/djacu.nix
@@ -28,6 +28,7 @@ in
         extraGroups = [ "wheel" ];
         openssh.authorizedKeys.keys = [
           "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIEbH7DL3UpeYHm+J3YHJTIsnk/vdo5JgEzwD/Bf1tupp yubikey"
+          "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIDQA01HeYZvMbIuTu4ePrGCO5GVBpXdrq3IIVUohX3PH root@malachite"
         ];
       };
     };


### PR DESCRIPTION
## Description of PR

Adds the root ssh key for djacu's malachite system. Used for remote building on dev server.

## Previous Behavior

Couldn't remote build before.

## New Behavior

Can remote build on dev server.

## Tests

Manually modified `/etc/ssh/authorized_keys.d/djacu` on the dev server and was able to use the dev server as a remote builder.
