### PR TITLE
[READY] nixos-modules.routers.conf: vlans, radvd, dhcp4-relay

### DIFF
--- a/nix/nixos-modules/routers/expo.nix
+++ b/nix/nixos-modules/routers/expo.nix
@@ -47,6 +47,20 @@ in
     # must be disabled if using systemd.network
     networking.useDHCP = false;
 
+    scale-network.router.radvd = {
+      enable = true;
+      vlans = [
+        "100"
+        "101"
+        "102"
+        "103"
+        "104"
+        "105"
+        "107"
+        "110"
+      ];
+    };
+
     systemd.network = {
       enable = true;
       netdevs = {


### PR DESCRIPTION
## Description of PR

<!--
Brief description of the changes in PR

If change is related to an open issue template include at the top of your
description.
-->
fixes: #1079
relates to: #1006

Bulk porting over of SRX vlan config: https://github.com/socallinuxexpo/scale-network/blob/9510e467b08cacd812161afe3280f087c67b3f0e/router-configuration/backups/ex-mdf-01

Ive omitted some vlans that we arent using for 23x.

## Previous Behavior
- No wifi, speaker, and management vlans on router-expo
- No dhcp4-relay on router-expo
- No radvd on router-expo
<!--
What was the behavior before this PR?

Remove this section if not relevant
-->

## New Behavior
- wifi, speaker, and management vlans (bulk added) on router-expo
- dhcp4-relay for tech on router-expo
- radvd on router-expo

<!--
What is the new behavior being introduced in this PR?

Remove this section if not relevant
-->

## Tests

- Applied to baremetal router-expo and temporarily overrode the carrier for bridge100:

```
...
  "50-bridge100" = {
  matchConfig.Name = "bridge100";
  enable = true;
  address = [
    "10.0.128.1/21"
    "2001:470:f026:100::1/64"
  ];
  networkConfig = {
    ConfigureWithoutCarrier = "yes";
  };
};
...
```

Results in:

<img width="1169" height="148" alt="ss-202602201771574608" src="https://github.com/user-attachments/assets/caaddc3e-df13-4ec8-a34d-78eaae4ea83a" />

<!--
How was this PR tested? Please provide as much detail as possible
so we can ensure this change is working as intended before being merged.
-->
