### PR TITLE
[READY] - nixos-configartions.dev-server: these go to 15 (gitlab-runner)

### DIFF
--- a/nix/nixos-configurations/dev-server/default.nix
+++ b/nix/nixos-configurations/dev-server/default.nix
@@ -21,7 +21,7 @@
           libvirt.enable = true;
           services.gitlab = {
             enable = true;
-            concurrent = 5;
+            concurrent = 15;
           };
           services.bindMaster.enable = true;
           services.keaMaster.enable = true;


### PR DESCRIPTION
## Description of PR

<!--
Brief description of the changes in PR

If change is related to an open issue template include at the top of your
description.
-->
Trying to elevate some queueing on the dev-server when multiple PRs come into scale-network. We had some job queued at several minutes when many contributors are pushing.

## Previous Behavior
- 5 concurrent jobs
<!--
What was the behavior before this PR?

Remove this section if not relevant
-->

## New Behavior
- 15 concurrent jobs

<!--
What is the new behavior being introduced in this PR?

Remove this section if not relevant
-->

## Tests
-  applied to `dev-server` and confirm config:

```
[root@dev-server:~]# cat  /var/lib/gitlab-runner/.gitlab-runner/config.toml
concurrent = 15
```
<!--
How was this PR tested? Please provide as much detail as possible
so we can ensure this change is working as intended before being merged.
-->
