### PR TITLE
Spare switches sould be in group Z

### DIFF
--- a/switch-configuration/config/switchtypes
+++ b/switch-configuration/config/switchtypes
@@ -16,10 +16,10 @@
 // .9 = Stub (No subordinate switches) regardless of next level up switch
 //Name		Num	MgtVL	IPv6				Type		Hierarchy	Noiselevel	Model		Mgmt MAC
 NOC		1	503	2001:470:f026:503::200:1	cfNOC		I.9		Quiet		ex4200-48p	2c:6b:f5:39:e9:00
-SpareK		2	503	2001:470:f026:503::200:2	cfIDF		I.1		Loud		ex4200-48p	00:26:88:60:79:00
+SpareK		2	503	2001:470:f026:503::200:2	cfIDF		Z.9		Loud		ex4200-48p	00:26:88:60:79:00
 NW-IDF		3	103	2001:470:f026:103::200:3	exIDF		F.1		Loud		ex4200-48p	00:26:88:6e:ba:80
 NE-IDF		4	103	2001:470:f026:103::200:4	exIDF		C.1		Normal		ex4200-48p	00:26:88:7d:fb:00
-SpareL		5	103	2001:470:f026:103::200:5	exIDF		X.1		-		ex4200-48p	00:26:88:6e:aa:80
+SpareL		5	103	2001:470:f026:103::200:5	exIDF		Z.9		-		ex4200-48p	00:26:88:6e:aa:80
 Expo-Catwalk	6	103	2001:470:f026:103::200:6	Catwalk		W.1		Loud		ex4200-48p	00:26:88:7d:d3:00
 MassFlash	7	503	2001:470:f026:503::200:7	MassFlash	Z.9		Normal		ex4200-48p	00:26:88:6e:b6:80
 AVSwitch	8	503	2001:470:f026:503::200:8	cfAV		I.9		Quiet		ex4200-48p	00:26:88:7d:dd:80
@@ -27,8 +27,8 @@ DECEASED1	9	503	2001:470:f026:503::200:9	cfRoom		Z.9		Normal		ex4200-48p	00:26:8
 Rm211		10	503	2001:470:f026:503::200:10	cfRoom		I.9		Loud		ex4200-48p	2c:6b:f5:39:cb:80
 Rm214		11	503	2001:470:f026:503::200:11	cfRoom		I.9		Normal		ex4200-48p	00:26:88:60:71:00
 DECEASED3	12	503	2001:470:f026:503::200:12	cfRoom		Z.9		Normal		ex4200-48p	b0:c6:9a:dc:4d:80
-SpareG		13	503	2001:470:f026:503::200:13	cfRoom		I.9		Normal		ex4200-48p	00:26:88:7a:8f:80
-SpareH		14	503	2001:470:f026:503::200:14	cfRoom		I.9		Normal		ex4200-48p	00:26:88:7d:e5:80
+SpareG		13	503	2001:470:f026:503::200:13	cfRoom		Z.9		Normal		ex4200-48p	00:26:88:7a:8f:80
+SpareH		14	503	2001:470:f026:503::200:14	cfRoom		Z.9		Normal		ex4200-48p	00:26:88:7d:e5:80
 Rm105		15	503	2001:470:f026:503::200:15	cfRoom		I.9		??		ex4200-48p	b0:c6:9a:db:b5:00
 Rm106		16	503	2001:470:f026:503::200:16	cfRoom		I.9		??		ex4200-48p	00:26:88:7e:3e:00
 Rm107		17	503	2001:470:f026:503::200:17	cfRoom		I.9		Normal		ex4200-48p	00:26:88:6e:a6:80
@@ -54,7 +54,7 @@ ExpoC2		36	103	2001:470:f026:103::200:36	Booth		W.9		Normal		ex4200-48p	2c:6b:f5
 ExpoC3		37	103	2001:470:f026:103::200:37	Booth		W.9		Quiet		ex4200-48p	2c:6b:f5:37:cd:00
 ExpoC4		38	103	2001:470:f026:103::200:38	Booth		W.9		Normal		ex4200-48p	00:26:88:7e:1b:80
 ExpoC5		39	103	2001:470:f026:103::200:39	Booth		Z.9		Normal		ex4200-48p	00:26:88:70:d6:00
-SpareI		40	103	2001:470:f026:103::200:40	exRoom		C.9		Quiet		ex4200-48p	b0:c6:9a:64:85:80
+SpareI		40	103	2001:470:f026:103::200:40	exRoom		Z.9		Quiet		ex4200-48p	b0:c6:9a:64:85:80
 BallroomB	41	103	2001:470:f026:103::200:41	exRoom		C.9		Normal		ex4200-48p	00:26:88:70:bb:00
 BallroomC	42	103	2001:470:f026:103::200:42	exRoom		C.9		Normal		ex4200-48p	00:26:88:60:40:00
 BallroomD	43	103	2001:470:f026:103::200:43	exRoom		F.9		Normal		ex4200-48p	00:26:88:7d:1b:80


### PR DESCRIPTION
## Description of PR

Subject says it all

## Previous Behavior

switch_pinger hangs

## New Behavior

We don' need no steenkin spares clogging up our pings.

## Tests

Rotational velocity of a deceased feline.
