### PR TITLE
Experiment: pin switch GHA nix-installer to determinate-nix-action and pin to v3.16.3

### DIFF
--- a/.github/workflows/ci-nixos.yml
+++ b/.github/workflows/ci-nixos.yml
@@ -15,7 +15,7 @@ jobs:
       nixosconfignames: ${{ steps.nixosconfigsget.outputs.nixosconfignames }}
     steps:
       - uses: actions/checkout@v3
-      - uses: DeterminateSystems/nix-installer-action@main
+      - uses: DeterminateSystems/determinate-nix-action@v3.16.3
       - uses: DeterminateSystems/magic-nix-cache-action@main
       - name: Get all NixOS configurations
         id: nixosconfigsget
@@ -34,7 +34,7 @@ jobs:
         configName: ${{ fromJSON(needs.nixos_configs_get.outputs.nixosconfignames) }}
     steps:
       - uses: actions/checkout@v3
-      - uses: DeterminateSystems/nix-installer-action@main
+      - uses: DeterminateSystems/determinate-nix-action@v3.16.3
       - uses: DeterminateSystems/magic-nix-cache-action@main
       - name: Build ${{ matrix.configName }} nixos configuration
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,20 +7,20 @@ on:
   workflow_dispatch:
 jobs:
   # this check is doing odd things as of 20260305
-  # nix_checks:
-  #   name: nix flake check
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - uses: actions/checkout@v3
-  #     - uses: DeterminateSystems/nix-installer-action@main
-  #     - uses: DeterminateSystems/magic-nix-cache-action@main
-  #     - run: nix flake check -L
+  nix_checks:
+    name: nix flake check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: DeterminateSystems/determinate-nix-action@v3.16.3
+      - uses: DeterminateSystems/magic-nix-cache-action@main
+      - run: nix flake check -L
   nix_verify_scale_network:
     name: nix verify scale network
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: DeterminateSystems/nix-installer-action@main
+      - uses: DeterminateSystems/determinate-nix-action@v3.16.3
       - uses: DeterminateSystems/magic-nix-cache-action@main
       - run: nix run .#verify-scale-network
   nix_verify_scale_tests:
@@ -28,6 +28,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: DeterminateSystems/nix-installer-action@main
+      - uses: DeterminateSystems/determinate-nix-action@v3.16.3
       - uses: DeterminateSystems/magic-nix-cache-action@main
       - run: nix run .#verify-scale-tests


### PR DESCRIPTION
## Description of PR

**Changes**

- Switch from `DeterminateSystems/nix-installer-action` to `DeterminateSystems/determinate-nix-action`
- Pin the above to `v3.16.3`

### Context

@sarcasticadmin asked me to review review Github Actions runs and look for differences that may have caused the Github Actions runs to download the entirety of nixpkgs on every run. 

Here are examples from two recent ones:

**Last successful run** ([2 days ago](https://github.com/socallinuxexpo/scale-network/actions/runs/22703706307/job/65826282685)):

<img width="1099" height="779" alt="Screenshot 2026-03-06 at 12 54 43 PM" src="https://github.com/user-attachments/assets/baf0c9d8-4305-4dde-8f9c-a280fa557924" />

**First Failure** ([yesterday](https://github.com/socallinuxexpo/scale-network/actions/runs/22727822939/job/65908496958)):

<img width="1039" height="819" alt="Screenshot 2026-03-06 at 12 55 22 PM" src="https://github.com/user-attachments/assets/96c3e4d3-2893-4148-a570-715463386c30" />

> [!NOTE]
>This PR is to test the **theory** that the `v3.17.0` release [yesterday](https://github.com/DeterminateSystems/determinate-nix-action/tags) introduced this bug.

On the [README for that GHA](https://github.com/DeterminateSystems/determinate-nix-action?tab=readme-ov-file#-version-pinning-lock-it-down), they recommend that if you _want_ to pin the nix version you should use `determine-nix-action` instead.

The same suggestion for pinning nix version is also noted on the [nix-installer-action GHA's Readme](https://github.com/DeterminateSystems/nix-installer-action?tab=readme-ov-file#pinning-the-version) as well.

The failing builds have more than **30k lines of output** in the run where as the successful runs have only a few hundred lines.

## Previous Behavior

Before the regression was introduced running `nix flake check -L` meant that nixpkgs would not download the whole world. After the nix-determinate-action release to v3.17.0 yesterday, the regression appeared. 

## New Behavior

If this works as expected, we should have the previous behavior from a few days ago restored.

## Tests

Watch this space: https://github.com/socallinuxexpo/scale-network/actions

---

**Update**

This PR does restore the Github Actions to the previous behavior we want and looks like it fixes the regression. 