### PR TITLE
Clean up SNMP metrics

### DIFF
--- a/facts/inventory.py
+++ b/facts/inventory.py
@@ -949,7 +949,7 @@ def generatekeaconfig(servers, aps, vlans, outputdir):
 
 def _prom_exclude(name):
     """Return True if the name should be excluded from prom configs."""
-    return re.match(r"^(deceased|donotuse|massflash|spare)", name)
+    return re.match(r"^(deceased|donotuse|massflash|spare|expob5|expoc4|expoc5)", name)
 
 
 def generatepromconfigs(switches, pis, aps, outputdir):

--- a/nix/nixos-modules/services/snmp-alloy.yml
+++ b/nix/nixos-modules/services/snmp-alloy.yml
@@ -17,66 +17,10 @@ modules:
       - 1.3.6.1.2.1.2
       - 1.3.6.1.2.1.31.1.1
     metrics:
-      - name: ifNumber
-        oid: 1.3.6.1.2.1.2.1
-        type: gauge
-        help: The number of network interfaces present on this system.
-      # -- ifTable scalars (indexed by ifIndex) --
-      - name: ifType
-        oid: 1.3.6.1.2.1.2.2.1.3
-        type: EnumAsInfo
-        help: The type of interface.
-        indexes:
-          - labelname: ifIndex
-            type: gauge
-        lookups:
-          - labels: [ifIndex]
-            labelname: ifAlias
-            oid: 1.3.6.1.2.1.31.1.1.1.18
-            type: DisplayString
-          - labels: [ifIndex]
-            labelname: ifDescr
-            oid: 1.3.6.1.2.1.2.2.1.2
-            type: DisplayString
-          - labels: [ifIndex]
-            labelname: ifName
-            oid: 1.3.6.1.2.1.31.1.1.1.1
-            type: DisplayString
-        enum_values:
-          1: other
-          6: ethernetCsmacd
-          24: softwareLoopback
-          53: propVirtual
-          131: tunnel
-          135: l2vlan
-          136: l3ipvlan
-          150: mplsTunnel
-          161: ieee8023adLag
-          209: bridge
       - name: ifMtu
         oid: 1.3.6.1.2.1.2.2.1.4
         type: gauge
         help: The size of the largest packet which can be sent/received on the interface, in octets.
-        indexes:
-          - labelname: ifIndex
-            type: gauge
-        lookups:
-          - labels: [ifIndex]
-            labelname: ifAlias
-            oid: 1.3.6.1.2.1.31.1.1.1.18
-            type: DisplayString
-          - labels: [ifIndex]
-            labelname: ifDescr
-            oid: 1.3.6.1.2.1.2.2.1.2
-            type: DisplayString
-          - labels: [ifIndex]
-            labelname: ifName
-            oid: 1.3.6.1.2.1.31.1.1.1.1
-            type: DisplayString
-      - name: ifSpeed
-        oid: 1.3.6.1.2.1.2.2.1.5
-        type: gauge
-        help: An estimate of the interface's current bandwidth in bits per second.
         indexes:
           - labelname: ifIndex
             type: gauge
@@ -145,67 +89,6 @@ modules:
           5: dormant
           6: notPresent
           7: lowerLayerDown
-      - name: ifLastChange
-        oid: 1.3.6.1.2.1.2.2.1.9
-        type: gauge
-        help: The value of sysUpTime at the time the interface entered its current operational state.
-        indexes:
-          - labelname: ifIndex
-            type: gauge
-        lookups:
-          - labels: [ifIndex]
-            labelname: ifAlias
-            oid: 1.3.6.1.2.1.31.1.1.1.18
-            type: DisplayString
-          - labels: [ifIndex]
-            labelname: ifDescr
-            oid: 1.3.6.1.2.1.2.2.1.2
-            type: DisplayString
-          - labels: [ifIndex]
-            labelname: ifName
-            oid: 1.3.6.1.2.1.31.1.1.1.1
-            type: DisplayString
-      # -- 32-bit counters (ifTable) --
-      - name: ifInOctets
-        oid: 1.3.6.1.2.1.2.2.1.10
-        type: counter
-        help: The total number of octets received on the interface, including framing characters.
-        indexes:
-          - labelname: ifIndex
-            type: gauge
-        lookups:
-          - labels: [ifIndex]
-            labelname: ifAlias
-            oid: 1.3.6.1.2.1.31.1.1.1.18
-            type: DisplayString
-          - labels: [ifIndex]
-            labelname: ifDescr
-            oid: 1.3.6.1.2.1.2.2.1.2
-            type: DisplayString
-          - labels: [ifIndex]
-            labelname: ifName
-            oid: 1.3.6.1.2.1.31.1.1.1.1
-            type: DisplayString
-      - name: ifInUcastPkts
-        oid: 1.3.6.1.2.1.2.2.1.11
-        type: counter
-        help: The number of unicast packets delivered to a higher layer.
-        indexes:
-          - labelname: ifIndex
-            type: gauge
-        lookups:
-          - labels: [ifIndex]
-            labelname: ifAlias
-            oid: 1.3.6.1.2.1.31.1.1.1.18
-            type: DisplayString
-          - labels: [ifIndex]
-            labelname: ifDescr
-            oid: 1.3.6.1.2.1.2.2.1.2
-            type: DisplayString
-          - labels: [ifIndex]
-            labelname: ifName
-            oid: 1.3.6.1.2.1.31.1.1.1.1
-            type: DisplayString
       - name: ifInDiscards
         oid: 1.3.6.1.2.1.2.2.1.13
         type: counter
@@ -230,46 +113,6 @@ modules:
         oid: 1.3.6.1.2.1.2.2.1.14
         type: counter
         help: The number of inbound packets that contained errors.
-        indexes:
-          - labelname: ifIndex
-            type: gauge
-        lookups:
-          - labels: [ifIndex]
-            labelname: ifAlias
-            oid: 1.3.6.1.2.1.31.1.1.1.18
-            type: DisplayString
-          - labels: [ifIndex]
-            labelname: ifDescr
-            oid: 1.3.6.1.2.1.2.2.1.2
-            type: DisplayString
-          - labels: [ifIndex]
-            labelname: ifName
-            oid: 1.3.6.1.2.1.31.1.1.1.1
-            type: DisplayString
-      - name: ifOutOctets
-        oid: 1.3.6.1.2.1.2.2.1.16
-        type: counter
-        help: The total number of octets transmitted out of the interface, including framing characters.
-        indexes:
-          - labelname: ifIndex
-            type: gauge
-        lookups:
-          - labels: [ifIndex]
-            labelname: ifAlias
-            oid: 1.3.6.1.2.1.31.1.1.1.18
-            type: DisplayString
-          - labels: [ifIndex]
-            labelname: ifDescr
-            oid: 1.3.6.1.2.1.2.2.1.2
-            type: DisplayString
-          - labels: [ifIndex]
-            labelname: ifName
-            oid: 1.3.6.1.2.1.31.1.1.1.1
-            type: DisplayString
-      - name: ifOutUcastPkts
-        oid: 1.3.6.1.2.1.2.2.1.17
-        type: counter
-        help: The total number of unicast packets requested to be transmitted.
         indexes:
           - labelname: ifIndex
             type: gauge
@@ -522,18 +365,10 @@ modules:
         oid: 1.3.6.1.2.1.1.3
         type: gauge
         help: The time (in hundredths of a second) since the network management portion of the system was last re-initialized.
-      - name: sysContact
-        oid: 1.3.6.1.2.1.1.4
-        type: DisplayString
-        help: The textual identification of the contact person for this managed node.
       - name: sysName
         oid: 1.3.6.1.2.1.1.5
         type: DisplayString
         help: An administratively-assigned name for this managed node.
-      - name: sysLocation
-        oid: 1.3.6.1.2.1.1.6
-        type: DisplayString
-        help: The physical location of this node.
   # ---------------------------------------------------------------------------
   # jnxOperating - Juniper Operating State (JUNIPER-MIB)
   # OID base: 1.3.6.1.4.1.2636.3.1.13 (jnxOperatingTable)
@@ -560,78 +395,6 @@ modules:
         oid: 1.3.6.1.4.1.2636.3.1.13.1.8
         type: gauge
         help: CPU utilization percentage of the operating component.
-        indexes:
-          - labelname: jnxOperatingContentsIndex
-            type: gauge
-          - labelname: jnxOperatingL1Index
-            type: gauge
-          - labelname: jnxOperatingL2Index
-            type: gauge
-          - labelname: jnxOperatingL3Index
-            type: gauge
-        lookups:
-          - labels: [jnxOperatingContentsIndex, jnxOperatingL1Index, jnxOperatingL2Index, jnxOperatingL3Index]
-            labelname: jnxOperatingDescr
-            oid: 1.3.6.1.4.1.2636.3.1.13.1.5
-            type: DisplayString
-      - name: jnxOperatingTemp
-        oid: 1.3.6.1.4.1.2636.3.1.13.1.7
-        type: gauge
-        help: Temperature of the operating component in degrees Celsius.
-        indexes:
-          - labelname: jnxOperatingContentsIndex
-            type: gauge
-          - labelname: jnxOperatingL1Index
-            type: gauge
-          - labelname: jnxOperatingL2Index
-            type: gauge
-          - labelname: jnxOperatingL3Index
-            type: gauge
-        lookups:
-          - labels: [jnxOperatingContentsIndex, jnxOperatingL1Index, jnxOperatingL2Index, jnxOperatingL3Index]
-            labelname: jnxOperatingDescr
-            oid: 1.3.6.1.4.1.2636.3.1.13.1.5
-            type: DisplayString
-      - name: jnxOperatingBuffer
-        oid: 1.3.6.1.4.1.2636.3.1.13.1.11
-        type: gauge
-        help: Buffer pool utilization percentage of the operating component.
-        indexes:
-          - labelname: jnxOperatingContentsIndex
-            type: gauge
-          - labelname: jnxOperatingL1Index
-            type: gauge
-          - labelname: jnxOperatingL2Index
-            type: gauge
-          - labelname: jnxOperatingL3Index
-            type: gauge
-        lookups:
-          - labels: [jnxOperatingContentsIndex, jnxOperatingL1Index, jnxOperatingL2Index, jnxOperatingL3Index]
-            labelname: jnxOperatingDescr
-            oid: 1.3.6.1.4.1.2636.3.1.13.1.5
-            type: DisplayString
-      - name: jnxOperating1MinLoadAvg
-        oid: 1.3.6.1.4.1.2636.3.1.13.1.20
-        type: gauge
-        help: 1-minute load average of the operating component.
-        indexes:
-          - labelname: jnxOperatingContentsIndex
-            type: gauge
-          - labelname: jnxOperatingL1Index
-            type: gauge
-          - labelname: jnxOperatingL2Index
-            type: gauge
-          - labelname: jnxOperatingL3Index
-            type: gauge
-        lookups:
-          - labels: [jnxOperatingContentsIndex, jnxOperatingL1Index, jnxOperatingL2Index, jnxOperatingL3Index]
-            labelname: jnxOperatingDescr
-            oid: 1.3.6.1.4.1.2636.3.1.13.1.5
-            type: DisplayString
-      - name: jnxOperating5MinLoadAvg
-        oid: 1.3.6.1.4.1.2636.3.1.13.1.21
-        type: gauge
-        help: 5-minute load average of the operating component.
         indexes:
           - labelname: jnxOperatingContentsIndex
             type: gauge


### PR DESCRIPTION
## Overview

- updates filtering for Prometheus inventory
- removes unused metrics from SNMP configuration