### PR TITLE
router*: ensure ixgbe kernel module is loaded on bootup

### DIFF
--- a/nix/nixos-configurations/router-border/default.nix
+++ b/nix/nixos-configurations/router-border/default.nix
@@ -20,6 +20,7 @@
         boot.extraModprobeConfig = ''
           options ixgbe allow_unsupported_sfp=1,1
         '';
+        boot.kernelParams = [ "ixgbe" ];
 
         nixpkgs.hostPlatform = "x86_64-linux";
 

--- a/nix/nixos-configurations/router-conf/default.nix
+++ b/nix/nixos-configurations/router-conf/default.nix
@@ -20,6 +20,7 @@
         boot.extraModprobeConfig = ''
           options ixgbe allow_unsupported_sfp=1,1
         '';
+        boot.kernelParams = [ "ixgbe" ];
 
         nixpkgs.hostPlatform = "x86_64-linux";
         # make friend eth names based on paths from lspci

--- a/nix/nixos-configurations/router-expo/default.nix
+++ b/nix/nixos-configurations/router-expo/default.nix
@@ -20,6 +20,7 @@
         boot.extraModprobeConfig = ''
           options ixgbe allow_unsupported_sfp=1,1
         '';
+        boot.kernelParams = [ "ixgbe" ];
 
         nixpkgs.hostPlatform = "x86_64-linux";
         # make friend eth names based on paths from lspci


### PR DESCRIPTION
## Description of PR

<!--
Brief description of the changes in PR

If change is related to an open issue template include at the top of your
description.
-->

Currently ixgbe must be manually loaded, adding it to `boot.kernelModules` ensures it is loaded when the machine boots up (post stage 1).

## Previous Behavior

<!--
What was the behavior before this PR?

Remove this section if not relevant
-->

We had the module parameter `allow_unsupported_sfp` successfully configured, but were not loading the module in an automated manner.

## New Behavior

The module is now both correctly configured as well as automatically loaded.
<!--
What is the new behavior being introduced in this PR?

Remove this section if not relevant
-->

## Tests

On a freshly booted machine with this config:
```
$ lsmod  | grep ixgbe
ixgbe                 487424  0
...
$ cat /sys/module/ixgbe/parameters/allow_unsupported_sfp 
Y
```

<!--
How was this PR tested? Please provide as much detail as possible
so we can ensure this change is working as intended before being merged.
-->
