### PR TITLE
Add smartmontools package to standard build

### DIFF
--- a/nix/nixos-modules/base.nix
+++ b/nix/nixos-modules/base.nix
@@ -74,6 +74,7 @@ in
       pciutils
       psmisc # fuser
       silver-searcher
+      smartmontools
       strace
       tcpdump
       tmux


### PR DESCRIPTION
## Description of PR

Adds smartmontools (smartctl, etc.) to the standard package set for nix installations

 ## Previous Behavior

smartctl: Command not found

## New Behavior

smartctl gives useful data on disk behavior and history

## Tests

surgical tubing, lubricants, and a yak.
