### PR TITLE
[READY] - nixosConfiguration.router-scale-br-fmt2: init

### DIFF
--- a/nix/nixos-configurations/router-scale-br-fmt2/configuration.nix
+++ b/nix/nixos-configurations/router-scale-br-fmt2/configuration.nix
@@ -1,0 +1,27 @@
+{
+  ...
+}:
+{
+  scale-network = {
+    base.enable = true;
+    # router.expo = {
+    #   enable = true;
+    #   frrBorderInterface = "sfp0";
+    #   frrConferenceInterface = "sfp1";
+    # };
+    services.ssh.enable = true;
+    services.alloy = {
+      enable = true;
+      remoteWrite.url = "http://10.128.3.20:3200/api/v1/push";
+    };
+    users.conjones.enable = true;
+    users.djacu.enable = true;
+    users.jared.enable = true;
+    users.kylerisse.enable = true;
+    users.owen.enable = true;
+    users.rhamel.enable = true;
+    users.rob.enable = true;
+    users.root.enable = true;
+    users.erikreinert.enable = true;
+  };
+}

--- a/nix/nixos-configurations/router-scale-br-fmt2/default.nix
+++ b/nix/nixos-configurations/router-scale-br-fmt2/default.nix
@@ -1,0 +1,142 @@
+{
+  release = "unstable";
+
+  modules =
+    {
+      config,
+      lib,
+      ...
+    }:
+    {
+      imports = [
+        ./configuration.nix
+        ./hardware-configuration.nix
+        ./disko.nix
+      ];
+
+      config = {
+
+        # verify: modinfo -p ixgbe
+        boot.extraModprobeConfig = ''
+          options ixgbe allow_unsupported_sfp=1,1
+        '';
+        boot.kernelParams = [ "ixgbe" ];
+
+        nixpkgs.hostPlatform = "x86_64-linux";
+        # make friend eth names based on paths from lspci
+        services.udev.extraRules = ''
+          # Ethernet controller: Realtek Semiconductor Co., Ltd. RTL8111/8168/8211/8411 PCI Express Gigabit Ethernet Controller (rev 15)
+          SUBSYSTEM=="net", ACTION=="add", KERNELS=="0000:0e:00.0", NAME="backdoor0"
+          # Ethernet controller: Intel Corporation 82599ES 10-Gigabit SFI/SFP+ Network Connection (rev 01)
+          SUBSYSTEM=="net", ACTION=="add", KERNELS=="0000:03:00.0", NAME="sfp0"
+          SUBSYSTEM=="net", ACTION=="add", KERNELS=="0000:03:00.1", NAME="sfp1"
+          SUBSYSTEM=="net", ACTION=="add", KERNELS=="0000:05:00.0", NAME="sfp2"
+          SUBSYSTEM=="net", ACTION=="add", KERNELS=="0000:05:00.1", NAME="sfp3"
+          # Ethernet controller: Intel Corporation I350 Gigabit Network Connection (rev 01)
+          SUBSYSTEM=="net", ACTION=="add", KERNELS=="0000:08:00.0", NAME="copper0"
+          SUBSYSTEM=="net", ACTION=="add", KERNELS=="0000:08:00.1", NAME="copper1"
+          SUBSYSTEM=="net", ACTION=="add", KERNELS=="0000:08:00.2", NAME="copper2"
+          SUBSYSTEM=="net", ACTION=="add", KERNELS=="0000:08:00.3", NAME="copper3"
+        '';
+        systemd.services.systemd-networkd.environment.SYSTEMD_LOG_LEVEL = "debug";
+
+        boot.kernel.sysctl = {
+          "net.ipv4.conf.all.forwarding" = true;
+          "net.ipv6.conf.all.forwarding" = true;
+        };
+
+        networking.firewall.enable = false;
+        networking.nftables.enable = true;
+        networking.nftables.ruleset = ''
+           table ip nat {
+            chain PREROUTING {
+              type nat hook prerouting priority dstnat; policy accept;
+            }
+
+            chain INPUT {
+              type nat hook input priority 100; policy accept;
+            }
+
+            chain OUTPUT {
+              type nat hook output priority -100; policy accept;
+            }
+
+            chain POSTROUTING {
+              type nat hook postrouting priority srcnat; policy accept;
+              oifname "copper0" ip daddr 0.0.0.0/0 counter masquerade
+            }
+          }
+        '';
+
+        # must be disabled if using systemd.network
+        networking.useDHCP = false;
+
+        systemd.network = {
+          enable = true;
+          netdevs = {
+            # expoInfra
+            "20-vlan103" = {
+              netdevConfig = {
+                Kind = "vlan";
+                Name = "vlan103";
+              };
+              vlanConfig.Id = 103;
+            };
+            "25-bridge103" = {
+              netdevConfig = {
+                Kind = "bridge";
+                Name = "bridge103";
+              };
+            };
+          };
+          networks = {
+            # Keep this for troubleshooting
+            "10-backdoor" = {
+              matchConfig.Name = "backdoor0";
+              enable = true;
+              networkConfig = {
+                DHCP = "yes";
+                LLDP = true;
+                EmitLLDP = true;
+              };
+              linkConfig.RequiredForOnline = "no";
+            };
+            "10-copper0" = {
+              matchConfig.Name = "copper0";
+              networkConfig = {
+                DHCP = "yes";
+                LLDP = true;
+                EmitLLDP = true;
+              };
+            };
+            "30-copper1" = {
+              matchConfig.Name = "copper1";
+              linkConfig = {
+                RequiredForOnline = "carrier";
+              };
+              networkConfig = {
+                LinkLocalAddressing = "no";
+              };
+              vlan = [
+                "vlan103"
+              ];
+            };
+            "40-vlan103" = {
+              matchConfig.Name = "vlan103";
+              networkConfig = {
+                Bridge = "bridge103";
+              };
+            };
+            "50-bridge103" = {
+              matchConfig.Name = "bridge103";
+              enable = true;
+              address = [
+                "10.0.3.1/24"
+                "2001:470:f026:103::1/64"
+              ];
+            };
+          };
+        };
+      };
+    };
+}

--- a/nix/nixos-configurations/router-scale-br-fmt2/disko.nix
+++ b/nix/nixos-configurations/router-scale-br-fmt2/disko.nix
@@ -1,0 +1,100 @@
+{
+  disko.devices = {
+    disk = {
+      one = {
+        type = "disk";
+        device = "/dev/disk/by-path/pci-0000:0c:00.0-nvme-1";
+        content = {
+          type = "gpt";
+          partitions = {
+            ESP = {
+              size = "512M";
+              type = "EF00";
+              content = {
+                type = "filesystem";
+                format = "vfat";
+                mountpoint = "/boot";
+              };
+            };
+            zfs = {
+              size = "100%";
+              content = {
+                type = "zfs";
+                pool = "tank0";
+              };
+            };
+          };
+        };
+      };
+      two = {
+        type = "disk";
+        device = "/dev/disk/by-path/pci-0000:0f:00.0-nvme-1";
+        content = {
+          type = "gpt";
+          partitions = {
+            # Support multiple disks to boot from
+            ESP = {
+              size = "512M";
+              type = "EF00";
+              content = {
+                type = "filesystem";
+                format = "vfat";
+                mountpoint = "/boot2";
+              };
+            };
+            zfs = {
+              size = "100%";
+              content = {
+                type = "zfs";
+                pool = "tank0";
+              };
+            };
+          };
+        };
+      };
+    };
+    zpool = {
+      tank0 = {
+        type = "zpool";
+        mode = "mirror";
+        # Workaround: cannot import 'tank0': I/O error in disko tests
+        options.cachefile = "none";
+        rootFsOptions = {
+          compression = "zstd";
+          "com.sun:auto-snapshot" = "true";
+          acltype = "posixacl";
+          xattr = "sa";
+          canmount = "off";
+          mountpoint = "none";
+        };
+        options = {
+          ashift = "12";
+          autotrim = "on";
+        };
+
+        datasets = {
+          "root" = {
+            type = "zfs_fs";
+            mountpoint = "/";
+            options.mountpoint = "legacy";
+          };
+          "home" = {
+            type = "zfs_fs";
+            mountpoint = "/home";
+            options.mountpoint = "legacy";
+          };
+          "nix" = {
+            type = "zfs_fs";
+            mountpoint = "/nix";
+            options.mountpoint = "legacy";
+          };
+          "persist" = {
+            type = "zfs_fs";
+            mountpoint = "/persist";
+            options.mountpoint = "legacy";
+          };
+        };
+      };
+    };
+  };
+}

--- a/nix/nixos-configurations/router-scale-br-fmt2/hardware-configuration.nix
+++ b/nix/nixos-configurations/router-scale-br-fmt2/hardware-configuration.nix
@@ -1,0 +1,49 @@
+{
+  config,
+  lib,
+  modulesPath,
+  ...
+}:
+
+{
+  imports = [
+    (modulesPath + "/installer/scan/not-detected.nix")
+  ];
+
+  boot.initrd.availableKernelModules = [
+    "ehci_pci"
+    "ahci"
+    "usbhid"
+    "usb_storage"
+    "sd_mod"
+  ];
+
+  boot.initrd.kernelModules = [ ];
+  boot.kernelModules = [ "kvm-amd" ];
+  boot.extraModulePackages = [ ];
+
+  swapDevices = [ ];
+
+  nixpkgs.hostPlatform = lib.mkDefault "x86_64-linux";
+  hardware.cpu.intel.updateMicrocode = lib.mkDefault config.hardware.enableRedistributableFirmware;
+
+  boot.loader.grub = {
+    enable = true;
+    efiSupport = true;
+    efiInstallAsRemovable = true;
+    mirroredBoots = [
+      {
+        devices = [ "nodev" ];
+        path = "/boot";
+      }
+      {
+        devices = [ "nodev" ];
+        path = "/boot2";
+      }
+    ];
+  };
+
+  # ZFS uniq system ID
+  # to generate: head -c4 /dev/urandom | od -A none -t x4
+  networking.hostId = "1bb5bbbc";
+}


### PR DESCRIPTION
## Description of PR

<!--
Brief description of the changes in PR

If change is related to an open issue template include at the top of your
description.
-->

Setting up the new router-scale-br-fmt2 (he)

General flow:
1. `lspci` output to get hardware addresses
2. Update disko.nix for disk address
3. Update configurations.nix for interface address
4. Initial provisioning (disko):

```
nix run github:nix-community/nixos-anywhere -- --flake .#router-scale-br-fmt2 root@<address>
```


Future rebuild:
```
nixos-rebuild switch --flake .#router-scale-br-fmt2  --sudo --ask-sudo-password --target-host <user>@<address>`
```

## Previous Behavior

- SRX was scale-br-fmt2
<!--
What was the behavior before this PR?

Remove this section if not relevant
-->

## New Behavior

- nixos router now scale-br-fmt2
<!--
What is the new behavior being introduced in this PR?

Remove this section if not relevant
-->

## Tests
- fmt2 up and running
<!--
How was this PR tested? Please provide as much detail as possible
so we can ensure this change is working as intended before being merged.
-->
