### PR TITLE
fix(monitoring): increase limits for mimir

### DIFF
--- a/nix/nixos-modules/services/monitoring.nix
+++ b/nix/nixos-modules/services/monitoring.nix
@@ -143,6 +143,10 @@ in
             storage_prefix = "ruler";
           };
 
+          limits = {
+            max_global_series_per_user = 300000;
+          };
+
           alertmanager_storage = {
             storage_prefix = "alertmanager";
           };


### PR DESCRIPTION
## Summary
- Increase `max_global_series_per_user` to 300,000 in Mimir configuration to prevent series limit issues during monitoring

## Test plan
- [x] Verify Mimir starts successfully with the updated limits
- [x] Confirm monitoring metrics are being ingested without hitting series limits