### PR TITLE
[READY] - nixos-modules.services.gitlab: allow for configurable concurrency

### DIFF
--- a/nix/nixos-configurations/dev-server/default.nix
+++ b/nix/nixos-configurations/dev-server/default.nix
@@ -19,7 +19,10 @@
         scale-network = {
           base.enable = true;
           libvirt.enable = true;
-          services.gitlab.enable = true;
+          services.gitlab = {
+            enable = true;
+            concurrent = 5;
+          };
           services.bindMaster.enable = true;
           services.keaMaster.enable = true;
           services.prometheus.enable = false;

--- a/nix/nixos-modules/services/gitlab.nix
+++ b/nix/nixos-modules/services/gitlab.nix
@@ -11,17 +11,32 @@ let
     mkIf
     ;
 
+  inherit (lib.types)
+    int
+    ;
+
   inherit (lib.options)
     mkEnableOption
     ;
 in
 {
-  options.scale-network.services.gitlab.enable = mkEnableOption "SCaLE network GitLab runner";
+  options.scale-network.services.gitlab = {
+    enable = mkEnableOption "SCaLE network GitLab runner";
+
+    concurrent = lib.mkOption {
+      type = int;
+      default = 3;
+      description = ''
+        Number of concurrent jobs to schedule on the gitlab-runner
+      '';
+    };
+  };
 
   config = mkIf cfg.enable {
     services.gitlab-runner = {
       enable = true;
       gracefulTermination = true;
+      settings.concurrent = cfg.concurrent;
       services = {
         shell = {
           # make sure this is a quote path so it doesnt end up in /nix/store


### PR DESCRIPTION
## Description of PR

<!--
Brief description of the changes in PR

If change is related to an open issue template include at the top of your
description.
-->


Relates to: #1001

## Previous Behavior
- gitlab-runner concurrency was 1 (default)


<!--
What was the behavior before this PR?

Remove this section if not relevant
-->

## New Behavior
- gitlab-runner concurrency for `dev-server` set to 5

<!--
What is the new behavior being introduced in this PR?

Remove this section if not relevant
-->

## Tests
- Trigger multiple PRs at once and saw the runner concurrently running them:
<img width="1059" height="314" alt="ss-202602111770791680" src="https://github.com/user-attachments/assets/89c23d76-e8ba-435d-9866-8a016099f5e9" />

<!--
How was this PR tested? Please provide as much detail as possible
so we can ensure this change is working as intended before being merged.
-->
