### PR TITLE
[READY] facts.inventory: add uplink check to wasgeht

### DIFF
--- a/facts/inventory.py
+++ b/facts/inventory.py
@@ -1033,6 +1033,17 @@ switch{{ item['num'] }}  IN  CNAME   {{item['fqdn'] }}.
 
 def generatewasgehtconfig(switches, routers, pis, aps, servers, outputdir):
     wasgehtconfig = {}
+    wasgehtconfig["uplink"] = {
+        "checks": {
+            "ping": {"addresses": ["2001:470:c:3d::1", "4.8.155.1"]},
+            "http": {
+                "urls": [
+                    "https://www.google.com",
+                    "https://www.socallinuxexpo.org/scale/23x",
+                ]
+            },
+        }
+    }
     for switch in switches:
         entry = {
             "tags": {


### PR DESCRIPTION
## Description of PR

add a wasgeht check for uplink

## Previous Behavior

no check outside of network

## New Behavior

check outside of network

## Tests

`nix build .#hydraJobs.scale-network.x86_64-linux.scale-inventory`

```
> cat result/config/scale-wasgeht-config.json | head -17
{
  "uplink": {
    "checks": {
      "ping": {
        "addresses": [
          "2001:470:c:3d::1",
          "4.8.155.1"
        ]
      },
      "http": {
        "urls": [
          "https://www.google.com",
          "https://www.socallinuxexpo.org/scale/23x"
        ]
      }
    }
  },
  ```
