### PR TITLE
router*: add helpful altnames to router interfaces

### DIFF
--- a/nix/nixos-configurations/router-border/default.nix
+++ b/nix/nixos-configurations/router-border/default.nix
@@ -2,11 +2,14 @@
   release = "unstable";
 
   modules =
-    {
-      config,
-      lib,
-      ...
-    }:
+    { lib, ... }:
+    let
+      inherit (lib)
+        const
+        mapAttrs
+        recursiveUpdate
+        ;
+    in
     {
       imports = [
         ./configuration.nix
@@ -15,7 +18,6 @@
       ];
 
       config = {
-
         # verify: modinfo -p ixgbe
         boot.extraModprobeConfig = ''
           options ixgbe allow_unsupported_sfp=1,1
@@ -24,23 +26,70 @@
 
         nixpkgs.hostPlatform = "x86_64-linux";
 
-        # make friend eth names based on paths from lspci -D
-        services.udev.extraRules = ''
-          # Ethernet controller: Realtek Semiconductor Co., Ltd. RTL8111/8168/8211/8411 PCI Express Gigabit Ethernet Controller (rev 15)
-          SUBSYSTEM=="net", ACTION=="add", KERNELS=="0000:11:00.0", NAME="backdoor0"
-          # Ethernet controller: Intel Corporation 82599ES 10-Gigabit SFI/SFP+ Network Connection (rev 01)
-          SUBSYSTEM=="net", ACTION=="add", KERNELS=="0000:03:00.0", NAME="fiber0"
-          SUBSYSTEM=="net", ACTION=="add", KERNELS=="0000:03:00.1", NAME="fiber1"
-          SUBSYSTEM=="net", ACTION=="add", KERNELS=="0000:06:00.0", NAME="fiber2"
-          SUBSYSTEM=="net", ACTION=="add", KERNELS=="0000:06:00.1", NAME="fiber3"
-          # Ethernet controller: Intel Corporation I350 Gigabit Network Connection (rev 01)
-          SUBSYSTEM=="net", ACTION=="add", KERNELS=="0000:0d:00.0", NAME="copper0"
-          SUBSYSTEM=="net", ACTION=="add", KERNELS=="0000:0d:00.1", NAME="copper1"
-          SUBSYSTEM=="net", ACTION=="add", KERNELS=="0000:0d:00.2", NAME="copper2"
-          SUBSYSTEM=="net", ACTION=="add", KERNELS=="0000:0d:00.3", NAME="copper3"
-        '';
-
         systemd.network = {
+          # make friend eth names based on paths from lspci -D
+          links =
+            mapAttrs
+              (const (recursiveUpdate {
+                linkConfig.AlternativeNamesPolicy = [
+                  "database"
+                  "onboard"
+                  "slot"
+                  "path"
+                  "mac"
+                ];
+              }))
+              {
+                # Ethernet controller: Realtek Semiconductor Co., Ltd. RTL8111/8168/8211/8411 PCI Express Gigabit Ethernet Controller (rev 15)
+                "10-backdoor0" = {
+                  matchConfig.Path = "pci-0000:11:00.0";
+                  linkConfig.Name = "backdoor0";
+                };
+                # Ethernet controller: Intel Corporation I350 Gigabit Network Connection (rev 01)
+                "10-copper0" = {
+                  matchConfig.Path = "pci-0000:0d:00.0";
+                  linkConfig = {
+                    Name = "copper0";
+                    AlternativeName = "internet0";
+                  };
+                };
+                "10-copper1" = {
+                  matchConfig.Path = "pci-0000:0d:00.1";
+                  linkConfig.Name = "copper1";
+                };
+                "10-copper2" = {
+                  matchConfig.Path = "pci-0000:0d:00.2";
+                  linkConfig.Name = "copper2";
+                };
+                "10-copper3" = {
+                  matchConfig.Path = "pci-0000:0d:00.3";
+                  linkConfig.Name = "copper3";
+                };
+                # Ethernet controller: Intel Corporation 82599ES 10-Gigabit SFI/SFP+ Network Connection (rev 01)
+                "10-fiber0" = {
+                  matchConfig.Path = "pci-0000:03:00.0";
+                  linkConfig = {
+                    Name = "fiber0";
+                    AlternativeName = "toconf0";
+                  };
+                };
+                "10-fiber1" = {
+                  matchConfig.Path = "pci-0000:03:00.1";
+                  linkConfig = {
+                    Name = "fiber1";
+                    AlternativeName = "toexpo0";
+                  };
+                };
+                "10-fiber2" = {
+                  matchConfig.Path = "pci-0000:06:00.0";
+                  linkConfig.Name = "fiber2";
+                };
+                "10-fiber3" = {
+                  matchConfig.Path = "pci-0000:06:00.1";
+                  linkConfig.Name = "fiber3";
+                };
+              };
+
           networks = {
             # Keep this for troubleshooting
             "10-backdoor" = {

--- a/nix/nixos-configurations/router-conf/default.nix
+++ b/nix/nixos-configurations/router-conf/default.nix
@@ -2,11 +2,14 @@
   release = "unstable";
 
   modules =
-    {
-      config,
-      lib,
-      ...
-    }:
+    { lib, ... }:
+    let
+      inherit (lib)
+        const
+        mapAttrs
+        recursiveUpdate
+        ;
+    in
     {
       imports = [
         ./configuration.nix
@@ -15,7 +18,6 @@
       ];
 
       config = {
-
         # verify: modinfo -p ixgbe
         boot.extraModprobeConfig = ''
           options ixgbe allow_unsupported_sfp=1,1
@@ -23,23 +25,70 @@
         boot.kernelParams = [ "ixgbe" ];
 
         nixpkgs.hostPlatform = "x86_64-linux";
-        # make friend eth names based on paths from lspci
-        services.udev.extraRules = ''
-          # Ethernet controller: Realtek Semiconductor Co., Ltd. RTL8111/8168/8211/8411 PCI Express Gigabit Ethernet Controller (rev 15)
-          SUBSYSTEM=="net", ACTION=="add", KERNELS=="0000:11:00.0", NAME="backdoor0"
-          # Ethernet controller: Intel Corporation 82599ES 10-Gigabit SFI/SFP+ Network Connection (rev 01)
-          SUBSYSTEM=="net", ACTION=="add", KERNELS=="0000:03:00.0", NAME="fiber0"
-          SUBSYSTEM=="net", ACTION=="add", KERNELS=="0000:03:00.1", NAME="fiber1"
-          SUBSYSTEM=="net", ACTION=="add", KERNELS=="0000:06:00.0", NAME="fiber2"
-          SUBSYSTEM=="net", ACTION=="add", KERNELS=="0000:06:00.1", NAME="fiber3"
-          # Ethernet controller: Intel Corporation I350 Gigabit Network Connection (rev 01)
-          SUBSYSTEM=="net", ACTION=="add", KERNELS=="0000:0d:00.0", NAME="copper0"
-          SUBSYSTEM=="net", ACTION=="add", KERNELS=="0000:0d:00.1", NAME="copper1"
-          SUBSYSTEM=="net", ACTION=="add", KERNELS=="0000:0d:00.2", NAME="copper2"
-          SUBSYSTEM=="net", ACTION=="add", KERNELS=="0000:0d:00.3", NAME="copper3"
-        '';
 
         systemd.network = {
+          # make friend eth names based on paths from lspci -D
+          links =
+            mapAttrs
+              (const (recursiveUpdate {
+                linkConfig.AlternativeNamesPolicy = [
+                  "database"
+                  "onboard"
+                  "slot"
+                  "path"
+                  "mac"
+                ];
+              }))
+              {
+                # Ethernet controller: Realtek Semiconductor Co., Ltd. RTL8111/8168/8211/8411 PCI Express Gigabit Ethernet Controller (rev 15)
+                "10-backdoor0" = {
+                  matchConfig.Path = "pci-0000:11:00.0";
+                  linkConfig.Name = "backdoor0";
+                };
+                # Ethernet controller: Intel Corporation I350 Gigabit Network Connection (rev 01)
+                "10-copper0" = {
+                  matchConfig.Path = "pci-0000:0d:00.0";
+                  linkConfig = {
+                    Name = "copper0";
+                    AlternativeName = "TRconfidf";
+                  };
+                };
+                "10-copper1" = {
+                  matchConfig.Path = "pci-0000:0d:00.1";
+                  linkConfig.Name = "copper1";
+                };
+                "10-copper2" = {
+                  matchConfig.Path = "pci-0000:0d:00.2";
+                  linkConfig.Name = "copper2";
+                };
+                "10-copper3" = {
+                  matchConfig.Path = "pci-0000:0d:00.3";
+                  linkConfig.Name = "copper3";
+                };
+                # Ethernet controller: Intel Corporation 82599ES 10-Gigabit SFI/SFP+ Network Connection (rev 01)
+                "10-fiber0" = {
+                  matchConfig.Path = "pci-0000:03:00.0";
+                  linkConfig = {
+                    Name = "fiber0";
+                    AlternativeName = "toborder0";
+                  };
+                };
+                "10-fiber1" = {
+                  matchConfig.Path = "pci-0000:03:00.1";
+                  linkConfig = {
+                    Name = "fiber1";
+                    AlternativeName = "toexpo0";
+                  };
+                };
+                "10-fiber2" = {
+                  matchConfig.Path = "pci-0000:06:00.0";
+                  linkConfig.Name = "fiber2";
+                };
+                "10-fiber3" = {
+                  matchConfig.Path = "pci-0000:06:00.1";
+                  linkConfig.Name = "fiber3";
+                };
+              };
           networks = {
             # Keep this for troubleshooting
             "10-backdoor" = {

--- a/nix/nixos-configurations/router-expo/default.nix
+++ b/nix/nixos-configurations/router-expo/default.nix
@@ -2,11 +2,14 @@
   release = "unstable";
 
   modules =
-    {
-      config,
-      lib,
-      ...
-    }:
+    { lib, ... }:
+    let
+      inherit (lib)
+        const
+        mapAttrs
+        recursiveUpdate
+        ;
+    in
     {
       imports = [
         ./configuration.nix
@@ -15,7 +18,6 @@
       ];
 
       config = {
-
         # verify: modinfo -p ixgbe
         boot.extraModprobeConfig = ''
           options ixgbe allow_unsupported_sfp=1,1
@@ -23,23 +25,85 @@
         boot.kernelParams = [ "ixgbe" ];
 
         nixpkgs.hostPlatform = "x86_64-linux";
-        # make friend eth names based on paths from lspci
-        services.udev.extraRules = ''
-          # Ethernet controller: Realtek Semiconductor Co., Ltd. RTL8111/8168/8211/8411 PCI Express Gigabit Ethernet Controller (rev 15)
-          SUBSYSTEM=="net", ACTION=="add", KERNELS=="0000:11:00.0", NAME="backdoor0"
-          # Ethernet controller: Intel Corporation 82599ES 10-Gigabit SFI/SFP+ Network Connection (rev 01)
-          SUBSYSTEM=="net", ACTION=="add", KERNELS=="0000:03:00.0", NAME="fiber0"
-          SUBSYSTEM=="net", ACTION=="add", KERNELS=="0000:03:00.1", NAME="fiber1"
-          SUBSYSTEM=="net", ACTION=="add", KERNELS=="0000:06:00.0", NAME="fiber2"
-          SUBSYSTEM=="net", ACTION=="add", KERNELS=="0000:06:00.1", NAME="fiber3"
-          # Ethernet controller: Intel Corporation I350 Gigabit Network Connection (rev 01)
-          SUBSYSTEM=="net", ACTION=="add", KERNELS=="0000:0d:00.0", NAME="copper0"
-          SUBSYSTEM=="net", ACTION=="add", KERNELS=="0000:0d:00.1", NAME="copper1"
-          SUBSYSTEM=="net", ACTION=="add", KERNELS=="0000:0d:00.2", NAME="copper2"
-          SUBSYSTEM=="net", ACTION=="add", KERNELS=="0000:0d:00.3", NAME="copper3"
-        '';
 
         systemd.network = {
+          # make friend eth names based on paths from lspci -D
+          links =
+            mapAttrs
+              (const (recursiveUpdate {
+                linkConfig.AlternativeNamesPolicy = [
+                  "database"
+                  "onboard"
+                  "slot"
+                  "path"
+                  "mac"
+                ];
+              }))
+              {
+                # Ethernet controller: Realtek Semiconductor Co., Ltd. RTL8111/8168/8211/8411 PCI Express Gigabit Ethernet Controller (rev 15)
+                "10-backdoor0" = {
+                  matchConfig.Path = "pci-0000:11:00.0";
+                  linkConfig.Name = "backdoor0";
+                };
+                # Ethernet controller: Intel Corporation I350 Gigabit Network Connection (rev 01)
+                "10-copper0" = {
+                  matchConfig.Path = "pci-0000:0d:00.0";
+                  linkConfig = {
+                    Name = "copper0";
+                    AlternativeName = "TRexpoIDF";
+                  };
+                };
+                "10-copper1" = {
+                  matchConfig.Path = "pci-0000:0d:00.1";
+                  linkConfig = {
+                    Name = "copper1";
+                    AlternativeName = "TRCatwalk";
+                  };
+                };
+                "10-copper2" = {
+                  matchConfig.Path = "pci-0000:0d:00.2";
+                  linkConfig = {
+                    Name = "copper2";
+                    AlternativeName = "TechServer";
+                  };
+                };
+                "10-copper3" = {
+                  matchConfig.Path = "pci-0000:0d:00.3";
+                  linkConfig = {
+                    Name = "copper3";
+                    AlternativeName = "AVServer";
+                  };
+                };
+                # Ethernet controller: Intel Corporation 82599ES 10-Gigabit SFI/SFP+ Network Connection (rev 01)
+                "10-fiber0" = {
+                  matchConfig.Path = "pci-0000:03:00.0";
+                  linkConfig = {
+                    Name = "fiber0";
+                    AlternativeName = "toborder0";
+                  };
+                };
+                "10-fiber1" = {
+                  matchConfig.Path = "pci-0000:03:00.1";
+                  linkConfig = {
+                    Name = "fiber1";
+                    AlternativeName = "toconf0";
+                  };
+                };
+                "10-fiber2" = {
+                  matchConfig.Path = "pci-0000:06:00.0";
+                  linkConfig = {
+                    Name = "fiber2";
+                    AlternativeName = "TRneidf0";
+                  };
+                };
+                "10-fiber3" = {
+                  matchConfig.Path = "pci-0000:06:00.1";
+                  linkConfig = {
+                    Name = "fiber3";
+                    AlternativeName = "TRnwidf0";
+                  };
+                };
+              };
           networks = {
             # Keep this for troubleshooting
             "10-backdoor" = {


### PR DESCRIPTION
## Description of PR

Add helpful alternative names to router interfaces.
<!--
Brief description of the changes in PR

If change is related to an open issue template include at the top of your
description.
-->

## Previous Behavior

Interface names only contained hardware type and interface index.
<!--
What was the behavior before this PR?

Remove this section if not relevant
-->

## New Behavior

Interface names contain alternate names that describe the interface function.
<!--
What is the new behavior being introduced in this PR?

Remove this section if not relevant
-->

## Tests

Tested on a deployment to router-expo.
<!--
How was this PR tested? Please provide as much detail as possible
so we can ensure this change is working as intended before being merged.
-->
