### PR TITLE
[READY] - nixos-modules.routers.border: allow lo on input filter

### DIFF
--- a/nix/nixos-modules/routers/border.nix
+++ b/nix/nixos-modules/routers/border.nix
@@ -255,7 +255,7 @@ in
            type filter hook input priority filter;
            policy drop;
            # Show internal traffic (To the router only via the management net)
-           iifname { bridge103, bridge104, backdoor0 } accept;
+           iifname { bridge103, bridge104, backdoor0, lo } accept;
            # Allow traffic from Owen's network
            ip6 saddr 2620:0:930::/48 accept;
            # Existing Flows


### PR DESCRIPTION
## Description of PR

<!--
Brief description of the changes in PR

If change is related to an open issue template include at the top of your
description.
-->

Was unable to resolve locally:

```
[root@router-border:~]# nixos-rebuild dry-activate --flake github:socallinuxexpo/scale-network#router-border --refresh
building the system configuration...
warning: error: unable to download 'https://api.github.com/repos/socallinuxexpo/scale-network/commits/HEAD': Could not resolve hostname (6) Could not
resolve host: api.github.com; retrying in 311 ms
^C

[root@router-border:~]# nixos-rebuild dry-activate --flake github:socallinuxexpo/scale-network#router-border --refresh
building the system configuration...
downloading 'https://api.github.com/repos/socallinuxexpo/scale-network/commits/HEAD'^C

[root@router-border:~]# dig api.github.com
^C
[root@router-border:~]# dig github.com
^C
[root@router-border:~]# dig google.com
;; communications error to 127.0.0.53#53: timed out
```
## Previous Behavior
- unable to resolve locally on border
<!--
What was the behavior before this PR?

Remove this section if not relevant
-->

## New Behavior
- able to resolve locally on border
<!--
What is the new behavior being introduced in this PR?

Remove this section if not relevant
-->

## Tests
- Confirmed by applied to border router
<!--
How was this PR tested? Please provide as much detail as possible
so we can ensure this change is working as intended before being merged.
-->
