### PR TITLE
[READY] Reduce BIND resolver query timeout

### DIFF
--- a/nix/nixos-modules/services/bind-master.nix
+++ b/nix/nixos-modules/services/bind-master.nix
@@ -93,6 +93,7 @@ let
       directory "/run/named";
       pid-file "/run/named/named.pid";
       allow-recursion { any; };
+      resolver-query-timeout 3;
       dnssec-validation auto;
       max-cache-size 10%;
     };
@@ -114,14 +115,14 @@ let
       file "${named2001Rev}";
       allow-transfer { };
       allow-query { any; };
-      
+
     };
     zone "scale.lan." {
       type master;
       file "${namedScaleLan}";
       allow-transfer { };
       allow-query { any; };
-      
+
     };
 
   '';


### PR DESCRIPTION
Fixes #1063 

## Description of PR

Default BIND resolver query timeout is 10 seconds. It can be set to 1-30. This PR sets it to 3.
Supporting doc: https://www.zytrax.com/books/dns/ch7/queries.html#resolver-query-timeout 

## Previous Behavior

Default behavior for BIND resolver query timeout, 10 seconds

## New Behavior

Specified behavior for BIND resolver query timeout, 3 seconds

## Tests

Used driver Interactive environment. from client1:

On `master` failed DNS takes > 10 seconds, takes 15 sec and shows network timeout

<img width="643" height="116" alt="Screenshot From 2026-02-06 08-00-09" src="https://github.com/user-attachments/assets/af553df3-aa3a-4417-ad8c-9c4b93c77da8" />


on this branch approx 3 seconds

<img width="381" height="96" alt="Screenshot From 2026-02-06 07-57-49" src="https://github.com/user-attachments/assets/1174be3b-2cc5-4a82-a46a-2544a2dfed9d" />


