### PR TITLE
[READY] flake.nix: bump 25.05 -> 25.11

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -20,17 +20,18 @@
         "type": "github"
       }
     },
-    "nixpkgs-2505": {
+    "nixpkgs-2511": {
       "locked": {
-        "lastModified": 1756809922,
-        "narHash": "sha256-mBqVeURIgK+lxYb/H63AuFQu/cGLsJHjSz88V7Rkj3s=",
+        "lastModified": 1770136044,
+        "narHash": "sha256-tlFqNG/uzz2++aAmn4v8J0vAkV3z7XngeIIB3rM3650=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "227e81d2f16e6e72cd7e53f7cd06aaa2db632ad3",
+        "rev": "e576e3c9cf9bad747afcddd9e34f51d18c855b4e",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
+        "ref": "nixos-25.11",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -72,7 +73,7 @@
         "nixpkgs": [
           "nixpkgs-unstable"
         ],
-        "nixpkgs-2505": "nixpkgs-2505",
+        "nixpkgs-2511": "nixpkgs-2511",
         "nixpkgs-lib": "nixpkgs-lib",
         "nixpkgs-unstable": "nixpkgs-unstable",
         "treefmt-nix": "treefmt-nix"

--- a/flake.nix
+++ b/flake.nix
@@ -4,7 +4,7 @@
   inputs = {
     disko.inputs.nixpkgs.follows = "nixpkgs-unstable";
     disko.url = "github:nix-community/disko";
-    nixpkgs-2505.url = "github:NixOS/nixpkgs";
+    nixpkgs-2511.url = "github:NixOS/nixpkgs/nixos-25.11";
     nixpkgs-lib.url = "github:nix-community/nixpkgs.lib";
     nixpkgs-unstable.url = "github:NixOS/nixpkgs/nixos-unstable";
     nixpkgs.follows = "nixpkgs-unstable";


### PR DESCRIPTION
## Description of PR

<!--
Brief description of the changes in PR

If change is related to an open issue template include at the top of your
description.
-->

This input isn't actually used by anything atm. But the mixos configurations need to run on a 6.18 kernel which is available in 25.11 thats part of https://github.com/socallinuxexpo/scale-network/pull/1064 (specifically this thread https://github.com/socallinuxexpo/scale-network/pull/1064#discussion_r2761300862)

## Previous Behavior

- input was on 25.05
<!--
What was the behavior before this PR?

Remove this section if not relevant
-->

## New Behavior

- input now on 25.11
<!--
What is the new behavior being introduced in this PR?

Remove this section if not relevant
-->

## Tests
- tests pass, but nothing is using this :)
<!--
How was this PR tested? Please provide as much detail as possible
so we can ensure this change is working as intended before being merged.
-->
