### PR TITLE
[READY] nix.services.ntp: allow UDP 123

### DIFF
--- a/nix/nixos-modules/services/ntp.nix
+++ b/nix/nixos-modules/services/ntp.nix
@@ -29,5 +29,8 @@ in
         restrict 2001:470:f026::/48 kod nomodify notrap nopeer
       '';
     };
+    networking.firewall = {
+      allowedUDPPorts = [ 123 ];
+    };
   };
 }


### PR DESCRIPTION
## Description of PR

ntp seems to be blocked on the core servers

## Previous Behavior

ntp not working

## New Behavior

ntp working

## Tests

live of course
