### PR TITLE
[READY] Better sticker size detection

### DIFF
--- a/switch-configuration/config/scripts/generate_ps_stickers.pl
+++ b/switch-configuration/config/scripts/generate_ps_stickers.pl
@@ -7,8 +7,9 @@
 # Currently output is to STDOUT. Might convert to sending to a file later.
 
 # Values for 17" wide switch labels on 24" media roll (Labels print vertically, joined horizontally 2" per label)
+use strict;
+use Data::Dumper qw/Dumper/;
 
-##FIXME## Added horrible hacks to manage labels for Micro 12 port switches
 
 my $PageWidth = 20;
 my $PageHeight = 15;
@@ -20,6 +21,13 @@ my $Radius = 0.25;
 
 my @maps = <switch-maps/*.eps>;
 my $SheetCount = ($#maps / $StickersPerPage ) + ($#maps % $StickersPerPage ? 1 : 0);
+
+my %WIDTHS = (
+        "ex2300-c-12p"	=>	"9",
+        "ex4200-48p"	=>	"14",
+        "ex4200-48px"	=>	"14",
+        "ex4300-48p"	=>	"14"
+        );
 
 my $PS_Preamble = <<EOF;
 %!PS-Adobe
@@ -38,7 +46,7 @@ my $PS_Preamble = <<EOF;
 % Assumes a $PageWidth Wide $PageHeight tall page. (Change above, according to media roll)
 /PageWidth { $PageWidth Inch } bind def
 /PageHeight { $PageHeight Inch } bind def
-%/StickerWidth { $StickerWidth Inch } def %%FIXME%% Moved StickerWidth definition into embed() routine to enable MicroSwitch
+%/StickerWidth { $StickerWidth Inch } def
 /StickerHeight { $StickerHeight Inch } bind def
 /CornerRadius { $Radius Inch } bind def			% Radius for Corner of sticker cut line
 << /PageSize [ PageWidth 0.25 Inch add PageHeight $SheetCount mul ] >> setpagedevice
@@ -131,19 +139,36 @@ sub embed
 {
   my $file = shift(@_);
   my $stickwidth = $StickerWidth;
-  if ($file =~ /Micro/) {
-	  $stickwidth = 9;
-  }
+  my $Model;
   open INPUT, "<$file" || die("Could not read $file: ");
   foreach(<INPUT>)
   {
+    ##FIXME## This regex could probably be improved.
+    if ($_ =~ /Model: ([\S]+)\)\)/)
+    {
+      $Model = $1;
+      print STDERR "Model String: $_ -> ($Model)\n";
+      if (!exists $WIDTHS{$Model})
+      {
+        warn("Unknown Model ($Model), assuming full rack width");
+      }
+      else
+      {
+        $stickwidth = $WIDTHS{$Model};
+      }
+    }
     print $_;
+  }
+  unless ("$Model")
+  {
+    die("Error: File $file has no Model string\n");
   }
   close INPUT;
   # Draw sticker cut bounding box around sticker with 0.25" radius corners
+  print STDERR "File: $file Model: $Model -- $stickwidth Inches wide\n";
   print <<EOF;
     gsave
-    /StickerWidth { $stickwidth Inch } def %%FIXME%% Moved StickerWidth definition into embed() routine to enable MicroSwitch
+    /StickerWidth { $stickwidth Inch } def
     0.5 0 0 0 (StickerCut) 0 /tint exch def
     findcmykcustomcolor
     false setoverprint

--- a/switch-configuration/config/scripts/switch_template.pm
+++ b/switch-configuration/config/scripts/switch_template.pm
@@ -11,7 +11,6 @@
 ##FIXME## Build a consistency check to match up VLANs in the vlans file(s) and
 ##FIXME## those defined in the types/* files.
 
-##FIXME## Learn v6 prefix dynamically from config files (look for 2001:470 throughout script)
 ##FIXME## Assumes v6 prefix is a /48 and many code dependencies on this assumption. Safe at least for now.
 
 
@@ -459,8 +458,6 @@ EOF
 
 sub build_interfaces_from_config
 {
-  ##FIXME## There are lots of assumptions here like all switches being 19" standard rack wide. Now we have to accommodate stupid Micro 12 port switches
-  ##FIXME## Because of short time frame for coding this, it's going to be a hellatious hack.
   ##FIXME## There are a number of places where this subroutine assumes
   ##FIXME## that all interaces are ge-0/0/*
   ##FIXME## There are special excpetions coded for FIBER ports at ge-0/1/[0-3] to partially compensate
@@ -484,7 +481,7 @@ EOF
 			"(Type: $Type)\n";
   my $portmap_PS = "%!PS-Adobe-3.0 EPSF-3.0\n%%BoundingBox: 0 0 1008 144 % 14\" x 2\"\n%\n".
             "% Generated Interface Portmap for ".
-            "Switch #$Number Name: $hostname (Type: $Type)\n%\n";
+            "Switch #$Number Name: $hostname (Type: $Type Model: $Model)\n%\n";
   $portmap_PS .= <<EOF;
 % Initialization of graphical context for portmap
 % Each portmap is roughly 14" wide by 2" high.
@@ -494,6 +491,7 @@ SwitchMapDict begin
 % Font Definitions
 /BoxFont { /Helvetica-Bold findfont 9 scalefont setfont } bind def
 /TitleFont { /Helvetica findfont 24 scalefont setfont } bind def
+/MicroTitleFont { /Helvetica findfont 18 scalefont setfont } bind def
 
 % Color Setting
 /PoEOnColor { 0 1 0 setrgbcolor } def
@@ -521,14 +519,14 @@ if ($Type =~ /Micro/) # Treat as 12-port micro switch
   $portmap_PS .= <<EOF;
 /Fiber_Left_Edge  Port_Width 6 mul Port_Group_Gap add 2 Inch add def % Compute position for left edge of Fiber Ports
 /Fiber_Port_Width 2 Inch def		% Width of SFP Port
-/Center           4.5 Inch def                    % Center of box diagram
+/Center           Left_Port_Edge 4.5 Inch add def                    % Center of box diagram
 /Fiber_Bottom     Odd_Bottom def
 EOF
 } else {
   $portmap_PS.= <<EOF;
 /Fiber_Left_Edge  Port_Width 6 mul Port_Group_Gap add 3 mul Port_Width add def % Compute position for left edge of Fiber Ports
 /Fiber_Port_Width 0.583 Inch def		% Width of SFP Port
-/Center           7 Inch def                    % Center of box diagram
+/Center           Left_Port_Edge 7 Inch add def                    % Center of box diagram
 /Fiber_Bottom     Even_Bottom Box_Height add 0.1 Inch add def
 EOF
 }
@@ -546,6 +544,17 @@ $portmap_PS.= <<EOF;
   dup stringwidth pop          % Get width from font metrics (discard height) [ text ] -> [ text width ]
   2 div                        % Convert to offset from center for left edge -> [ text width/2 ]
   Center exch sub              % Subtract from Center position -> [ text Center-width/2 ]
+  % Check if we are left of the FiberLeftEdge and if so, use MicroTitleFont
+  dup (Left Text Position: ) == == Left_Port_Edge (Left Edge: ) == ==
+  dup Left_Port_Edge exch lt {}     % If not left, do nothing [ text textXpos ] -> [ text textXpos bool {} ] (bool and {} will be consumed by ifelse before else proc executes)
+  {
+    pop                        % Drop the previously computed X position for the start of text [ text width ] -> [ text ]
+    MicroTitleFont             % Select MicroTitle Font
+    0 0 0 setrgbcolor            % Title in black
+    dup stringwidth pop        % Get new text width [ text width ]
+    2 div                      % Convert to offset from center for left edge [ text width/2 ]
+    Center exch sub            % Subtract offset from center [ text textXpos ]
+  } ifelse
   Label_Ligature moveto        % Position at bottom left edge of text -> [ text ]
   show                         % Display text [ text ] -> [ ]
 } bind def
@@ -704,7 +713,7 @@ $portmap_PS.= <<EOF;
   Left Port_Width 2 div add W sub Ligature 10 sub moveto P show
 } bind def
 
-(Switch #$Number Name: $hostname (Type: $Type)) ShowTitle
+(Switch #$Number Name: $hostname (Type: $Type Model: $Model)) ShowTitle
 EOF
 
 # Preamble information to put in generator pulling EPS files together for printing
@@ -1949,12 +1958,12 @@ system {
         encrypted-password "$root_auth";
     }
     ntp {
-        server 2001:470:f026:503::20;
-        server 2001:470:f026:103::20;
+        server $PREFIX:503::20;
+        server $PREFIX:103::20;
     }
     name-server {
-        2001:470:f026:503::20;
-        2001:470:f026:103::20;
+        $PREFIX:503::20;
+        $PREFIX:103::20;
     }
 
     syslog {

--- a/switch-configuration/config/switchtypes
+++ b/switch-configuration/config/switchtypes
@@ -70,8 +70,8 @@ RegDesk		52	103	2001:470:f026:103::200:52	registration	X.9		Normal		ex4200-48px	
 ExpoIDF		53	103	2001:470:f026:103::200:53	exIDF		F.1		Loud		ex4300-48p	58:00:bb:4a:59:e0
 //retired	54	503	2001:470:f026:503::200:54	cfIDF		I.1		Loud		ex4300-48p
 //retired	55	103	2001:470:f026:103::200:55	Booth		W.9		Loud		ex4300-48p
-MicroA		56	103	2001:470:f026:103::200:56	exMicro		C.9		Silent		ex2300-c-12p	4c:16:fc:3f:36:03
-MicroG		57	103	2001:470:f026:103::200:57	exMicro		F.9		Silent		ex2300-c-12p	38:4f:49:15:f2:05
-Micro103	58	503	2001:470:f026:503::200:58	cfMicro		I.9		Silent		ex2300-c-12p	84:03:28:0b:f0:7a
+BallroomA	56	103	2001:470:f026:103::200:56	exMicro		C.9		Silent		ex2300-c-12p	4c:16:fc:3f:36:03
+BallroomG	57	103	2001:470:f026:103::200:57	exMicro		F.9		Silent		ex2300-c-12p	38:4f:49:15:f2:05
+Room103		58	503	2001:470:f026:503::200:58	cfMicro		I.9		Silent		ex2300-c-12p	84:03:28:0b:f0:7a
 ConfIDF		59	503	2001:470:f026:503::200:59	cfIDF		C.1		Loud		ex4300-48p	58:00:bb:4a:2e:c0
-Micro104	60	503	2001:470:f026:503::200:60	cfMicro		I.9		Silent		ex2300-c-12p	b4:8a:5f:07:17:0c
+Room104		60	503	2001:470:f026:503::200:60	cfMicro		I.9		Silent		ex2300-c-12p	b4:8a:5f:07:17:0c


### PR DESCRIPTION
	- switchtypes renamed switches away from magic naming for toy switches
	- switch_template -- Many mods to postscript to accomodate tiny labels
	- generate_ps_stickers -- Improved detection of switch Model Side effect, titles for labels now include switch model as well as type

## Description of PR

Fixes: #1106

Improved code for handling toy switches

## Previous Behavior

Magic switch naming convention to trigger smaller cut lines for stickers to go on toy switches
Most (all) titles too wide to fit properly on toy switch labels

## New Behavior

No more magic naming convention, now based on switch model (default full size)
Added a place in the code that needs to be updated if we add more switches (not ideal).
Use smaller title font if Title doesn't fit (this will be applied to a full size switch if needed, too)

Currently, we don't test for max width on switches with fiber ports, so some titles are truncated behind fiber port displays on the few switches that have fiber ports configured.

## Tests
make
open config/switch-maps/stickers.pdf
Use mark 1 eyeball (x2) to visually inspect results
