### PR TITLE
[READY] nix.modules.routers: set router ospf priorities

### DIFF
--- a/nix/nixos-modules/routers/border.nix
+++ b/nix/nixos-modules/routers/border.nix
@@ -315,6 +315,10 @@ in
         "bridge104" # expo
         "bridge901" # cf
       ];
+      services.frr.interface-priority = {
+        "bridge104" = 200;
+        "bridge901" = 200;
+      };
       services.frr.passive-interface = [
         cfg.WANInterface
         "bridge103"

--- a/nix/nixos-modules/routers/conference.nix
+++ b/nix/nixos-modules/routers/conference.nix
@@ -432,6 +432,10 @@ in
         "bridge901" # border
         "bridge903" # expo
       ];
+      services.frr.interface-priority = {
+        "bridge901" = 50;
+        "bridge903" = 50;
+      };
       services.frr.passive-interface = [
         "bridge500"
         "bridge501"

--- a/nix/nixos-modules/routers/expo.nix
+++ b/nix/nixos-modules/routers/expo.nix
@@ -341,6 +341,10 @@ in
         "bridge104" # border
         "bridge903" # conf
       ];
+      services.frr.interface-priority = {
+        "bridge104" = 100;
+        "bridge903" = 100;
+      };
       services.frr.passive-interface = [
         "bridge100"
         "bridge101"

--- a/nix/nixos-modules/services/frr.nix
+++ b/nix/nixos-modules/services/frr.nix
@@ -25,6 +25,7 @@ let
 
   inherit (lib.strings)
     concatStringsSep
+    optionalString
     ;
 in
 {
@@ -46,6 +47,12 @@ in
       description = "Passive Interface";
       type = types.listOf types.str;
       default = [ ];
+    };
+
+    interface-priority = mkOption {
+      description = "OSPF priority per interface for DR election";
+      type = types.attrsOf types.int;
+      default = { };
     };
 
     routing-config = mkOption {
@@ -89,7 +96,13 @@ in
               interface ${x}
                no ip ospf passive
                ip ospf network broadcast
+               ${optionalString (builtins.hasAttr x cfg.interface-priority) "ip ospf priority ${
+                 toString cfg.interface-priority.${x}
+               }"}
                ipv6 ospf6 network broadcast
+               ${optionalString (builtins.hasAttr x cfg.interface-priority) "ipv6 ospf6 priority ${
+                 toString cfg.interface-priority.${x}
+               }"}
                ipv6 ospf6 area 0
               exit
             '') cfg.broadcast-interface


### PR DESCRIPTION
## Description of PR

Set OSPF priorities

## Previous Behavior

no priorities set for OSPF

## New Behavior

OSPF priorities set

## Tests

`nix run .#hydraJobs.scale-nixos-tests.x86_64-linux.routers.driverInteractive` and then login to the routers and run: `show ip ospf neighbor` and `show ipv6 ospf6 neighbor` + `show ip ospf interface $interface` and `show ipv6 ospf6 interface $interface` and review outputs

border:
```
> nix build -L .#nixosConfigurations.router-border.config.system.build.toplevel
> cat result/etc/frr/frr.conf
! FRR configuration
!
hostname router-border
log syslog
service password-encryption
service integrated-vtysh-config
!
router-id 172.20.1.1
interface bridge104
 no ip ospf passive
 ip ospf network broadcast
 ip ospf priority 200
 ipv6 ospf6 network broadcast
 ipv6 ospf6 priority 200
 ipv6 ospf6 area 0
exit

interface bridge901
 no ip ospf passive
 ip ospf network broadcast
 ip ospf priority 200
 ipv6 ospf6 network broadcast
 ipv6 ospf6 priority 200
 ipv6 ospf6 area 0
exit

interface copper0
 ipv6 ospf6 passive

interface bridge103
 ipv6 ospf6 passive

router ospf
 passive-interface default
 network 0.0.0.0/0 area 0
 redistribute connected
exit
router ospf6
 redistribute connected
 redistribute kernel
 default-information originate
exit

!
end
```

expo
```
> nix build -L .#nixosConfigurations.router-expo.config.system.build.toplevel
> cat result/etc/frr/frr.conf
! FRR configuration
!
hostname router-expo
log syslog
service password-encryption
service integrated-vtysh-config
!
router-id 172.20.4.3
interface bridge104
 no ip ospf passive
 ip ospf network broadcast
 ip ospf priority 100
 ipv6 ospf6 network broadcast
 ipv6 ospf6 priority 100
 ipv6 ospf6 area 0
exit

interface bridge903
 no ip ospf passive
 ip ospf network broadcast
 ip ospf priority 100
 ipv6 ospf6 network broadcast
 ipv6 ospf6 priority 100
 ipv6 ospf6 area 0
exit

interface bridge100
 ipv6 ospf6 passive

interface bridge101
 ipv6 ospf6 passive

interface bridge102
 ipv6 ospf6 passive

interface bridge105
 ipv6 ospf6 passive

interface bridge107
 ipv6 ospf6 passive

interface bridge110
 ipv6 ospf6 passive

router ospf
 passive-interface default
 network 0.0.0.0/0 area 0
 redistribute connected
exit
router ospf6
 redistribute connected
exit

!
end
```

conf
```
> nix build -L .#nixosConfigurations.router-conf.config.system.build.toplevel
> cat result/etc/frr/frr.conf
! FRR configuration
!
hostname router-conf
log syslog
service password-encryption
service integrated-vtysh-config
!
router-id 172.20.1.2
interface bridge901
 no ip ospf passive
 ip ospf network broadcast
 ip ospf priority 50
 ipv6 ospf6 network broadcast
 ipv6 ospf6 priority 50
 ipv6 ospf6 area 0
exit

interface bridge903
 no ip ospf passive
 ip ospf network broadcast
 ip ospf priority 50
 ipv6 ospf6 network broadcast
 ipv6 ospf6 priority 50
 ipv6 ospf6 area 0
exit

interface bridge500
 ipv6 ospf6 passive

interface bridge501
 ipv6 ospf6 passive

interface bridge502
 ipv6 ospf6 passive

interface bridge504
 ipv6 ospf6 passive

interface bridge505
 ipv6 ospf6 passive

interface bridge506
 ipv6 ospf6 passive

interface bridge507
 ipv6 ospf6 passive

router ospf
 passive-interface default
 network 0.0.0.0/0 area 0
 redistribute connected
exit
router ospf6
 redistribute connected
exit

!
end
```