### PR TITLE
feat(monitoring): replace jnxJsSPUMonitoring with jnxOperating for switch CPU metrics

### DIFF
--- a/nix/nixos-modules/services/grafana-dashboards/switch-views-global.json
+++ b/nix/nixos-modules/services/grafana-dashboards/switch-views-global.json
@@ -53,7 +53,7 @@
       },
       "gridPos": {
         "h": 4,
-        "w": 8,
+        "w": 6,
         "x": 0,
         "y": 0
       },
@@ -122,8 +122,8 @@
       },
       "gridPos": {
         "h": 4,
-        "w": 8,
-        "x": 8,
+        "w": 6,
+        "x": 6,
         "y": 0
       },
       "id": 2,
@@ -187,8 +187,8 @@
       },
       "gridPos": {
         "h": 4,
-        "w": 8,
-        "x": 16,
+        "w": 6,
+        "x": 12,
         "y": 0
       },
       "id": 4,
@@ -223,6 +223,79 @@
         }
       ],
       "title": "Total Switches Monitored",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PAE45454D0EDB9216"
+      },
+      "description": "Average CPU utilization across all switches in the fleet",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "yellow",
+                "value": 50
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 18,
+        "y": 0
+      },
+      "id": 10,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "12.1.1",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PAE45454D0EDB9216"
+          },
+          "expr": "avg(jnxOperatingCPU{job=\"switches\", jnxOperatingDescr=~\"Routing Engine.*\"})",
+          "instant": true,
+          "legendFormat": "Avg CPU",
+          "refId": "A"
+        }
+      ],
+      "title": "Fleet Average CPU Usage",
       "type": "stat"
     },
     {
@@ -422,6 +495,212 @@
         "type": "prometheus",
         "uid": "PAE45454D0EDB9216"
       },
+      "description": "Average CPU utilization across the switch fleet over time",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 25,
+            "gradientMode": "opacity",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "max": 100,
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "yellow",
+                "value": 50
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 12
+      },
+      "id": 11,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max",
+            "lastNotNull"
+          ],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "12.1.1",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PAE45454D0EDB9216"
+          },
+          "expr": "avg(jnxOperatingCPU{job=\"switches\", jnxOperatingDescr=~\"Routing Engine.*\"})",
+          "legendFormat": "Fleet Average",
+          "refId": "A"
+        }
+      ],
+      "title": "Fleet CPU Usage Over Time",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PAE45454D0EDB9216"
+      },
+      "description": "Top 10 switches by average CPU utilization",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "max": 100,
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              }
+            ]
+          },
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 12
+      },
+      "id": 12,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max",
+            "lastNotNull"
+          ],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "12.1.1",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PAE45454D0EDB9216"
+          },
+          "expr": "topk(10, avg by (switch) (jnxOperatingCPU{job=\"switches\", jnxOperatingDescr=~\"Routing Engine.*\"}))",
+          "legendFormat": "{{switch}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Top 10 Switches by CPU Usage",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PAE45454D0EDB9216"
+      },
       "description": "Overview of all switches with system info, uptime, and interface status",
       "fieldConfig": {
         "defaults": {
@@ -516,7 +795,7 @@
         "h": 7,
         "w": 24,
         "x": 0,
-        "y": 12
+        "y": 20
       },
       "id": 5,
       "options": {
@@ -667,7 +946,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 19
+        "y": 27
       },
       "id": 9,
       "options": {
@@ -785,7 +1064,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 19
+        "y": 27
       },
       "id": 8,
       "options": {

--- a/nix/nixos-modules/services/monitoring.nix
+++ b/nix/nixos-modules/services/monitoring.nix
@@ -307,7 +307,7 @@ in
         // Relabel switch targets for the standalone SNMP exporter.
         // The SNMP exporter is an HTTP service at 127.0.0.1:9116 that accepts
         // target, module, and auth as query parameters:
-        //   GET /snmp?target=[ipv6]:161&module=if_mib,system,jnxJsSPUMonitoring&auth=Junitux
+        //   GET /snmp?target=[ipv6]:161&module=if_mib,system,jnxOperating&auth=Junitux
         discovery.relabel "switches" {
           targets = discovery.file.switches.targets
 
@@ -323,7 +323,7 @@ in
 
           rule {
             target_label = "__param_module"
-            replacement  = "if_mib,system,jnxJsSPUMonitoring"
+            replacement  = "if_mib,system,jnxOperating"
           }
 
           rule {

--- a/nix/nixos-modules/services/snmp-alloy.yml
+++ b/nix/nixos-modules/services/snmp-alloy.yml
@@ -1,5 +1,5 @@
 # Prometheus SNMP Exporter configuration
-# Modules: if_mib, system, jnxJsSPUMonitoring
+# Modules: if_mib, system, jnxOperating
 # Auth: SNMPv2c with community "Junitux"
 auths:
   Junitux:
@@ -535,67 +535,114 @@ modules:
         type: DisplayString
         help: The physical location of this node.
   # ---------------------------------------------------------------------------
-  # jnxJsSPUMonitoring - Juniper SRX SPU Monitoring (JUNIPER-SRX-SPU-MONITORING-MIB)
-  # OID base: 1.3.6.1.4.1.2636.3.39.1.12.1.1 (jnxJsSPUMonitoringMIB)
-  # Table:    1.3.6.1.4.1.2636.3.39.1.12.1.1.1.1 (jnxJsSPUMonitoringObjectsTable)
+  # jnxOperating - Juniper Operating State (JUNIPER-MIB)
+  # OID base: 1.3.6.1.4.1.2636.3.1.13 (jnxOperatingTable)
+  # Provides CPU, memory, and temperature for EX/QFX/MX switch components
   # ---------------------------------------------------------------------------
-  jnxJsSPUMonitoring:
+  jnxOperating:
     walk:
-      - 1.3.6.1.4.1.2636.3.39.1.12.1.1
+      - 1.3.6.1.4.1.2636.3.1.13
     metrics:
-      - name: jnxJsSPUMonitoringCPUUsage
-        oid: 1.3.6.1.4.1.2636.3.39.1.12.1.1.1.1.4
-        type: gauge
-        help: SPU CPU utilization percentage.
-        indexes:
-          - labelname: jnxJsSPUMonitoringIndex
-            type: gauge
-      - name: jnxJsSPUMonitoringMemoryUsage
-        oid: 1.3.6.1.4.1.2636.3.39.1.12.1.1.1.1.5
-        type: gauge
-        help: SPU memory utilization percentage.
-        indexes:
-          - labelname: jnxJsSPUMonitoringIndex
-            type: gauge
-      - name: jnxJsSPUMonitoringCurrentFlowSession
-        oid: 1.3.6.1.4.1.2636.3.39.1.12.1.1.1.1.6
-        type: gauge
-        help: Current number of flow sessions on the SPU.
-        indexes:
-          - labelname: jnxJsSPUMonitoringIndex
-            type: gauge
-      - name: jnxJsSPUMonitoringMaxFlowSession
-        oid: 1.3.6.1.4.1.2636.3.39.1.12.1.1.1.1.7
-        type: gauge
-        help: Maximum number of flow sessions supported by the SPU.
-        indexes:
-          - labelname: jnxJsSPUMonitoringIndex
-            type: gauge
-      - name: jnxJsSPUMonitoringCurrentCPSession
-        oid: 1.3.6.1.4.1.2636.3.39.1.12.1.1.1.1.8
-        type: gauge
-        help: Current number of CP (central point) sessions on the SPU.
-        indexes:
-          - labelname: jnxJsSPUMonitoringIndex
-            type: gauge
-      - name: jnxJsSPUMonitoringMaxCPSession
-        oid: 1.3.6.1.4.1.2636.3.39.1.12.1.1.1.1.9
-        type: gauge
-        help: Maximum number of CP sessions supported by the SPU.
-        indexes:
-          - labelname: jnxJsSPUMonitoringIndex
-            type: gauge
-      - name: jnxJsSPUMonitoringNodeIndex
-        oid: 1.3.6.1.4.1.2636.3.39.1.12.1.1.1.1.2
-        type: gauge
-        help: Node index for identifying SPU in a cluster.
-        indexes:
-          - labelname: jnxJsSPUMonitoringIndex
-            type: gauge
-      - name: jnxJsSPUMonitoringNodeDescr
-        oid: 1.3.6.1.4.1.2636.3.39.1.12.1.1.1.1.3
+      - name: jnxOperatingDescr
+        oid: 1.3.6.1.4.1.2636.3.1.13.1.5
         type: DisplayString
-        help: Description of the SPU node.
+        help: Description of the operating component.
         indexes:
-          - labelname: jnxJsSPUMonitoringIndex
+          - labelname: jnxOperatingContentsIndex
             type: gauge
+          - labelname: jnxOperatingL1Index
+            type: gauge
+          - labelname: jnxOperatingL2Index
+            type: gauge
+          - labelname: jnxOperatingL3Index
+            type: gauge
+      - name: jnxOperatingCPU
+        oid: 1.3.6.1.4.1.2636.3.1.13.1.8
+        type: gauge
+        help: CPU utilization percentage of the operating component.
+        indexes:
+          - labelname: jnxOperatingContentsIndex
+            type: gauge
+          - labelname: jnxOperatingL1Index
+            type: gauge
+          - labelname: jnxOperatingL2Index
+            type: gauge
+          - labelname: jnxOperatingL3Index
+            type: gauge
+        lookups:
+          - labels: [jnxOperatingContentsIndex, jnxOperatingL1Index, jnxOperatingL2Index, jnxOperatingL3Index]
+            labelname: jnxOperatingDescr
+            oid: 1.3.6.1.4.1.2636.3.1.13.1.5
+            type: DisplayString
+      - name: jnxOperatingTemp
+        oid: 1.3.6.1.4.1.2636.3.1.13.1.7
+        type: gauge
+        help: Temperature of the operating component in degrees Celsius.
+        indexes:
+          - labelname: jnxOperatingContentsIndex
+            type: gauge
+          - labelname: jnxOperatingL1Index
+            type: gauge
+          - labelname: jnxOperatingL2Index
+            type: gauge
+          - labelname: jnxOperatingL3Index
+            type: gauge
+        lookups:
+          - labels: [jnxOperatingContentsIndex, jnxOperatingL1Index, jnxOperatingL2Index, jnxOperatingL3Index]
+            labelname: jnxOperatingDescr
+            oid: 1.3.6.1.4.1.2636.3.1.13.1.5
+            type: DisplayString
+      - name: jnxOperatingBuffer
+        oid: 1.3.6.1.4.1.2636.3.1.13.1.11
+        type: gauge
+        help: Buffer pool utilization percentage of the operating component.
+        indexes:
+          - labelname: jnxOperatingContentsIndex
+            type: gauge
+          - labelname: jnxOperatingL1Index
+            type: gauge
+          - labelname: jnxOperatingL2Index
+            type: gauge
+          - labelname: jnxOperatingL3Index
+            type: gauge
+        lookups:
+          - labels: [jnxOperatingContentsIndex, jnxOperatingL1Index, jnxOperatingL2Index, jnxOperatingL3Index]
+            labelname: jnxOperatingDescr
+            oid: 1.3.6.1.4.1.2636.3.1.13.1.5
+            type: DisplayString
+      - name: jnxOperating1MinLoadAvg
+        oid: 1.3.6.1.4.1.2636.3.1.13.1.20
+        type: gauge
+        help: 1-minute load average of the operating component.
+        indexes:
+          - labelname: jnxOperatingContentsIndex
+            type: gauge
+          - labelname: jnxOperatingL1Index
+            type: gauge
+          - labelname: jnxOperatingL2Index
+            type: gauge
+          - labelname: jnxOperatingL3Index
+            type: gauge
+        lookups:
+          - labels: [jnxOperatingContentsIndex, jnxOperatingL1Index, jnxOperatingL2Index, jnxOperatingL3Index]
+            labelname: jnxOperatingDescr
+            oid: 1.3.6.1.4.1.2636.3.1.13.1.5
+            type: DisplayString
+      - name: jnxOperating5MinLoadAvg
+        oid: 1.3.6.1.4.1.2636.3.1.13.1.21
+        type: gauge
+        help: 5-minute load average of the operating component.
+        indexes:
+          - labelname: jnxOperatingContentsIndex
+            type: gauge
+          - labelname: jnxOperatingL1Index
+            type: gauge
+          - labelname: jnxOperatingL2Index
+            type: gauge
+          - labelname: jnxOperatingL3Index
+            type: gauge
+        lookups:
+          - labels: [jnxOperatingContentsIndex, jnxOperatingL1Index, jnxOperatingL2Index, jnxOperatingL3Index]
+            labelname: jnxOperatingDescr
+            oid: 1.3.6.1.4.1.2636.3.1.13.1.5
+            type: DisplayString


### PR DESCRIPTION
## Summary
- Replaces the `jnxJsSPUMonitoring` (SRX SPU-specific) SNMP module with `jnxOperating` (JUNIPER-MIB), which provides CPU, temperature, buffer, and load average metrics for EX/QFX/MX switches
- Updates the SNMP exporter configuration with new OIDs and component-level index labels (`jnxOperatingContentsIndex`, `L1Index`, `L2Index`, `L3Index`) with description lookups
- Adds CPU utilization panels to the Grafana switch dashboard

## Test plan
- [x] Verify SNMP exporter starts and scrapes metrics from switches using the new `jnxOperating` module
- [x] Confirm Grafana dashboard loads and displays CPU metrics for switch components
- [x] Validate that `if_mib` and `system` modules continue to work alongside `jnxOperating`