### PR TITLE
[READY] - treewide: update nix.input.nixos-2511

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -42,11 +42,11 @@
     },
     "nixpkgs-2511": {
       "locked": {
-        "lastModified": 1770136044,
-        "narHash": "sha256-tlFqNG/uzz2++aAmn4v8J0vAkV3z7XngeIIB3rM3650=",
+        "lastModified": 1777077449,
+        "narHash": "sha256-AIiMJiqvGrN4HyLEbKAoCSRRYn0rnlW5VbKNIMIYqm4=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "e576e3c9cf9bad747afcddd9e34f51d18c855b4e",
+        "rev": "a4bf06618f0b5ee50f14ed8f0da77d34ecc19160",
         "type": "github"
       },
       "original": {

--- a/nix/nixos-configurations/dev-server/default.nix
+++ b/nix/nixos-configurations/dev-server/default.nix
@@ -1,5 +1,5 @@
 {
-  release = "unstable";
+  release = "2511";
 
   modules =
     {

--- a/nix/nixos-configurations/dev-server/default.nix
+++ b/nix/nixos-configurations/dev-server/default.nix
@@ -16,6 +16,9 @@
       config = {
         nixpkgs.hostPlatform = "x86_64-linux";
 
+        # need to be 6.18 to avoid https://copy.fail/
+        boot.kernelPackages = pkgs.linuxPackages_6_18;
+
         scale-network = {
           base.enable = true;
           libvirt.enable = true;

--- a/nix/nixos-modules/base.nix
+++ b/nix/nixos-modules/base.nix
@@ -86,7 +86,7 @@ in
     programs.vim = {
       enable = true;
       defaultEditor = true;
-      package = (pkgs.vim_configurable.override { }).customize {
+      package = (pkgs.vim-full.override { }).customize {
         name = "vim";
         # Install plugins for syntax highlighting of nix files
         vimrcConfig.packages.myplugins = with pkgs.vimPlugins; {

--- a/nix/nixos-modules/libvirt.nix
+++ b/nix/nixos-modules/libvirt.nix
@@ -29,7 +29,6 @@ in
     virtualisation.libvirtd = {
       enable = true;
       qemu = {
-        ovmf.enable = true;
         runAsRoot = false;
       };
       onBoot = "ignore";


### PR DESCRIPTION
## Description of PR

relates to: https://github.com/socallinuxexpo/scale-network/issues/1190
<!--
Brief description of the changes in PR

If change is related to an open issue template include at the top of your
description.
-->

Updating the `dev-server` to run on the latest 6.18 kernel from the nixpkgs-2511 release input. 25.11 is actually slightly new than our version of unstable (aug 2025). 25.11 includes the appropriate fixes for https://copy.fail/ in latest 6.18 kernl.

There were some deprecations on a few different module attributes as well.

We can update more of the machines on unstable but just trying to limit the blast radius to only machines that are currently online. The router for HE will be up next.

## Previous Behavior

<!--
What was the behavior before this PR?

Remove this section if not relevant
-->
- nixpkgs-25.11 input was from months back
- running 6.12 kernel effected by copy.fail

## New Behavior
- nixpkgs-25.11 updated
- running 6.18 kernel that includes path for copy.fail
<!--
What is the new behavior being introduced in this PR?

Remove this section if not relevant
-->

## Tests
- Running on `dev-server`
<!--
How was this PR tested? Please provide as much detail as possible
so we can ensure this change is working as intended before being merged.
-->
