### PR TITLE
[READY] - nix.package-sets..make-dhcpd: work with untagged ifaces

### DIFF
--- a/nix/package-sets/top-level/scale-network/make-dhcpd/make-dhcpd.sh
+++ b/nix/package-sets/top-level/scale-network/make-dhcpd/make-dhcpd.sh
@@ -1,3 +1,43 @@
+#shellcheck disable=SC2086
+FILENAME="$(basename $0)"
+
+usage(){
+  cat << EOF
+usage: $FILENAME [OPTIONS] ARGS
+
+dhcpd service for adhoc dhcp
+
+OPTIONS:
+  -h      Show this message
+
+EXAMPLES:
+  Create a tagged interface and start dhcpd:
+
+      $FILENAME enp7s0f4u2.503
+
+  To print out this message:
+
+      $FILENAME -h
+
+EOF
+}
+
+while getopts "h" OPTION
+do
+  case $OPTION in
+    h )
+      usage
+      exit 0
+      ;;
+    \? )
+      usage
+      exit 1
+      ;;
+  esac
+done
+
+shift $((OPTIND -1))
+
 if [[ -z "$1" ]]; then
   echo "ERROR: Please pass interface for dhcp server to bind to"
   exit 1
@@ -5,17 +45,23 @@ fi
 
 IFACE=$1
 
-sudo ip link add link "$IFACE" name "$IFACE".503 type vlan id 503
-sudo ip addr add 192.168.254.1/24 dev "$IFACE".503
+if [[ "$IFACE" == *.* ]]; then
+  #shellcheck disable=SC2046
+  sudo ip link add link $(echo "$IFACE" | cut -d . -f1) name "$IFACE" type vlan id $(echo "$IFACE" | cut -d . -f2)
+fi
+sudo ip addr add 192.168.254.1/24 dev "$IFACE"
+if [[ "$IFACE" == *.* ]]; then
+  #shellcheck disable=SC2046
+  sudo ip link set up $(echo "$IFACE" | cut -d . -f1)
+fi
 sudo ip link set up "$IFACE"
-sudo ip link set up "$IFACE".503
 
 if systemctl is-active --quiet service firewall; then
   echo -e "\nWARN: firewall is running so dhcp server might not be able to hand out leases\n\
 WARN: consider running: sudo systemctl stop firewall\n"
 fi
 
-sudo dnsmasq -i "$IFACE".503 \
+sudo dnsmasq -i "$IFACE" \
   --dhcp-range=192.168.254.100,192.168.254.120,255.255.255.0,120s \
   --dhcp-option=3,192.168.254.1 \
   -p0 -d \


### PR DESCRIPTION

## Description of PR

<!--
Brief description of the changes in PR

If change is related to an open issue template include at the top of your
description.
-->

Adding the ability to spin up a dhcp server on a given interface.

Also added a usage and -h flag for sanity.

## Previous Behavior
- make-dhcpd only setup ifaces on x.503

<!--
What was the behavior before this PR?

Remove this section if not relevant
-->

## New Behavior
- ability to setup on untagged and tagged interfaces
<!--
What is the new behavior being introduced in this PR?

Remove this section if not relevant
-->

## Tests
- Tested against my local machine and a openwrt device (netgear wndr3800)
<!--
How was this PR tested? Please provide as much detail as possible
so we can ensure this change is working as intended before being merged.
-->
