### PR TITLE
[READY] Enable ssh-key authentication for sudo via rssh

### DIFF
--- a/nix/nixos-configurations/router-scale-br-fmt2/configuration.nix
+++ b/nix/nixos-configurations/router-scale-br-fmt2/configuration.nix
@@ -24,6 +24,4 @@
     users.root.enable = true;
     users.erikreinert.enable = true;
   };
-  security.pam.sshAgentAuth.enable = true;
-  security.pam.services.sudo.sshAgentAuth = true;
 }

--- a/nix/nixos-configurations/router-scale-br-fmt2/configuration.nix
+++ b/nix/nixos-configurations/router-scale-br-fmt2/configuration.nix
@@ -24,4 +24,6 @@
     users.root.enable = true;
     users.erikreinert.enable = true;
   };
+  security.pam.sshAgentAuth.enable = true;
+  security.pam.services.sudo.sshAgentAuth = true;
 }

--- a/nix/nixos-modules/users/root.nix
+++ b/nix/nixos-modules/users/root.nix
@@ -23,7 +23,6 @@ in
 
     security.sudo = {
       extraConfig = ''
-#        Defaults rootpw
         Defaults lecture="never"
       '';
     };

--- a/nix/nixos-modules/users/root.nix
+++ b/nix/nixos-modules/users/root.nix
@@ -17,6 +17,10 @@ in
   options.scale-network.users.root.enable = mkEnableOption "user root and sudo configs";
 
   config = mkIf cfg.enable {
+
+    security.pam.sshAgentAuth.enable = true;
+    security.pam.services.sudo.sshAgentAuth = true;
+
     security.sudo = {
       extraConfig = ''
 #        Defaults rootpw

--- a/nix/nixos-modules/users/root.nix
+++ b/nix/nixos-modules/users/root.nix
@@ -25,7 +25,6 @@ in
       extraConfig = ''
 #        Defaults rootpw
         Defaults lecture="never"
-        Defaults env_keep+=SSH_AUTH_SOCK
       '';
     };
 

--- a/nix/nixos-modules/users/root.nix
+++ b/nix/nixos-modules/users/root.nix
@@ -17,6 +17,10 @@ in
   options.scale-network.users.root.enable = mkEnableOption "user root and sudo configs";
 
   config = mkIf cfg.enable {
+
+    security.pam.rssh.enable = true;
+    security.pam.services.sudo.rssh = true;
+
     security.sudo = {
       extraConfig = ''
         Defaults rootpw

--- a/nix/nixos-modules/users/root.nix
+++ b/nix/nixos-modules/users/root.nix
@@ -25,7 +25,7 @@ in
       extraConfig = ''
 #        Defaults rootpw
         Defaults lecture="never"
-	Defaults env_keep+=SSH_AUTH_SOCK
+        Defaults env_keep+=SSH_AUTH_SOCK
       '';
     };
 

--- a/nix/nixos-modules/users/root.nix
+++ b/nix/nixos-modules/users/root.nix
@@ -24,6 +24,7 @@ in
     security.sudo = {
       extraConfig = ''
         Defaults lecture="never"
+        Defaults rootpw
       '';
     };
 

--- a/nix/nixos-modules/users/root.nix
+++ b/nix/nixos-modules/users/root.nix
@@ -19,7 +19,7 @@ in
   config = mkIf cfg.enable {
     security.sudo = {
       extraConfig = ''
-        Defaults rootpw
+#        Defaults rootpw
         Defaults lecture="never"
       '';
     };

--- a/nix/nixos-modules/users/root.nix
+++ b/nix/nixos-modules/users/root.nix
@@ -18,13 +18,14 @@ in
 
   config = mkIf cfg.enable {
 
-    security.pam.sshAgentAuth.enable = true;
-    security.pam.services.sudo.sshAgentAuth = true;
+    security.pam.rssh.enable = true;
+    security.pam.services.sudo.rssh = true;
 
     security.sudo = {
       extraConfig = ''
 #        Defaults rootpw
         Defaults lecture="never"
+	Defaults env_keep+=SSH_AUTH_SOCK
       '';
     };
 


### PR DESCRIPTION
## Description of PR

See #964 

## Previous Behavior

sudo used root password.

## New Behavior

sudo is passwordless as long as the user's SSH key is available from their SSH Agent or agent forwarding.

## Tests

nixos-rebuild with this branch on both scale-devserver and br-fmt2
