### PR TITLE
[READY] nix.nixos-modules.routers.border: dont accept RAs on bridge103

### DIFF
--- a/nix/nixos-modules/routers/border.nix
+++ b/nix/nixos-modules/routers/border.nix
@@ -200,6 +200,9 @@ in
           "40-bridge103" = {
             matchConfig.Name = "bridge103";
             enable = true;
+            networkConfig = {
+              IPv6AcceptRA = false;
+            };
             address = [
               "10.0.3.2/24"
               "2001:470:f026:103::2/64"


### PR DESCRIPTION
## Description of PR

don't accept RAs on bridge103

## Previous Behavior

accept RAs on bridge103

## New Behavior

don't accept RAs on bridge103

## Tests

rendered the file and reviewed.
