### PR TITLE
[READY] Datasource testing cleanup

### DIFF
--- a/facts/datasource.py
+++ b/facts/datasource.py
@@ -22,29 +22,19 @@ import pandas as pd
 # =============================================================================
 
 
-def isuntested(value):
-    # pylint: disable=unused-argument
-    """dummy function for untested values"""
+def is_untested(_val) -> bool:
+    """Dummy validator for untested fields, always passes."""
     return True
 
 
-def isvalidhostname(hostname):
-    """
-    test for valid short hostname with letters, numbers, and dashes
-    cannot begin or end with a dash
-    """
-    pattern = r"^([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]*[a-zA-Z0-9])$"
-    result = re.match(pattern, hostname)
-    if result:
-        return True
-    return False
+def is_valid_hostname(val: str) -> bool:
+    """Test for valid short hostname: letters, numbers, dashes. No leading/trailing dash."""
+    return bool(re.match(r"^[a-zA-Z0-9]([a-zA-Z0-9-]*[a-zA-Z0-9])?$", val))
 
 
-def is_valid_asset_id(asset_id):
-    """
-    test for valid asset ID, which has the same constraints as a hostname
-    """
-    return isvalidhostname(asset_id)
+def is_valid_asset_id(val: str) -> bool:
+    """Test for valid asset ID (same constraints as hostname)."""
+    return is_valid_hostname(val)
 
 
 def is_valid_switch_model(val: str) -> bool:
@@ -369,7 +359,7 @@ def validate_dataframe(
     Args:
         df: DataFrame to validate
         validators: List of validator functions, one per column.
-                   Use None or isuntested to skip validation for a column.
+                   Use None or is_untested to skip validation for a column.
         filename: Filename for error messages
         skip_header: If True, skip the first row
 
@@ -383,7 +373,7 @@ def validate_dataframe(
             # Skip if no validator or beyond available columns
             if validator is None or col_idx >= len(df.columns):
                 continue
-            if validator is isuntested:
+            if validator is is_untested:
                 continue
 
             value = df.iloc[row_idx, col_idx]

--- a/facts/test_datasources.py
+++ b/facts/test_datasources.py
@@ -14,7 +14,7 @@ def test_apuse_csv():
         "header": True,
         "count": 9,
         "cols": [
-            ds.isvalidhostname,
+            ds.is_valid_hostname,
             ds.is_in_ap_list,
             ds.is_valid_ipv4_address,
             ds.is_valid_wifi_24ghz_chan,
@@ -36,7 +36,7 @@ def test_aps_csv():
         "header": True,
         "count": 2,
         "cols": [
-            ds.isuntested,
+            ds.is_untested,
             ds.is_valid_mac_address,
         ],
     }
@@ -67,7 +67,7 @@ def test_piuse_csv():
         "header": True,
         "count": 3,
         "cols": [
-            ds.isvalidhostname,
+            ds.is_valid_hostname,
             ds.is_valid_asset_id,
             ds.is_valid_pi_vlan,
         ],
@@ -83,7 +83,7 @@ def test_routerlist_csv():
         "header": True,
         "count": 2,
         "cols": [
-            ds.isvalidhostname,
+            ds.is_valid_hostname,
             ds.is_valid_ipv6_address,
         ],
     }
@@ -98,11 +98,11 @@ def test_serverlist_csv():
         "header": True,
         "count": 5,
         "cols": [
-            ds.isvalidhostname,
+            ds.is_valid_hostname,
             ds.is_valid_mac_address,
             ds.is_valid_ipv6_address,
             ds.is_valid_ipv4_address,
-            ds.isuntested,
+            ds.is_untested,
         ],
     }
     result, err = ds.test_csvfile(meta)
@@ -116,13 +116,13 @@ def test_switchtypes_tsv():
         "header": False,
         "count": "9+",
         "cols": [
-            ds.isvalidhostname,
+            ds.is_valid_hostname,
             ds.is_non_negative_int,
             ds.is_non_negative_int,
             ds.is_valid_ipv6_address,
             ds.is_valid_switch_type,
             ds.is_valid_switch_hierarchy,
-            ds.isuntested,
+            ds.is_untested,
             ds.is_valid_switch_model,
             ds.is_valid_mac_address,
         ],
@@ -141,12 +141,12 @@ def test_vlansd_tsv():
             "header": False,
             "count": "6+",
             "cols": [
-                ds.isuntested,
-                ds.isuntested,
-                ds.isuntested,
+                ds.is_untested,
+                ds.is_untested,
+                ds.is_untested,
                 ds.is_valid_ipv6_subnet,
                 ds.is_valid_ipv4_subnet,
-                ds.isuntested,
+                ds.is_untested,
             ],
         }
         result, err = ds.test_tsvfile(meta)


### PR DESCRIPTION
## Description of PR

Massive cleanup of `datasource.py` with the main goal of readability and simplicity. 

- All functions moved to snake case for readability.
- Type hints added to all functions.
- Tests that were shared between IPv4 and IPv6 are now distinct for accuracy.
- Use of regex removed when possible
- Unused tests removed

## Previous Behavior

worse

## New Behavior

better

## Tests

- `nix build -L .#checks.x86_64-linux.pytest-facts`
- `nix fmt`
- `nix flake check`
