### PR TITLE
[READY] Fixing more ELS annoyances from Juniper.

### DIFF
--- a/switch-configuration/config/scripts/switch_template.pm
+++ b/switch-configuration/config/scripts/switch_template.pm
@@ -1980,9 +1980,14 @@ $USER_AUTHENTICATION
         ssh {
             no-passwords;
             protocol-version v2;
-        }
-        netconf {
-            ssh;
+EOF
+if ($Model !~ /ex4200/)
+{
+  $OUTPUT .= <<EOF;
+            sftp-server;
+EOF
+}
+$OUTPUT .= <<EOF;
         }
     }
     syslog {


### PR DESCRIPTION
## Description of PR

JunOS with ELS uses somewhat annoyingly different syntax than JunOS on the ex4200s.
In order to support the toy switches, we have to support ELS.

## Previous Behavior

We couldn't SCP or SFTP things to ELS switches.

## New Behavior

Config includes additional statement to enable SCP/SFTP mechanisms.

## Tests

Used balance scale to compare weights of unladen African and European swallows.
Turns out that the Pacific Gray Whale is heavier than both.
