### PR TITLE
[READY] nix.nixos-modules.routers.expo: add access ports for av and core servers

### DIFF
--- a/nix/nixos-modules/routers/expo.nix
+++ b/nix/nixos-modules/routers/expo.nix
@@ -238,6 +238,22 @@ in
             };
             vlan = map (id: "vlan${toString id}${cfg.frrConferenceInterface}") conferenceVlans;
           };
+          # server access port - vlan 103
+          "30-copper2" = {
+            matchConfig.Name = "copper2";
+            networkConfig = {
+              Bridge = "bridge103";
+              LinkLocalAddressing = "no";
+            };
+          };
+          # av access port - vlan 105
+          "30-copper3" = {
+            matchConfig.Name = "copper3";
+            networkConfig = {
+              Bridge = "bridge105";
+              LinkLocalAddressing = "no";
+            };
+          };
           "40-bridge100" = {
             matchConfig.Name = "bridge100";
             enable = true;


### PR DESCRIPTION
## Description of PR

Add 2 access ports to the expo router

## Previous Behavior

- no access ports for copper2 and copper3

## New Behavior

- new access ports on copper2 and copper3

## Tests

- `nix build -L .#nixosConfigurations.router-expo.config.system.build.toplevel` and reviewd:

```
> cat result/etc/systemd/network/30-copper2.network
[Match]
Name=copper2

[Network]
Bridge=bridge103
LinkLocalAddressing=no

> cat result/etc/systemd/network/30-copper3.network
[Match]
Name=copper3

[Network]
Bridge=bridge105
LinkLocalAddressing=no
```