### PR TITLE
nix.nixos-modules.routers.border: override frr config

### DIFF
--- a/nix/nixos-modules/routers/border.nix
+++ b/nix/nixos-modules/routers/border.nix
@@ -316,6 +316,18 @@ in
         cfg.WANInterface
         "bridge103"
       ];
+      services.frr.routing-config = ''
+        router ospf
+         passive-interface default
+         network 0.0.0.0/0 area 0
+         redistribute connected
+        exit
+        router ospf6
+         redistribute connected
+         redistribute kernel
+         default-information originate
+        exit
+      '';
     };
   };
 }


### PR DESCRIPTION
## Description of PR

Overrides the border frr config to account for differences from the other 2

## Previous Behavior

identical ospf6 configs on all routers

## New Behavior

border router has variations

## Tests

- `nix build -L .#nixosConfigurations.router-border.config.system.build.toplevel` and inspect `result/etc/frr/frr.conf` (see the difference)
- `nix build -L .#nixosConfigurations.router-expo.config.system.build.toplevel` and inspect `result/etc/frr/frr.conf` (same as before)
- `make test-all` passes
