### PR TITLE
[READY] - Magic naming necessary for sizing stickers correctly

### DIFF
--- a/switch-configuration/config/scripts/generate_ps_stickers.pl
+++ b/switch-configuration/config/scripts/generate_ps_stickers.pl
@@ -38,7 +38,7 @@ my $PS_Preamble = <<EOF;
 % Assumes a $PageWidth Wide $PageHeight tall page. (Change above, according to media roll)
 /PageWidth { $PageWidth Inch } bind def
 /PageHeight { $PageHeight Inch } bind def
-%/StickerWidth { $StickerWidth Inch } bind def %%FIXME%% Moved StickerWidth definition into embed() routine to enable MicroSwitch
+%/StickerWidth { $StickerWidth Inch } def %%FIXME%% Moved StickerWidth definition into embed() routine to enable MicroSwitch
 /StickerHeight { $StickerHeight Inch } bind def
 /CornerRadius { $Radius Inch } bind def			% Radius for Corner of sticker cut line
 << /PageSize [ PageWidth 0.25 Inch add PageHeight $SheetCount mul ] >> setpagedevice
@@ -143,7 +143,7 @@ sub embed
   # Draw sticker cut bounding box around sticker with 0.25" radius corners
   print <<EOF;
     gsave
-    /StickerWidth { $stickwidth Inch } bind def %%FIXME%% Moved StickerWidth definition into embed() routine to enable MicroSwitch
+    /StickerWidth { $stickwidth Inch } def %%FIXME%% Moved StickerWidth definition into embed() routine to enable MicroSwitch
     0.5 0 0 0 (StickerCut) 0 /tint exch def
     findcmykcustomcolor
     false setoverprint

--- a/switch-configuration/config/switchtypes
+++ b/switch-configuration/config/switchtypes
@@ -70,8 +70,8 @@ RegDesk		52	103	2001:470:f026:103::200:52	registration	X.9		Normal		ex4200-48px	
 ExpoIDF		53	103	2001:470:f026:103::200:53	exIDF		F.1		Loud		ex4300-48p	58:00:bb:4a:59:e0
 //retired	54	503	2001:470:f026:503::200:54	cfIDF		I.1		Loud		ex4300-48p
 //retired	55	103	2001:470:f026:103::200:55	Booth		W.9		Loud		ex4300-48p
-BallroomA	56	103	2001:470:f026:103::200:56	exMicro		C.9		Silent		ex2300-c-12p	4c:16:fc:3f:36:03
-BallroomG	57	103	2001:470:f026:103::200:57	exMicro		F.9		Silent		ex2300-c-12p	38:4f:49:15:f2:05
-Rm103		58	503	2001:470:f026:503::200:58	cfMicro		I.9		Silent		ex2300-c-12p	84:03:28:0b:f0:7a
+MicroA		56	103	2001:470:f026:103::200:56	exMicro		C.9		Silent		ex2300-c-12p	4c:16:fc:3f:36:03
+MicroG		57	103	2001:470:f026:103::200:57	exMicro		F.9		Silent		ex2300-c-12p	38:4f:49:15:f2:05
+Micro103	58	503	2001:470:f026:503::200:58	cfMicro		I.9		Silent		ex2300-c-12p	84:03:28:0b:f0:7a
 ConfIDF		59	503	2001:470:f026:503::200:59	cfIDF		C.1		Loud		ex4300-48p	58:00:bb:4a:2e:c0
-Rm104		60	503	2001:470:f026:503::200:60	cfMicro		I.9		Silent		ex2300-c-12p	b4:8a:5f:07:17:0c
+Micro104	60	503	2001:470:f026:503::200:60	cfMicro		I.9		Silent		ex2300-c-12p	b4:8a:5f:07:17:0c


### PR DESCRIPTION
## Description of PR

Modified switch names in switch types file to accommodate magic naming needed for sticker generator.

## Previous Behavior

Large stickers for tiny switches

## New Behavior

Right sized stickers for toy switches

## Tests

make
open PDF
Lather
Rinse
Repeat
